### PR TITLE
feat: add verification-methodology skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,7 @@ When the user mentions these keywords, load the corresponding skill:
 | "adr-authoring", "adr authoring" | [adr-authoring](adr-authoring/SKILL.md) |
 | "c4-diagramming", "c4 diagramming" | [c4-diagramming](c4-diagramming/SKILL.md) |
 | "technology-radar", "technology radar" | [technology-radar](technology-radar/SKILL.md) |
+| "verification-methodology", "verification methodology" | [verification-methodology](verification-methodology/SKILL.md) |
 ## Use-When Sections
 
 Every skill description must identify when to load it. Skills with meaningful overlap should also include a `## When not to use` section naming the nearest alternative or prerequisite. Keep these sections trigger-oriented and concise; implementation details belong in references.

--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ Trakt.tv media discovery from the terminal. Browse trending, anticipated, and po
 
 Transistor.fm podcast hosting from the terminal. Manage shows and episodes, view subscriber analytics. API key from transistor.fm settings.
 
+### [verification-methodology](verification-methodology/SKILL.md)
+
+Replace completion claims with a disciplined evidence trail that shows what was checked, what passed, and what remains uncertain.
+
 ### [woodpecker-ci](woodpecker-ci/SKILL.md)
 Operate self-hosted Woodpecker CI from installation through production troubleshooting. Covers Forgejo/Gitea integration, server and agent setup, Docker and Kubernetes backends, workflow syntax, secrets, plugins, matrices, CLI/local execution, upgrades, security, and incident response.
 

