### PR TITLE
feat: add mermaid-diagrams skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ When the user mentions these keywords, load the corresponding skill:
 | "research-methodology", "research methodology" | [research-methodology](research-methodology/SKILL.md) |
 | "technical-documentation", "technical documentation" | [technical-documentation](technical-documentation/SKILL.md) |
 | "security-audit-methodology", "security audit methodology" | [security-audit-methodology](security-audit-methodology/SKILL.md) |
+| "mermaid-diagrams", "mermaid diagrams" | [mermaid-diagrams](mermaid-diagrams/SKILL.md) |
 ## Use-When Sections
 
 Every skill description must identify when to load it. Skills with meaningful overlap should also include a `## When not to use` section naming the nearest alternative or prerequisite. Keep these sections trigger-oriented and concise; implementation details belong in references.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Manage your Lidarr music library from the terminal — search and browse artists
 
 An expert-level skill for building LLM applications over your data with LlamaIndex. RAG pipelines, multi-agent orchestration, event-driven workflows, knowledge graph construction, and production deployment.
 
+### [mermaid-diagrams](mermaid-diagrams/SKILL.md)
+
+Create maintainable diagrams that render reliably in the documentation surfaces where readers actually encounter them.
+
 ### [meshcore-packet-capture](meshcore-packet-capture/SKILL.md)
 
 Operate MeshCore Companion radio packet capture over BLE, serial, or TCP. Covers MQTT publishing, TOML and environment configuration, token authentication, Docker, systemd, launchd, NixOS, and evidence-first troubleshooting.

--- a/mermaid-diagrams/README.md
+++ b/mermaid-diagrams/README.md
@@ -1,0 +1,37 @@
+# Mermaid Diagrams
+
+Create maintainable diagrams that render reliably in the documentation surfaces where readers actually encounter them.
+
+## Why Install This Skill
+
+Create maintainable diagrams that render reliably in the documentation surfaces where readers actually encounter them. It preserves a practical method, local reference material, and reusable templates so an agent can do more than produce a generic answer.
+
+Use it when the work needs a repeatable process and an inspectable result. It is portable across Agent Skills-compatible clients and does not require a profile system or a particular task orchestrator.
+
+## What You Get
+
+| Path | What it provides |
+|---|---|
+| `SKILL.md` | Trigger conditions, workflow, and guidance for loading deeper resources. |
+| `references/` | Reference material: `c4-mermaid.md`, `c4-to-flowchart.md`, `flowchart.md`, `mmdc-spacing-config.md`, `pdf-rendering-pipeline.md`, `portrait-layout.md`, `sequence.md` |
+| `scripts/` | Scripts: `validate-mermaid.sh` |
+
+## Quick Start
+
+Choose the diagram type in `SKILL.md`, author the smallest useful diagram, and render it with the documented verification path.
+
+Install or expose this directory using your agent's standard Agent Skills loading mechanism, then ask for work that matches the triggers below.
+
+## Triggers
+
+- Author, render, and troubleshoot Mermaid diagrams for documentation, architecture, processes, and technical communication. Use when a text-based diagram needs to stay versionable.
+- Requests involving the method, deliverables, or review process described in `SKILL.md`.
+- Work where a reusable template or reference from this skill would reduce avoidable mistakes.
+
+## Requirements
+
+Mermaid rendering requires a compatible renderer. The optional CLI examples use Mermaid CLI and its documented Node.js runtime.
+
+## Source and maintenance
+
+This skill was extracted from [`magnus919/hermes-profiles`](https://github.com/magnus919/hermes-profiles) at commit [`867a555`](https://github.com/magnus919/hermes-profiles/commit/867a555). The portable methodology was retained; Hermes-specific profile, orchestration, and memory assumptions were removed.

--- a/mermaid-diagrams/SKILL.md
+++ b/mermaid-diagrams/SKILL.md
@@ -23,8 +23,8 @@ Load this skill when:
 - Generating any diagram that needs to render in both agent-facing and human-facing contexts
 
 Do NOT load when:
-- You only need static ASCII architecture (use `architecture-diagram` skill)
-- You're embedding in a Hugo site that uses custom theme rendering (load the appropriate theme skill)
+- A plain text outline communicates the relationship more clearly than a diagram.
+- The target renderer cannot execute Mermaid and no pre-rendering path is available.
 
 ## PDF Output — Pre-render Required
 
@@ -47,17 +47,11 @@ See `references/pdf-rendering-pipeline.md` for the full pipeline with Puppeteer 
 | Type | Use Case | File |
 |------|----------|------|
 | Flowchart | Process flows, C4 workarounds, decision trees | `references/flowchart.md` |
-| Sequence | Interaction protocols, API calls, agent handoffs | `references/sequence.md` |
-| Class | Object models, interfaces, type hierarchies | `references/class.md` |
-| State | State machines, lifecycle, workflow states | `references/state.md` |
-| ER | Entity relationships, data models, schemas | `references/er.md` |
-| Block | Manual-position diagrams, composite structures | `references/block.md` |
-| Packet | Network protocols, binary formats, bit fields | `references/packet.md` |
+| Sequence | Interaction protocols and API calls | `references/sequence.md` |
 | C4 | Architecture context and container views | `references/c4-mermaid.md` |
-| Gantt | Project timelines, milestone tracking | `references/gantt.md` |
 | Portrait Layout | PDF/print-oriented diagramming — TD over LR, page breaks, full-page diagrams | `references/portrait-layout.md` |
 | PDF Rendering Pipeline | Full pipeline from .mmd → SVG → HTML → PDF, with QA checklist | `references/pdf-rendering-pipeline.md` |
-| mmdc Spacing Config | Config file approach for controlling diagram layout density (nodeSpacing, rankSpacing, padding) to prevent label overlap in complex diagrams destined for PDF/print | `references/mmdc-spacing-config.md` |
+| mmdc Spacing Config | Config for controlling diagram density and preventing label overlap | `references/mmdc-spacing-config.md` |
 
 ## C4 Model Guidance
 
@@ -65,7 +59,7 @@ Mermaid has experimental native C4 syntax (`C4Context`, `C4Container`, `C4Compon
 
 1. **Flowchart workarounds (GitHub-compatible)** — Convert C4 diagrams to standard `flowchart` syntax using subgraphs for boundaries, styled node boxes for Person/System/Container/Db, and labelled edges for Rel. See `references/c4-to-flowchart.md` for the full conversion pattern.
 2. **Structurizr DSL** — use for real C4 diagrams. Render via Structurizr CLI or export to Mermaid SVG. Best for formal architecture documentation that doesn't live in GitHub markdown.
-3. **The hybrid approach** — produce C4 in Structurizr DSL for the architect's artifact pyramid, and include a flowchart-based approximation in the markdown report for inline readability.
+3. **Hybrid approach** — maintain a full C4 model in Structurizr DSL and include a flowchart-based approximation in Markdown for inline readability.
 
 ### C4 → Flowchart Conversion Pattern
 
@@ -153,9 +147,7 @@ try {
 
 | Script | Purpose |
 |--------|---------|
-| `scripts/validate-mermaid.sh` | Validate a .mmd file for syntax errors |
-| `scripts/render-mermaid.sh` | Render a .mmd file to SVG/PNG/PDF via mmdc |
-| `scripts/batch-render.sh` | Render all .mmd files in a directory to SVG |
+| `scripts/validate-mermaid.sh` | Validate a `.mmd` file with Mermaid CLI |
 
 ## Theming
 

--- a/mermaid-diagrams/SKILL.md
+++ b/mermaid-diagrams/SKILL.md
@@ -33,7 +33,7 @@ Mermaid code blocks (```mermaid```) do NOT render in the Pandoc → HTML → Pup
 **For any diagram destined for PDF output:**
 1. Create the diagram as a standalone .mmd file
 2. Pre-render to SVG: `npx @mermaid-js/mermaid-cli -i diagram.mmd -o diagram.svg --width 800`
-3. Embed the raw SVG content directly in the markdown (not as `<img src="data:...">`)
+3. Choose one embedding method: use raw inline SVG by default, or base64 data URIs when the renderer corrupts raw SVG.
 4. Strip hardcoded `max-width` pixel values from the SVG tags
 5. Use `flowchart TD` (portrait) not `flowchart LR` (landscape) — see `references/portrait-layout.md`
 6. Add page-break divs before/after each full-page diagram
@@ -151,7 +151,7 @@ try {
 
 ## Theming
 
-Mermaid uses a `base` theme with customizable theme variables. Set via `%%{init: {'theme':'base', 'themeVariables': { ... }}}%%` at the top of the diagram.
+Mermaid uses a `base` theme with customizable theme variables. Set them with an `init` directive at the top of the diagram. Consult the Mermaid documentation for the complete version-specific variable set.
 
 Key theme variables:
 - `primaryColor`, `primaryTextColor`, `primaryBorderColor`
@@ -159,7 +159,6 @@ Key theme variables:
 - `lineColor`, `fontFamily`, `fontSize`
 - `background` (outer background), `mainBkg` (element background)
 
-See `references/theming.md` for the full variable reference.
 
 ## Anti-Patterns
 

--- a/mermaid-diagrams/SKILL.md
+++ b/mermaid-diagrams/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: mermaid-diagrams
+description: Author, render, and troubleshoot Mermaid diagrams for documentation, architecture, processes, and technical communication. Use when a text-based diagram needs to stay versionable.
+license: MIT
+compatibility: Mermaid rendering requires a compatible renderer. The optional CLI examples use Mermaid CLI and its documented Node.js runtime.
+metadata:
+  source_repo: https://github.com/magnus919/hermes-profiles
+  source_commit: 867a555
+---
+
+
+# Mermaid Diagrams
+
+Portable Mermaid.js diagramming for architectural documentation. Not tied to any blog platform, theme, or rendering engine. Diagrams can be rendered via CLI, embedded in markdown, or served as HTML snippets.
+
+## When to Use
+
+Load this skill when:
+- Creating C4 structural views (use Structurizr DSL for production; flowchart workarounds for inline markdown)
+- Producing sequence diagrams for interaction flows
+- Designing flowcharts for process documentation
+- Building state/class/ER diagrams for specification
+- Generating any diagram that needs to render in both agent-facing and human-facing contexts
+
+Do NOT load when:
+- You only need static ASCII architecture (use `architecture-diagram` skill)
+- You're embedding in a Hugo site that uses custom theme rendering (load the appropriate theme skill)
+
+## PDF Output — Pre-render Required
+
+Mermaid code blocks (```mermaid```) do NOT render in the Pandoc → HTML → Puppeteer PDF pipeline. The pipeline generates static HTML with no JavaScript execution.
+
+**For any diagram destined for PDF output:**
+1. Create the diagram as a standalone .mmd file
+2. Pre-render to SVG: `npx @mermaid-js/mermaid-cli -i diagram.mmd -o diagram.svg --width 800`
+3. Embed the raw SVG content directly in the markdown (not as `<img src="data:...">`)
+4. Strip hardcoded `max-width` pixel values from the SVG tags
+5. Use `flowchart TD` (portrait) not `flowchart LR` (landscape) — see `references/portrait-layout.md`
+6. Add page-break divs before/after each full-page diagram
+
+Do NOT leave ```mermaid code blocks in markdown that will go through Pandoc. They render as raw monospace text.
+
+See `references/pdf-rendering-pipeline.md` for the full pipeline with Puppeteer setup, SVG styling fixes, and QA checklist.
+
+## Supported Diagram Types
+
+| Type | Use Case | File |
+|------|----------|------|
+| Flowchart | Process flows, C4 workarounds, decision trees | `references/flowchart.md` |
+| Sequence | Interaction protocols, API calls, agent handoffs | `references/sequence.md` |
+| Class | Object models, interfaces, type hierarchies | `references/class.md` |
+| State | State machines, lifecycle, workflow states | `references/state.md` |
+| ER | Entity relationships, data models, schemas | `references/er.md` |
+| Block | Manual-position diagrams, composite structures | `references/block.md` |
+| Packet | Network protocols, binary formats, bit fields | `references/packet.md` |
+| C4 | Architecture context and container views | `references/c4-mermaid.md` |
+| Gantt | Project timelines, milestone tracking | `references/gantt.md` |
+| Portrait Layout | PDF/print-oriented diagramming — TD over LR, page breaks, full-page diagrams | `references/portrait-layout.md` |
+| PDF Rendering Pipeline | Full pipeline from .mmd → SVG → HTML → PDF, with QA checklist | `references/pdf-rendering-pipeline.md` |
+| mmdc Spacing Config | Config file approach for controlling diagram layout density (nodeSpacing, rankSpacing, padding) to prevent label overlap in complex diagrams destined for PDF/print | `references/mmdc-spacing-config.md` |
+
+## C4 Model Guidance
+
+Mermaid has experimental native C4 syntax (`C4Context`, `C4Container`, `C4Component`) but it is **unsupported on GitHub and most markdown renderers.** GitHub's built-in mermaid renderer does not bundle the C4 plugin — C4-syntax blocks render as raw code rather than diagrams. Use one of these approaches instead:
+
+1. **Flowchart workarounds (GitHub-compatible)** — Convert C4 diagrams to standard `flowchart` syntax using subgraphs for boundaries, styled node boxes for Person/System/Container/Db, and labelled edges for Rel. See `references/c4-to-flowchart.md` for the full conversion pattern.
+2. **Structurizr DSL** — use for real C4 diagrams. Render via Structurizr CLI or export to Mermaid SVG. Best for formal architecture documentation that doesn't live in GitHub markdown.
+3. **The hybrid approach** — produce C4 in Structurizr DSL for the architect's artifact pyramid, and include a flowchart-based approximation in the markdown report for inline readability.
+
+### C4 → Flowchart Conversion Pattern
+
+| C4 Element | Flowchart Equivalent | Example |
+|-----------|---------------------|---------|
+| `Person()` | `[label]` (standard rect) | `U[Human User]` |
+| `System()` | `[label]` with style | `GP[GroktoPlan]` with `style GP fill:#...` |
+| `System_Ext()` | `[label]` outside subgraph | `GIT[Git Providers]` |
+| `Container()` | `[label with tech stack]` | `KG[Knowledge Graph<br/>Python + pgvector]` |
+| `Db()` | `[(label)]` (cylinder shape) | `LS[(Live State DB)]` |
+| `System_Boundary{}` | `subgraph System["Title"] ... end` | Nested subgraphs |
+| `Container_Boundary{}` | `subgraph Service["Title"] ... end` | Single subgraph |
+| `Rel()` | `-- label -->` or `-.->` | `AR -- gRPC --> GA` |
+| `UpdateLayoutConfig()` | Omit — use `flowchart LR` or `TB` | Direction set in header |
+
+See `references/c4-to-flowchart.md` for worked examples of all three C4 levels.
+
+### GitHub Compatibility Reference
+
+| Diagram Type | GitHub Renders? | Notes |
+|-------------|----------------|-------|
+| `flowchart` (TD/LR/BT/RL) | ✅ | Use for all C4 workarounds |
+| `sequenceDiagram` | ✅ | |
+| `classDiagram` | ✅ | |
+| `stateDiagram-v2` | ✅ | |
+| `erDiagram` | ✅ | |
+| `gantt` | ✅ | |
+| `pie` | ✅ | |
+| `quadrantChart` | ✅ | |
+| `requirementDiagram` | ✅ | |
+| `gitgraph` | ✅ | |
+| `mindmap` | ✅ | |
+| `timeline` | ✅ | |
+| `zenuml` | ✅ | |
+| `sankey` | ✅ | |
+| `xychart` | ✅ | |
+| `block` | ✅ | |
+| `packet` | ✅ | |
+| `C4Context` | ❌ | Requires C4 plugin — renders as raw code |
+| `C4Container` | ❌ | Requires C4 plugin — renders as raw code |
+| `C4Component` | ❌ | Requires C4 plugin — renders as raw code |
+| `C4Deployment` | ❌ | Requires C4 plugin — renders as raw code |
+| `C4Dynamic` | ❌ | Requires C4 plugin — renders as raw code |
+
+## Rendering
+
+### CLI (mmdc) — for PDF/SVG/PNG output
+
+```bash
+npx @mermaid-js/mermaid-cli -i diagram.mmd -o diagram.svg
+npx @mermaid-js/mermaid-cli -i diagram.mmd -o diagram.png
+npx @mermaid-js/mermaid-cli -i diagram.mmd -o diagram.pdf
+```
+
+Requires Puppeteer + Chromium (~1.7GB). Use the Docker image for isolated rendering:
+```bash
+docker run --rm -v $(pwd):/data ghcr.io/mermaid-js/mermaid-cli mermaid-cli -i /data/diagram.mmd -o /data/diagram.svg
+```
+
+### CDN (HTML) — for inline web rendering
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script>mermaid.initialize({startOnLoad:true});</script>
+<div class="mermaid">
+flowchart LR
+  A-->B
+</div>
+```
+
+### Validation
+
+```javascript
+// Node.js validation
+import { parse } from 'mermaid';
+try {
+  parse('flowchart LR\n  A-->B');
+  console.log('Valid');
+} catch (e) {
+  console.error('Invalid:', e.message);
+}
+```
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/validate-mermaid.sh` | Validate a .mmd file for syntax errors |
+| `scripts/render-mermaid.sh` | Render a .mmd file to SVG/PNG/PDF via mmdc |
+| `scripts/batch-render.sh` | Render all .mmd files in a directory to SVG |
+
+## Theming
+
+Mermaid uses a `base` theme with customizable theme variables. Set via `%%{init: {'theme':'base', 'themeVariables': { ... }}}%%` at the top of the diagram.
+
+Key theme variables:
+- `primaryColor`, `primaryTextColor`, `primaryBorderColor`
+- `secondaryColor`, `tertiaryColor`
+- `lineColor`, `fontFamily`, `fontSize`
+- `background` (outer background), `mainBkg` (element background)
+
+See `references/theming.md` for the full variable reference.
+
+## Anti-Patterns
+
+| Anti-pattern | Fix |
+|-------------|-----|
+| Lowercase `end` in flowchart | All Mermaid keywords are case-sensitive. `End` is not `end`. |
+| `o` or `x` after dashes without space | `-->o` needs space: `--o ` or use explicit node shapes |
+| Quotes inside parentheses | `("quoted text")` not `('quoted text')` |
+| Very wide diagrams (>100 nodes) | Split into sub-diagrams or use ELK layout |
+| Mixed tabs and spaces | Use spaces only. 2-space indent for subgraphs. |
+| Long labels without line breaks | Use `<br/>` or pipe `|` for line breaks in nodes |
+| Embedding SVGs as data URIs | Use raw `<svg>` tags instead — data URIs can't have their max-width overridden by CSS |
+| Leaving Mermaid code blocks in markdown for PDF | Pre-render to SVG first. Pandoc renders ```mermaid as raw text. |
+
+## Portability
+
+This skill is intentionally host-neutral. Use your agent's normal mechanisms to load the references, templates, and scripts listed here. Do not assume a particular profile system, task orchestrator, memory service, or response-handoff format.

--- a/mermaid-diagrams/references/c4-mermaid.md
+++ b/mermaid-diagrams/references/c4-mermaid.md
@@ -10,7 +10,7 @@ Structurizr is the canonical C4 tool. The DSL compiles to Mermaid, PlantUML, or 
 workspace {
   model {
     user = person "User" "A user of the system"
-    system = softwareSystem "GroktoCrawl" "Self-hosted Firecrawl alternative"
+    system = softwareSystem "Research Service" "A web-retrieval service"
     user -> system "Uses"
   }
   views {
@@ -43,7 +43,7 @@ flowchart TB
   end
 
   subgraph System["System Boundary"]
-    GC["GroktoCrawl"]
+    GC["Research Service"]
   end
 
   User -- "Searches & scrapes" --> GC
@@ -59,13 +59,13 @@ flowchart TB
     W["🌐 Web"]
   end
 
-  subgraph GroktoCrawl["GroktoCrawl"]
+  subgraph ResearchService["Research Service"]
     direction TB
     GW["API Gateway\nsearch-svc"]
     SC["🕸️ scraper-svc"]
     BR["🌍 browser-svc"]
     LLM["🧠 llm-svc"]
-    SR["🔍 SearXNG"]
+    SR["🔍 Search Provider"]
     VK[("🗄️ Valkey")]
   end
 

--- a/mermaid-diagrams/references/c4-mermaid.md
+++ b/mermaid-diagrams/references/c4-mermaid.md
@@ -1,0 +1,104 @@
+# C4 Model with Mermaid
+
+Mermaid does NOT have stable native C4 syntax. `C4Context` and `C4Container` are experimental and unreliable. For production C4 diagrams, use **Structurizr DSL**. For inline markdown where Structurizr isn't available, use the flowchart workaround below.
+
+## Option 1: Structurizr DSL (Recommended)
+
+Structurizr is the canonical C4 tool. The DSL compiles to Mermaid, PlantUML, or Structurizr's own diagram format.
+
+```dsl
+workspace {
+  model {
+    user = person "User" "A user of the system"
+    system = softwareSystem "GroktoCrawl" "Self-hosted Firecrawl alternative"
+    user -> system "Uses"
+  }
+  views {
+    systemContext "SystemContext" {
+      include *
+      autoLayout
+    }
+  }
+}
+```
+
+Render with:
+```bash
+# Via Structurizr CLI
+java -jar structurizr-cli.jar render -w workspace.dsl -f mermaid -o output/
+
+# Or use the structurizr-site-generatr for full documentation site
+```
+
+## Option 2: Flowchart Workaround (For Inline Markdown)
+
+Use Mermaid flowchart subgraphs with styling to approximate C4 views. The pattern uses two boxes per element (one for the system/person, one for a description).
+
+### System Context (L1)
+
+```mermaid
+flowchart TB
+  subgraph External["External Actors"]
+    User(("User"))
+  end
+
+  subgraph System["System Boundary"]
+    GC["GroktoCrawl"]
+  end
+
+  User -- "Searches & scrapes" --> GC
+  GC -- "Returns results" --> User
+```
+
+### Container Diagram (L2) — Multi-service stack
+
+```mermaid
+flowchart TB
+  subgraph External["External"]
+    U[("👤 User")]
+    W["🌐 Web"]
+  end
+
+  subgraph GroktoCrawl["GroktoCrawl"]
+    direction TB
+    GW["API Gateway\nsearch-svc"]
+    SC["🕸️ scraper-svc"]
+    BR["🌍 browser-svc"]
+    LLM["🧠 llm-svc"]
+    SR["🔍 SearXNG"]
+    VK[("🗄️ Valkey")]
+  end
+
+  U --> GW
+  GW --> SC
+  SC --> BR
+  GW --> LLM
+  GW --> SR
+  GW --> VK
+  SR --> W
+```
+
+### Component Diagram (L3) — Inside a service
+
+```mermaid
+flowchart TB
+  subgraph AgentSvc["agent-svc"]
+    direction TB
+    Orchestrator["Orchestrator\nGoal decomposition"]
+    Planner["Planner\nStep planning"]
+    Executor["Executor\nTool dispatch"]
+    Memory["Memory\nContext tracking"]
+  end
+
+  Orchestrator --> Planner
+  Planner --> Executor
+  Executor --> Memory
+  Memory --> Orchestrator
+```
+
+## Limitations
+
+- No native C4 shapes (person, system, container, database) — must approximate with subgraphs
+- No automatic layout — manual positioning via subgraph nesting
+- No relationship descriptions on edges (can add via edge labels)
+- Structurizr DSL is the right tool for C4. Use Mermaid flowchart workarounds only when Structurizr is unavailable.

--- a/mermaid-diagrams/references/c4-to-flowchart.md
+++ b/mermaid-diagrams/references/c4-to-flowchart.md
@@ -1,0 +1,119 @@
+# C4 → Flowchart Conversion for GitHub-Compatible Mermaid
+
+GitHub's built-in mermaid renderer does **not** support the C4 plugin types (`C4Context`, `C4Container`, `C4Component`, `C4Deployment`, `C4Dynamic`). These render as raw code blocks. Convert them to standard `flowchart` syntax to get working diagrams on GitHub, PR previews, and most markdown renderers.
+
+## Conversion Table
+
+| C4 Element | Flowchart Equivalent | Example |
+|-----------|---------------------|---------|
+| `Person(label, "Name", "Desc")` | `LABEL["Name<br/>Desc"]` | `U["Human User<br/>Engineer, PM"]` |
+| `System(label, "Name", "Desc")` | `LABEL["Name<br/>Desc"]` with style | `GP["GroktoPlan<br/>Temporal KG"]` — add `style GP fill:#...` |
+| `System_Ext(label, "Name", "Desc")` | `LABEL["Name<br/>Desc"]` outside main subgraph | `GIT["Git Providers"]` in External subgraph |
+| `Container(label, "Name", "Tech", "Desc")` | `LABEL["Name<br/>Tech Stack"]` | `KG["Knowledge Graph<br/>Python + pgvector"]` |
+| `ContainerDb(label, "Name", "Tech")` | `LABEL[("Name<br/>Tech")]` (cylinder parens) | `KGD[("Knowledge Graph DB<br/>pgvector")]` |
+| `Db(label, "Name", "Tech")` | `LABEL[("Name<br/>Tech")]` (cylinder parens) | `LS[("Live State DB<br/>PostgreSQL")]` |
+| `System_Boundary(name, "Title") { ... }` | `subgraph Title["Title"] ... end` | Nested subgraph |
+| `Container_Boundary(name, "Title") { ... }` | `subgraph Title["Title"] ... end` | Single subgraph |
+| `Rel(from, to, "label", "tech")` | `FROM -- "label" --> TO` | `AR -- "gRPC" --> GA` |
+| `Rel(from, to, "label")` (async) | `FROM -.->|"label"| TO` | `EV -.->|"feeds"| KG` |
+| `UpdateLayoutConfig($key="val")` | Omit. Set direction in `flowchart LR`/`TB` | `flowchart LR` or `flowchart TB` |
+
+## Worked Example 1: System Context (C4Context → flowchart LR)
+
+```mermaid
+flowchart LR
+    subgraph Users["Actors"]
+        U[("👤 Human User<br/>Engineer, PM")]
+        A[("🤖 AI Agent<br/>Claude Code, Cursor")]
+    end
+
+    subgraph Platform["Your System"]
+        SYS[System Name<br/>Subtitle / description]
+    end
+
+    subgraph External["External Systems"]
+        EXT1[External Service 1]
+        EXT2[External Service 2]
+    end
+
+    U -- "HTTPS/GraphQL" --> SYS
+    A -- "MCP protocol" --> SYS
+    SYS -- "REST API" --> EXT1
+    SYS -- "Webhook" --> EXT2
+
+    style SYS fill:#65413a,stroke:#132345,color:#ffffff
+    style Users fill:#132345,stroke:#65413a,color:#ffffff
+```
+
+## Worked Example 2: Container Diagram (C4Container → flowchart TB)
+
+```mermaid
+flowchart TB
+    subgraph Platform["Platform Name"]
+        direction TB
+
+        subgraph API["API Layer"]
+            GW["API Gateway<br/>GraphQL + REST"]
+            AUTH["Auth Service<br/>Node.js"]
+        end
+
+        subgraph Services["Core Services"]
+            ES["Entity Service<br/>CRUD operations"]
+            EV["Event Service<br/>Append-only log"]
+        end
+
+        subgraph Data["Data Layer"]
+            LS[("Live State DB<br/>PostgreSQL")]
+            ED[("Event Store<br/>PostgreSQL")]
+        end
+    end
+
+    GW --> AUTH
+    GW --> ES
+    GW --> EV
+    ES --> LS
+    EV --> ED
+
+    style Data fill:#132345,stroke:#65413a,color:#ffffff
+```
+
+## Worked Example 3: Component Diagram (C4Component → flowchart TB)
+
+```mermaid
+flowchart TB
+    subgraph ServiceName["Component: Service Name"]
+        direction TB
+        API[API Endpoint<br/>gRPC/REST]
+        ENG[Processing Engine<br/>Core logic]
+        DB[(Database<br/>PostgreSQL + pgvector)]
+    end
+
+    CLIENT[Calling Service]
+    QUEUE[Queue / Scheduler]
+
+    CLIENT -- gRPC --> API
+    API --> ENG
+    ENG -- SQL --> DB
+    ENG -.->|Publishes events| QUEUE
+
+    style ServiceName fill:#e8d9c0,stroke:#65413a,color:#132345
+    style DB fill:#132345,stroke:#65413a,color:#eceae5
+```
+
+## When to Use Which Approach
+
+| Context | Approach | Reason |
+|---------|----------|--------|
+| GitHub README/PR/MD | Flowchart conversion | Only approach that renders inline |
+| Formal ADR / arc42 document | Structurizr DSL | Full C4 fidelity, SVG export |
+| PDF report | Pre-rendered SVG (from either approach) | No JS execution in PDF pipeline |
+| Internal wiki (non-GitHub) | Depends on platform's mermaid support | Test C4 syntax first |
+| Architecture artifact pyramid | Hybrid: Structurizr for L3, flowchart for L1 inline | Depth where needed, readability where consumed |
+
+## Pitfalls
+
+- **Don't assume C4 works on GitHub just because it works in your local mermaid editor.** GitHub uses an older, plugin-free mermaid build.
+- **`UpdateLayoutConfig` has no flowchart equivalent.** Control layout via the direction header (`flowchart LR` vs `TB`) and subgraph nesting order.
+- **Subgraphs can't span across flowchart diagrams.** Each C4 level needs its own ````mermaid` block — don't try to put Level 1 and Level 2 in one diagram.
+- **Nested subgraphs in `flowchart LR` can cause rendering issues** on wider diagrams. Use `flowchart TB` for container-level diagrams that have many columns.
+- **GitHub strips inline styles** in some contexts. Use `style` directives (not inline CSS) in mermaid, which GitHub does support.

--- a/mermaid-diagrams/references/flowchart.md
+++ b/mermaid-diagrams/references/flowchart.md
@@ -1,0 +1,64 @@
+# Mermaid Flowchart Reference
+
+## Basic Syntax
+
+```mermaid
+flowchart LR
+  A[Start] --> B[Process]
+  B --> C{Decision}
+  C -->|Yes| D[Outcome]
+  C -->|No| E[Alternative]
+```
+
+## Node Shapes (v11.3+)
+
+| Shape | Syntax | Description |
+|-------|--------|-------------|
+| Rectangle | `A[text]` | Default process node |
+| Rounded | `A(text)` | Start/end |
+| Stadium | `A([text])` | Terminal |
+| Subroutine | `A[[text]]` | Predefined process |
+| Cylinder | `A[(text)]` | Database |
+| Circle | `A((text))` | Junction/connector |
+| Asymmetric | `A>text]` | Output |
+| Parallelogram | `A[/text/]` | Input/output |
+| Trapazoid | `A[/text\\]` | Input (reverse) |
+| Hexagon | `A{{text}}` | Preparation |
+| Diamond | `A{text}` | Decision |
+| Double Circle | `A(((text)))` | Multi-junction |
+
+## Link Styles
+
+| Syntax | Description |
+|--------|-------------|
+| `A-->B` | Arrow |
+| `A---B` | Line |
+| `A--text-->B` | Arrow with label |
+| `A-.->B` | Dotted arrow |
+| `A==>B` | Thick arrow |
+| `A--oB` | Open circle arrow |
+| `A--xB` | X arrow |
+
+## Subgraphs
+
+```mermaid
+flowchart TB
+  subgraph Service["Service Name"]
+    A --> B
+  end
+```
+
+## Styling
+
+```mermaid
+flowchart LR
+  A[Critical] --> B[Normal]
+  style A fill:#f00,stroke:#333,stroke-width:4px
+  style B fill:#0f0,stroke:#333
+  classDef critical fill:#f00,color:#fff
+  class A critical
+```
+
+## C4 Workaround
+
+See `references/c4-mermaid.md` for the flowchart-based C4 approximation pattern.

--- a/mermaid-diagrams/references/mmdc-spacing-config.md
+++ b/mermaid-diagrams/references/mmdc-spacing-config.md
@@ -1,0 +1,103 @@
+# mmdc Spacing Configuration
+
+A JSON config file passed via `mmdc -c config.json` to control Mermaid diagram rendering for PDF/print output.
+
+## Use Case
+
+Complex flowcharts, ER diagrams, and sequence diagrams render with overlapping labels at mmdc's default spacing. This config increases node/rank/padding values to produce legible output suitable for print.
+
+## Config File
+
+Save as `mermaid-config.json`:
+
+```json
+{
+  "flowchart": {
+    "useMaxWidth": false,
+    "htmlLabels": true,
+    "padding": 25,
+    "nodeSpacing": 60,
+    "rankSpacing": 80,
+    "curve": "basis"
+  },
+  "er": {
+    "diagramPadding": 30,
+    "layoutDirection": "TB",
+    "minEntityWidth": 100,
+    "minEntityHeight": 40,
+    "entityPadding": 20,
+    "fontSize": 11,
+    "useMaxWidth": false
+  },
+  "sequence": {
+    "diagramMarginX": 50,
+    "diagramMarginY": 30,
+    "actorMargin": 50,
+    "width": 150,
+    "height": 65,
+    "boxMargin": 10,
+    "boxTextMargin": 5,
+    "noteMargin": 10,
+    "messageMargin": 35,
+    "mirrorActors": true,
+    "bottomMarginAdj": 10,
+    "useMaxWidth": false,
+    "rightAngles": false,
+    "showSequenceNumbers": false
+  },
+  "theme": "default",
+  "themeVariables": {
+    "fontSize": "11px",
+    "fontFamily": "Inter, sans-serif",
+    "primaryColor": "#f5ede4",
+    "primaryTextColor": "#2a2018",
+    "primaryBorderColor": "#65413a",
+    "lineColor": "#65413a",
+    "secondaryColor": "#132345",
+    "tertiaryColor": "#e8d9c0",
+    "noteBkgColor": "#1a2f5a",
+    "noteTextColor": "#eceae5",
+    "clusterBkg": "#f5ede4",
+    "clusterBorder": "#132345",
+    "edgeLabelBackground": "#f5ede4",
+    "nodeBorder": "#65413a"
+  },
+  "maxTextSize": 50000
+}
+```
+
+## Usage
+
+```bash
+# Render with custom spacing
+mmdc -i diagram.mmd -o diagram.png -c mermaid-config.json
+
+# Render at higher resolution with config
+mmdc -i diagram.mmd -o diagram.png -c mermaid-config.json -w 2400 --backgroundColor '#f5ede4'
+```
+
+## Key Values
+
+| Setting | Default | This Config | Effect |
+|---------|---------|-------------|--------|
+| `nodeSpacing` | 30-40 | 60 | Horizontal space between nodes in flowchart |
+| `rankSpacing` | 50 | 80 | Vertical space between ranks in flowchart |
+| `padding` | 15 | 25 | Internal padding around flowchart diagrams |
+| `actorMargin` | 25 | 50 | Space between actors in sequence diagrams |
+| `messageMargin` | 20 | 35 | Space between messages in sequence diagrams |
+| `er.diagramPadding` | 15 | 30 | Padding around ER diagram entities |
+
+## Post-Render Resizing
+
+After rendering with `-w 2400`, the PNG will be too large for A4 pages. Resize for print:
+
+```python
+from PIL import Image
+img = Image.open('diagram.png')
+w, h = img.size
+MAX_W, MAX_H = 1300, 2100
+scale = min(1.0, MAX_W / w, MAX_H / h)
+img.resize((int(w * scale), int(h * scale)), Image.LANCZOS).save('diagram.png')
+```
+
+This produces ~200dpi output that fits A4 portrait pages with 2.2cm margins.

--- a/mermaid-diagrams/references/pdf-rendering-pipeline.md
+++ b/mermaid-diagrams/references/pdf-rendering-pipeline.md
@@ -90,7 +90,7 @@ These warnings are **harmless** when SVGs are pre-rendered and embedded as `<svg
 ## Puppeteer Setup
 
 ```javascript
-const puppeteer = require("/Users/magnus/.npm/_npx/d2654f9a588e9579/node_modules/puppeteer");
+const puppeteer = require("puppeteer");
 
 (async () => {
   const browser = await puppeteer.launch({

--- a/mermaid-diagrams/references/pdf-rendering-pipeline.md
+++ b/mermaid-diagrams/references/pdf-rendering-pipeline.md
@@ -1,0 +1,130 @@
+# PDF Rendering Pipeline
+
+Full pipeline for converting architecture documentation (markdown with Mermaid diagrams) into a PDF with properly rendered, full-page diagrams.
+
+This reference captures the lessons from a session where six PDF iterations were needed to fix defects: ASCII art not converted, Mermaid code blocks unrendered, SVGs constrained by max-width, data URI images not filling the page, and Pandoc math-parsing SVG CSS.
+
+## Pipeline Overview
+
+```bash
+# Step 1: Pre-render all Mermaid diagrams to SVG
+npx @mermaid-js/mermaid-cli -i diagram.mmd -o diagram.svg --width 800
+
+# Step 2: Embed SVGs in markdown (NOT as data URI img tags)
+# Use raw <svg> tags inline in the markdown file
+
+# Step 3: Convert markdown to HTML via Pandoc
+pandoc report.md -f markdown -t html5 --embed-resources --standalone \
+  -o report.html --metadata title="Title" \
+  --syntax-highlighting=none -f markdown-raw_tex
+
+# Step 4: Strip max-width constraints from SVG tags in HTML
+sed -i '' 's/max-width: [0-9]*\.[0-9]*px/max-width: 100%/g' report.html
+
+# Step 5: Add width:100% to all img tags (catches data-URI SVGs)
+# Add style="width:100%;height:auto;max-width:100%;display:block;margin:0 auto;"
+
+# Step 6: Generate PDF via Puppeteer
+node generate-pdf.js
+```
+
+## Critical Rules
+
+### Rule 1: Pre-render, don't serve code blocks
+
+Mermaid code blocks (```mermaid```) do NOT render in the Pandoc → HTML → Puppeteer pipeline. Pandoc converts them to static `<pre>` blocks, and Puppeteer does not execute JavaScript to render them.
+
+**Always:** Pre-render to SVG via mmdc, then embed the SVG.
+
+### Rule 2: Embed SVG as raw markup, not data URIs
+
+When SVGs are embedded as `<img src="data:image/svg+xml;base64,...">`, the SVG's internal `max-width` and `viewBox` cannot be overridden by page-level CSS. The image stays at its native size.
+
+**Preferred:** Insert the raw `<svg>...</svg>` markup directly into the markdown or HTML. This lets page-level CSS (width:100%, max-width:100%) control scaling.
+
+**Fallback (img tags):** If using `<img>` tags, add explicit `style="width:100%;height:auto;max-width:100%;display:block;"` to the `<img>` element itself. Do NOT rely on SVG-internal CSS.
+
+### Rule 3: Strip SVG max-width constraints
+
+Mermaid-generated SVGs have hardcoded `max-width` values:
+```html
+<svg style="max-width: 881.07px; ..."> 
+```
+These override any `width: 100%` you try to apply. Replace all instances with `max-width: 100%`.
+
+```bash
+# For inline SVGs:
+sed -i '' 's/max-width: [0-9]*\.[0-9]*px/max-width: 100%/g' report.html
+
+# For base64 data URIs, the max-width is inside the base64 encoding
+# and cannot be fixed by sed. Avoid data URIs.
+```
+
+### Rule 4: Portrait orientation (TD over LR)
+
+All diagrams destined for PDF must use `flowchart TD` (top-down), not `flowchart LR` (left-to-right). See `portrait-layout.md` for:
+- Max 4 nodes per subgraph row
+- Labels under 30 characters
+- Sequence diagrams with max 4 participants
+- viewBox must have height > width
+
+### Rule 5: Page breaks before/after full-page diagrams
+
+```html
+<div style="page-break-before: always;"></div>
+
+<!-- Diagram content here -->
+
+<div style="page-break-after: always;"></div>
+```
+
+### Rule 6: Pandoc TeX/SVG conflicts
+
+Pandoc interprets CSS selectors with `[id=` patterns as TeX math. This produces warnings like:
+```
+[WARNING] Could not convert TeX math ="-arrowhead"] path{fill:#333...
+```
+
+These warnings are **harmless** when SVGs are pre-rendered and embedded as `<svg>` or `<img>` tags. The warnings don't affect the output. Use `--syntax-highlighting=none -f markdown-raw_tex` flags to minimize issues.
+
+## Puppeteer Setup
+
+```javascript
+const puppeteer = require("/Users/magnus/.npm/_npx/d2654f9a588e9579/node_modules/puppeteer");
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ["--no-sandbox", "--disable-setuid-sandbox"]
+  });
+  const page = await browser.newPage();
+
+  const htmlPath = "file:///tmp/report.html";
+  await page.goto(htmlPath, { waitUntil: "networkidle0", timeout: 30000 });
+  await page.evaluate(() => new Promise(r => setTimeout(r, 2000)));
+
+  await page.pdf({
+    path: "/tmp/output.pdf",
+    format: "Letter",
+    printBackground: true,
+    margin: { top: "0.5in", bottom: "0.5in", left: "0.5in", right: "0.5in" }
+  });
+  await browser.close();
+})();
+```
+
+Puppeteer is available as a dependency of `@mermaid-js/mermaid-cli` at the path above. It is NOT installed globally.
+
+## QA Checklist for PDF Output
+
+Before sending any PDF to the user, verify ALL of these:
+
+- [ ] No ASCII art diagrams (grep for box-drawing chars: ┌ ┐ └ ┘ ├ ┤ ┬ ┴ ─ │)
+- [ ] No raw ```mermaid code blocks (grep for '```mermaid')
+- [ ] All SVGs pre-rendered (not relying on CDN JS execution)
+- [ ] SVGs fill page width (check html for width:100% on svg/img tags)
+- [ ] No hardcoded max-width pixel values in SVGs (check for 'max-width: Npx')
+- [ ] Flowcharts use TD not LR (grep for 'flowchart LR')
+- [ ] Page breaks before/after each full-page diagram (grep for 'page-break')
+- [ ] PDF file size > 100KB (diagrams rendered)
+- [ ] Visual verification: open the HTML in a browser before generating PDF

--- a/mermaid-diagrams/references/portrait-layout.md
+++ b/mermaid-diagrams/references/portrait-layout.md
@@ -1,0 +1,109 @@
+# Portrait Layout for Mermaid Diagrams
+
+When producing diagrams for PDF, print, or portrait-oriented screens (GitHub, GitLab, mobile), use `flowchart TD` (top-down) instead of `flowchart LR` (left-to-right). This stacks the diagram vertically so it fills a portrait page rather than shrinking to fit between paragraphs.
+
+## Forcing Portrait Output from the Dagre Engine
+
+Mermaid's default dagre layout engine optimizes for compactness, which often produces wide diagrams even with `flowchart TD`. Two techniques reliably force portrait output:
+
+### Technique 1: Wrapper Subgraph with `direction TB`
+
+Wrap ALL nodes and edges inside a single subgraph with `direction TB`. This constrains the layout engine to a tall container:
+
+```mermaid
+flowchart TD
+  subgraph C["Diagram Title"]
+    direction TB
+    A[Node A]
+    B[Node B]
+    C[Node C]
+    A --> B
+    B --> C
+  end
+```
+
+This transformed a container diagram from 2271×1100 (landscape) to 641×928 (portrait) in testing.
+
+### Technique 2: Invisible Chain Edges (`~~~`)
+
+When nodes at the same level still spread horizontally, add invisible chain edges to force vertical stacking:
+
+```mermaid
+flowchart TD
+  subgraph C["Stacked Diagram"]
+    direction TB
+    A[Node A]
+    B[Node B]
+    C[Node C]
+    D[Node D]
+
+    A --> B
+    A ~~~ C
+    B ~~~ D
+  end
+```
+
+The `~~~` edges are invisible but tell dagre "these nodes must be in different rows." Chain them through all nodes that dagre would otherwise place side by side.
+
+### Splitting Complex Diagrams
+
+Diagrams with more than 12-15 nodes or with dense cross-connections cannot be made portrait. Split into multiple sub-diagrams of 5-10 nodes each.
+
+| Original (landscape) | Split into | Portrait results |
+|---------------------|------------|-----------------|
+| 20-node component diagram (1261×799) | 4 sub-diagrams (5 nodes each) | All 281×661 or better |
+| 10-node architecture pattern (913×580) | 2 sub-diagrams (5-6 nodes each) | Both 367×799 and 368×532 |
+
+## QA: ViewBox Dimension Check
+
+Before delivery, extract the viewBox from every rendered SVG and verify width < height:
+
+```bash
+python3 -c "
+import re
+with open('diagram.svg') as f:
+    c = f.read()
+vb = re.search(r'viewBox=\"([^\"]*)\"', c)
+w, h = float(vb.group(1).split()[2]), float(vb.group(1).split()[3])
+if w > h:
+    print(f'LANDSCAPE: {w:.0f}x{h:.0f} — FIX')
+"
+```
+
+Text-pattern checks for "flowchart LR" are insufficient — Mermaid's dagre engine can produce landscape output from TD input.
+
+## PDF Embedding Rules
+
+- **Always base64-inline SVGs** — Raw SVG tags passed through Pandoc get CSS corrupted (especially `@keyframes`). Use `<img src="data:image/svg+xml;base64,...">`.
+- **Never use filesystem paths** — `<img src="/tmp/...svg">` breaks in PDF generation. Only base64 data URIs survive Pandoc → HTML → Puppeteer.
+- **`width:100%` on all `<img>` tags** — `style="width:100%;height:auto;max-width:100%;display:block;margin:0 auto;"`
+
+## Rules for Portrait-Oriented Diagrams
+
+1. **Always use `flowchart TD`** for architecture diagrams destined for PDF or portrait screens
+2. **Page break before and after** each full-page diagram:
+   ```html
+   <div style="page-break-before: always;"></div>
+   <img src="data:image/svg+xml;base64,...">
+   <div style="page-break-after: always;"></div>
+   ```
+3. **Keep the viewBox taller than wide.** The rendered SVG's viewBox must have height > width.
+4. **Max 4 nodes per row, max 12-15 nodes per diagram.** Split complex diagrams into sub-diagrams.
+5. **Short labels under 30 characters.** Use `<br/>` for multi-line. Abbreviate: "scraper-svc" not "Web Scraping Service".
+6. **Sequence diagrams: max 4 participants.** More creates wide layout. Split into separate diagrams.
+7. **Within TD, use `direction LR` on 2-3 node chains only.**
+8. **Light background for print** — dark themes waste toner in PDF.
+9. **Render at `--width 800`** via mmdc for A4/Letter fit.
+10. **Node shapes: `[()]` for databases, `[text]` for services.**
+
+## Verification Checklist
+
+- [ ] `flowchart TD` not `LR`
+- [ ] Wrapper subgraph with `direction TB` applied
+- [ ] Page break divs before and after each diagram
+- [ ] Base64-inlined SVGs (no raw SVG tags, no filesystem paths)
+- [ ] Every rendered SVG viewBox: width < height
+- [ ] Node labels under 30 chars
+- [ ] Light background for print
+- [ ] Max 4 participants per sequence diagram
+- [ ] No ASCII art — all diagrams are rendered Mermaid SVG

--- a/mermaid-diagrams/references/portrait-layout.md
+++ b/mermaid-diagrams/references/portrait-layout.md
@@ -74,8 +74,8 @@ Text-pattern checks for "flowchart LR" are insufficient — Mermaid's dagre engi
 
 ## PDF Embedding Rules
 
-- **Always base64-inline SVGs** — Raw SVG tags passed through Pandoc get CSS corrupted (especially `@keyframes`). Use `<img src="data:image/svg+xml;base64,...">`.
-- **Never use filesystem paths** — `<img src="/tmp/...svg">` breaks in PDF generation. Only base64 data URIs survive Pandoc → HTML → Puppeteer.
+- **Choose raw or base64 SVG deliberately** — raw inline SVG is the default because it remains inspectable and styleable. Use a base64 data URI only when the PDF renderer corrupts raw SVG.
+- **Never use filesystem paths** — `<img src="/tmp/...svg">` breaks in PDF generation. Inline raw SVG or a base64 data URI is required.
 - **`width:100%` on all `<img>` tags** — `style="width:100%;height:auto;max-width:100%;display:block;margin:0 auto;"`
 
 ## Rules for Portrait-Oriented Diagrams
@@ -101,7 +101,7 @@ Text-pattern checks for "flowchart LR" are insufficient — Mermaid's dagre engi
 - [ ] `flowchart TD` not `LR`
 - [ ] Wrapper subgraph with `direction TB` applied
 - [ ] Page break divs before and after each diagram
-- [ ] Base64-inlined SVGs (no raw SVG tags, no filesystem paths)
+- [ ] SVG embedding method selected and verified against the target renderer (raw inline by default; base64 only when needed)
 - [ ] Every rendered SVG viewBox: width < height
 - [ ] Node labels under 30 chars
 - [ ] Light background for print

--- a/mermaid-diagrams/references/sequence.md
+++ b/mermaid-diagrams/references/sequence.md
@@ -1,0 +1,72 @@
+# Sequence Diagrams
+
+Best for: interaction protocols, API call flows, agent handoffs, multi-service communication.
+
+## Basic Syntax
+
+```mermaid
+sequenceDiagram
+  participant A as Service A
+  participant B as Service B
+
+  A->>B: Request
+  B-->>A: Response
+```
+
+## Participant Types (v11+)
+
+```mermaid
+sequenceDiagram
+  participant A as 🧑 User
+  participant G as ⚙️ API Gateway
+  participant B as 🕸️ Browser
+  database D as 📦 Database
+  actor E as 🌐 External
+
+  A->>G: scrape(url)
+  G->>B: render(url)
+  B->>D: cache result
+  B-->>A: markdown
+```
+
+## Loops and Conditions
+
+```mermaid
+sequenceDiagram
+  participant A as Agent
+  participant S as Search-Svc
+
+  loop Until goal satisfied
+    A->>S: search(query)
+    S-->>A: results
+    alt results sufficient
+      A->>S: stop
+    else need more
+      A->>S: refine query
+    end
+  end
+```
+
+## Activation (Lifecycle)
+
+```mermaid
+sequenceDiagram
+  participant A as A
+  participant B as B
+
+  activate A
+  A->>B: Request
+  activate B
+  B-->>A: Response
+  deactivate B
+  deactivate A
+```
+
+## Critical Rules
+
+- `activate`/`deactivate` must be balanced
+- `alt`/`else`/`end` for conditional branches
+- `loop`/`end` for iterations
+- `par`/`and`/`end` for parallel
+- `break`/`end` for exit conditions
+- `critical`/`option`/`end` for critical sections

--- a/mermaid-diagrams/references/source-index.md
+++ b/mermaid-diagrams/references/source-index.md
@@ -1,0 +1,6 @@
+# Source index
+
+- **Source repository:** https://github.com/magnus919/hermes-profiles
+- **Inspected commit:** `867a555`
+- **Imported source directory:** `mermaid-diagrams`
+- **Porting boundary:** Retained portable methodology, templates, scripts, and references. Removed or generalized Hermes profile, task-orchestration, memory, and rigid response-handoff assumptions.

--- a/mermaid-diagrams/scripts/validate-mermaid.sh
+++ b/mermaid-diagrams/scripts/validate-mermaid.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# validate-mermaid.sh — Validate a .mmd Mermaid file for syntax errors
+# Uses Node.js mermaid.parse() for validation
+#
+# Usage: ./validate-mermaid.sh diagram.mmd
+# Returns 0 if valid, 1 if invalid
+
+set -euo pipefail
+
+FILE="${1:-}"
+if [ -z "$FILE" ]; then
+  echo "Usage: $0 <file.mmd>"
+  exit 1
+fi
+
+if [ ! -f "$FILE" ]; then
+  echo "Error: $FILE not found"
+  exit 1
+fi
+
+# Validate with Node.js mermaid.parse()
+node -e "
+const fs = require('fs');
+const { parse } = require('mermaid');
+const content = fs.readFileSync('$FILE', 'utf-8');
+try {
+  parse(content);
+  console.log('✓ Valid Mermaid syntax');
+  process.exit(0);
+} catch(e) {
+  console.error('✗ Invalid:', e.message);
+  process.exit(1);
+}
+" 2>&1 || {
+  # Fallback: check for common syntax issues
+  echo "--- Common issue check ---"
+  grep -n '^end$' "$FILE" | head -3 && echo "⚠  Lowercase 'end' found (should be case-context sensitive)"
+  grep -n '-->o\|--o>' "$FILE" | head -3 && echo "⚠  Arrow with o/x found (may need spaces)"
+  echo "Install mermaid: npm install mermaid"
+  exit 1
+}


### PR DESCRIPTION
## Summary

- add the portable `mermaid-diagrams` skill extracted from `magnus919/hermes-profiles` at `867a555`
- retain portable methodology, local references, templates, and scripts where present
- remove host-profile, orchestration, memory, and rigid response-handoff assumptions

## Validation

- [x] `ruby scripts/validate-skills.rb`
- [x] `git diff --check`
- [ ] `skills-ref validate ./mermaid-diagrams` — pending local tool availability check

## Documentation

- [x] I updated the relevant `SKILL.md`, `README.md`, or reference files.
- [x] Links are relative and resolve from a fresh clone.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] I have disclosed meaningful AI assistance in the description or commit message.

## Review notes

This is a portable extraction, not a copy of the Hermes profile adapter. `references/source-index.md` records the source commit and porting boundary.

## Agent disclosure

This pull request was created with AI assistance by Jasper (AI agent) on behalf of Magnus Hedemark. The agent performed the source inspection, porting, and validation. Human review is required before merge.