--- a/verification-methodology/README.md
+++ b/verification-methodology/README.md
@@ -1,0 +1,36 @@
+# Verification Methodology
+
+Replace completion claims with a disciplined evidence trail that shows what was checked, what passed, and what remains uncertain.
+
+## Why Install This Skill
+
+Replace completion claims with a disciplined evidence trail that shows what was checked, what passed, and what remains uncertain. It preserves a practical method, local reference material, and reusable templates so an agent can do more than produce a generic answer.
+
+Use it when the work needs a repeatable process and an inspectable result. It is portable across Agent Skills-compatible clients and does not require a profile system or a particular task orchestrator.
+
+## What You Get
+
+| Path | What it provides |
+|---|---|
+| `SKILL.md` | Trigger conditions, workflow, and guidance for loading deeper resources. |
+| `references/` | Reference material: `criteria-assessment.md`, `evidence-standards.md`, `verdict-template.md` |
+
+## Quick Start
+
+Define the criteria, collect direct evidence, and produce a verdict using `references/verdict-template.md`.
+
+Install or expose this directory using your agent's standard Agent Skills loading mechanism, then ask for work that matches the triggers below.
+
+## Triggers
+
+- Verify work against explicit criteria using evidence, reproducible checks, and clear pass, conditional, or blocked verdicts. Use before declaring an artifact, implementation, or claim complete.
+- Requests involving the method, deliverables, or review process described in `SKILL.md`.
+- Work where a reusable template or reference from this skill would reduce avoidable mistakes.
+
+## Requirements
+
+No runtime dependency.
+
+## Source and maintenance
+
+This skill was extracted from [`magnus919/hermes-profiles`](https://github.com/magnus919/hermes-profiles) at commit [`867a555`](https://github.com/magnus919/hermes-profiles/commit/867a555). The portable methodology was retained; Hermes-specific profile, orchestration, and memory assumptions were removed.

--- a/verification-methodology/SKILL.md
+++ b/verification-methodology/SKILL.md
@@ -15,9 +15,13 @@ Pass/fail assessment against pre-defined criteria.
 
 ## The Verification Protocol
 
-```
-RECEIVE → ASSESS → INVESTIGATE → DECIDE → REPORT
-```
+1. **Receive** — restate the artifact, claim, or implementation being verified and the decision it will support.
+2. **Assess criteria** — convert requirements into observable pass/fail conditions; identify what would disprove each claim.
+3. **Investigate** — collect direct, reproducible evidence and record commands, source locations, or source URLs.
+4. **Decide** — mark each criterion passed, failed, blocked, or not applicable. Do not convert missing evidence into a pass.
+5. **Report** — use the verdict template to distinguish verified facts, assumptions, and remaining work.
+
+Stop when every criterion has direct evidence or an explicit blocked/not-applicable verdict. Escalate when the criterion is ambiguous, evidence conflicts, or the required access is unavailable.
 
 ## Reference Files
 

--- a/verification-methodology/SKILL.md
+++ b/verification-methodology/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: verification-methodology
+description: Verify work against explicit criteria using evidence, reproducible checks, and clear pass, conditional, or blocked verdicts. Use before declaring an artifact, implementation, or claim complete.
+license: MIT
+compatibility: No runtime dependency.
+metadata:
+  source_repo: https://github.com/magnus919/hermes-profiles
+  source_commit: 867a555
+---
+
+
+# Verification Methodology
+
+Pass/fail assessment against pre-defined criteria.
+
+## The Verification Protocol
+
+```
+RECEIVE → ASSESS → INVESTIGATE → DECIDE → REPORT
+```
+
+## Reference Files
+
+| Reference | When to load |
+|-----------|-------------|
+| `references/criteria-assessment.md` | You need to evaluate whether work meets completion criteria |
+| `references/evidence-standards.md` | You need to judge whether evidence supports the claims made |
+| `references/verdict-template.md` | You need to produce a structured pass/fail/hold verdict |
+
+## Portability
+
+This skill is intentionally host-neutral. Use your agent's normal mechanisms to load the references, templates, and scripts listed here. Do not assume a particular profile system, task orchestrator, memory service, or response-handoff format.

--- a/verification-methodology/references/criteria-assessment.md
+++ b/verification-methodology/references/criteria-assessment.md
@@ -1,0 +1,27 @@
+# Criteria Assessment
+
+## The Verifier's Question
+
+Not "is this good?" — that's a reviewer's question. The verifier asks: "does this meet the criteria?"
+
+## Criteria Types
+
+| Type | Example | Assessment |
+|------|---------|------------|
+| **Binary** | "All tests must pass" | Pass/Fail — no gray area |
+| **Threshold** | "At least 80% test coverage" | Pass/Fail with a number |
+| **Judgment** | "The argument must be coherent" | Requires explanation but still binary |
+| **Edge case** | "Must handle null input" | Pass only if explicitly tested |
+
+## Assessment Protocol
+
+1. **Identify all criteria** from the original brief or quality gate
+2. **Rate each criterion** independently — don't let one failure influence others
+3. **Distinguish failure from uncertainty.** If you can't verify a criterion because information is missing, flag it as uncertain, not failed
+4. **Report partial compliance.** If a criterion is partially met, state what's met and what's not
+
+## Verdict Decision
+
+- **PASS:** All criteria met. No exceptions.
+- **HOLD:** Most criteria met but some require clarification or information is missing.
+- **FAIL:** One or more criteria clearly not met, or evidence contradicts claims.

--- a/verification-methodology/references/evidence-standards.md
+++ b/verification-methodology/references/evidence-standards.md
@@ -1,0 +1,24 @@
+# Evidence Standards
+
+## Evidence Levels
+
+| Level | Standard | Example |
+|-------|----------|---------|
+| **Primary** | Direct observation, original data, reproducible experiment | Test output showing a passing result |
+| **Secondary** | Report from a credible source, cited with provenance | Quoting an API documentation reference |
+| **Circumstantial** | Indirect evidence that suggests but doesn't prove | Logs showing the system was up, but not that it processed correctly |
+| **Assertion** | Claim without supporting evidence | "The system should work" |
+
+## Verification Rules
+
+- Claims require evidence at the level specified by the criteria
+- A primary-source criterion cannot be satisfied with secondary evidence
+- Missing evidence for a criterion is a HOLD, not a FAIL
+- Contradictory evidence (claim says X, evidence shows Y) is a FAIL
+
+## Uncertainty Handling
+
+When evidence is insufficient:
+1. Document what evidence is available
+2. Document what evidence would be needed
+3. Report as HOLD with a clear description of what would resolve the uncertainty

--- a/verification-methodology/references/source-index.md
+++ b/verification-methodology/references/source-index.md
@@ -1,0 +1,6 @@
+# Source index
+
+- **Source repository:** https://github.com/magnus919/hermes-profiles
+- **Inspected commit:** `867a555`
+- **Imported source directory:** `verification-methodology`
+- **Porting boundary:** Retained portable methodology, templates, scripts, and references. Removed or generalized Hermes profile, task-orchestration, memory, and rigid response-handoff assumptions.

--- a/verification-methodology/references/verdict-template.md
+++ b/verification-methodology/references/verdict-template.md
@@ -1,0 +1,22 @@
+# Verdict Template
+
+## Verdict
+
+**PASS / HOLD / FAIL**
+
+## Criteria Assessment
+
+| Criterion | Result | Evidence | Notes |
+|-----------|--------|----------|-------|
+| Criterion 1 | PASS/FAIL/HOLD | What evidence supports this | Any caveats |
+
+## Summary
+
+- **Passed:** [count] criteria
+- **Failed:** [count] criteria
+- **Held:** [count] criteria (insufficient evidence)
+
+## Next Steps
+
+If HOLD: what would resolve the uncertainty.
+If FAIL: what must change before re-submission.


### PR DESCRIPTION
## Summary

- add the portable `verification-methodology` skill extracted from `magnus919/hermes-profiles` at `867a555`
- retain portable methodology, local references, templates, and scripts where present
- remove host-profile, orchestration, memory, and rigid response-handoff assumptions

## Validation

- [x] `ruby scripts/validate-skills.rb`
- [x] `git diff --check`
- [ ] `skills-ref validate ./verification-methodology` — pending local tool availability check

## Documentation

- [x] I updated the relevant `SKILL.md`, `README.md`, or reference files.
- [x] Links are relative and resolve from a fresh clone.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] I have disclosed meaningful AI assistance in the description or commit message.

## Review notes

This is a portable extraction, not a copy of the Hermes profile adapter. `references/source-index.md` records the source commit and porting boundary.

## Agent disclosure

This pull request was created with AI assistance by Jasper (AI agent) on behalf of Magnus Hedemark. The agent performed the source inspection, porting, and validation. Human review is required before merge.
