### PR TITLE
feat: add financial-modeling skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ When the user mentions these keywords, load the corresponding skill:
 | "traefik", "reverse proxy", "load balancer", "API gateway", "Let's Encrypt", "ACME", "Docker routing", "traefik.yml", "entry point", "middleware", "TLS termination", "forward auth", "rate limit" | [traefik](traefik/SKILL.md) |
 | "reverse-engineer", "understand this codebase", "PRD from code", "architecture document" | [software-architecture-analysis](software-architecture-analysis/SKILL.md) |
 | "data architecture", "data platform", "data strategy", "data mesh", "governance" | [data-architect](data-architect/SKILL.md) |
+| "financial modeling", "unit economics", "CAC", "LTV", "CAC payback", "pricing strategy", "fundraising", "cap table", "term sheet", "ARR", "MRR", "churn", "NDR", "Rule of 40", "Magic Number" | [financial-modeling](financial-modeling/SKILL.md) |
 | "statistical analysis", "experimental design", "A/B test", "hypothesis test", "power analysis", "causal inference", "regression", "Bayesian", "p-value", "effect size", "model selection", "machine learning methodology" | [data-scientist](data-scientist/SKILL.md) |
 | "brand identity", "brand guidelines", "style guide", "brand card", "brand strategy", "visual identity", "brand documentation", "color palette", "brand book" | [brand-designer](brand-designer/SKILL.md) |
 | "kanban", "WIP", "cycle time", "flow metrics", "Scrum to Kanban", "multi-portfolio", "throughput", "classes of service" | [kanban-guru](kanban-guru/SKILL.md) |
@@ -151,7 +152,7 @@ The `description` field is the trigger mechanism. If the user's request contains
 
 ### Don't Load Everything at Startup
 
-Loading all 15 skills at session start (~6,000 lines, ~75KB) wastes context. Let the conversation trigger loading. Skills load in ~100 tokens (metadata) and only expand when needed.
+Loading every skill at session start wastes context. Let the conversation trigger loading. Skills load in ~100 tokens (metadata) and only expand when needed.
 
 ### Follow Progressive Disclosure
 

--- a/README.md
+++ b/README.md
@@ -80,13 +80,17 @@ EPUB2→3 conversion, repair, and validation. Eight reference files covering for
 internals, Python libraries, spec/validation, tutorials, capability discovery,
 fixed-layout, accessibility, and media overlays. Portable across any AgentSkills harness.
 
-### [forgejo-cli](forgejo-cli/SKILL.md)
+### [financial-modeling](financial-modeling/SKILL.md)
 
-Safe Forgejo API v1 CLI for issues, pull requests, repositories, file contents, metadata, webhooks, and user settings. Includes a guarded generic `/api/v1/` route for version-specific endpoints such as Actions and admin APIs.
+Build and review assumptions-led financial models, unit economics, pricing, fundraising scenarios, and SaaS operating metrics.
 
 ### [flaresolverr](flaresolverr/SKILL.md)
 
 Use a private FlareSolverr service through a dependency-free JSON CLI when ordinary HTTP retrieval is blocked by a browser challenge.
+
+### [forgejo-cli](forgejo-cli/SKILL.md)
+
+Safe Forgejo API v1 CLI for issues, pull requests, repositories, file contents, metadata, webhooks, and user settings. Includes a guarded generic `/api/v1/` route for version-specific endpoints such as Actions and admin APIs.
 
 ### [ghost-cli](ghost-cli/SKILL.md)
 

--- a/financial-modeling/README.md
+++ b/financial-modeling/README.md
@@ -1,0 +1,41 @@
+# Financial Modeling
+
+Build clearer financial scenarios, pricing decisions, and operating-metric analyses from stated assumptions.
+
+## Why Install This Skill
+
+Business decisions often depend on numbers that look precise but rest on hidden assumptions. This skill gives your agent a practical method for making revenue, costs, cash, customer economics, and SaaS metrics explicit so you can test what changes when the assumptions change.
+
+It covers the questions teams repeatedly face: whether acquisition pays back, what a price change could do to retention, how long cash may last under different cases, and how to prepare a financing model or cap-table discussion. The material emphasizes traceable calculations and context rather than universal scorecards.
+
+It is an analytical aid, not financial, investment, tax, accounting, or legal advice. Use qualified professionals where those disciplines are required.
+
+## What You Get
+
+| Path | What it provides |
+|---|---|
+| `SKILL.md` | Scope, trigger boundaries, and a concise assumptions-led working method. |
+| `references/financial-modeling.md` | Linked statements, revenue and cost drivers, scenarios, and runway analysis. |
+| `references/unit-economics.md` | CAC, LTV, payback, contribution margin, and segmentation guidance. |
+| `references/pricing-strategy.md` | Pricing models, packaging, price-change tests, and trade-off analysis. |
+| `references/fundraising.md` | Valuation methods, cap tables, term-sheet concepts, and fundraising preparation. |
+| `references/saas-metrics.md` | ARR, retention, efficiency metrics, period alignment, and metric limitations. |
+| `references/source-index.md` | Source provenance, review date, and authoritative reference links. |
+
+## Quick Start
+
+This is a reference-only skill. No setup, API key, command, or dependency is required.
+
+## Triggers
+
+- Build or review a financial model, forecast, budget, scenario, or runway analysis.
+- Calculate CAC, LTV, payback, contribution margin, ARR, churn, NDR, Rule of 40, Magic Number, or burn multiple.
+- Evaluate a pricing change, packaging model, fundraising scenario, cap table, valuation method, or term-sheet concept.
+
+## Requirements
+
+No software dependencies or credentials. Useful analysis requires reliable business inputs with a defined currency, time period, and accounting basis.
+
+## Source and Maintenance
+
+This skill was ported from [`magnus919/hermes-profiles`](https://github.com/magnus919/hermes-profiles) at commit [`867a555`](https://github.com/magnus919/hermes-profiles/commit/867a555). See [`references/source-index.md`](references/source-index.md) for the portability boundary and source review details.

--- a/financial-modeling/SKILL.md
+++ b/financial-modeling/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: financial-modeling
+description: >-
+  Build and review assumptions-led financial models, unit economics, pricing,
+  fundraising scenarios, and SaaS operating metrics. Use when calculating CAC,
+  LTV, payback, runway, ARR, churn, NDR, Rule of 40, or sales efficiency; when
+  modeling revenue, costs, cash flow, pricing, cap tables, or financing.
+license: MIT
+metadata:
+  source_repo: https://github.com/magnus919/hermes-profiles
+  source_commit: 867a555
+---
+
+# Financial Modeling
+
+Use transparent assumptions, clearly labeled periods and units, and base/upside/downside scenarios. A model is a tool for exploring the implications of assumptions, not a prediction.
+
+**Analytical-aid boundary:** This skill provides analytical frameworks, not financial, investment, tax, accounting, or legal advice. Verify inputs and calculations, and consult qualified professionals for decisions that require them.
+
+## When to Use
+
+Load this skill when the task involves:
+
+- Building or reviewing a P&L, balance sheet, cash-flow, revenue, cost, or runway model
+- Calculating CAC, LTV, contribution margin, CAC payback, or segment-level unit economics
+- Evaluating pricing, packaging, price changes, or monetization
+- Preparing fundraising scenarios, a cap table, valuation analysis, or term-sheet questions
+- Analyzing SaaS ARR/MRR, churn, retention, NDR, Rule of 40, Magic Number, or burn multiple
+- Running sensitivity analysis or comparing base, upside, and downside cases
+
+## When Not to Use
+
+- For statistical inference, experiment design, causal analysis, or model selection, use `data-scientist`.
+- For the narrow question of whether a startup reaches profitability before cash runs out, use `yc-default-alive-calculator`.
+- Do not use this skill as a substitute for licensed financial, investment, tax, accounting, or legal advice.
+- Enterprise pricing negotiations, jurisdiction-specific securities rules, and tax/accounting treatment need specialist review beyond this skill.
+
+## Reference Guide
+
+Load only the reference relevant to the task:
+
+| Reference | Load when |
+|---|---|
+| [Unit economics](references/unit-economics.md) | Calculating CAC, LTV, payback, gross margin, or contribution margin |
+| [Financial modeling](references/financial-modeling.md) | Building linked statements, revenue and cost models, scenarios, or runway |
+| [Pricing strategy](references/pricing-strategy.md) | Evaluating value, packaging, tiers, price changes, or elasticity |
+| [Fundraising](references/fundraising.md) | Reviewing valuation methods, cap tables, term sheets, or fundraising process |
+| [SaaS metrics](references/saas-metrics.md) | Defining and interpreting ARR, churn, NDR, Rule of 40, Magic Number, or burn multiple |
+| [Source index](references/source-index.md) | Reviewing provenance, porting scope, source URLs, and currency boundaries |
+
+## Working Method
+
+1. Define the decision, audience, currency, time period, and accounting basis before calculating anything.
+2. List input sources and assumptions separately from calculated outputs. Keep monthly, quarterly, and annual figures distinct.
+3. Build from operational drivers, then use market-level estimates only as a reasonableness check.
+4. Show base, upside, and downside cases; vary the assumptions that materially change cash, growth, or profitability.
+5. Segment customers, channels, and products when their economics differ. Do not let an average conceal a loss-making segment.
+6. Treat benchmarks and thresholds as context-dependent heuristics, not pass/fail rules. Compare against stage, customer segment, contract cadence, business model, and current market conditions.
+7. State limitations, reconcile model outputs to the relevant statements where possible, and identify inputs that need professional review.
+
+## Portability
+
+This skill is intentionally host-neutral. Use the host agent's normal mechanisms to load the references listed above. It requires no profile system, task orchestrator, output format, scripts, or external services.

--- a/financial-modeling/references/financial-modeling.md
+++ b/financial-modeling/references/financial-modeling.md
@@ -1,0 +1,70 @@
+# Financial Modeling
+
+Financial models translate assumptions into projected statements. Their value is making assumptions explicit and internally consistent, not predicting the future.
+
+## Model Structure
+
+A complete model links three statements and the schedules that drive them.
+
+| Statement | What it shows | Key line items |
+|---|---|---|
+| Income statement (P&L) | Profitability over a period | Revenue, COGS, gross profit, operating expenses, net income |
+| Balance sheet | Assets, liabilities, and equity at a point in time | Cash, receivables, payables, debt, equity |
+| Cash-flow statement | Cash sources and uses over a period | Operating, investing, financing cash flows, net change in cash |
+
+| Supporting schedule | Feeds into | Contents |
+|---|---|---|
+| Revenue build | P&L revenue and receivables | Customers, conversion, pricing, collections |
+| Headcount plan | P&L operating expenses | Roles, start dates, compensation, benefits |
+| Capex and debt | Fixed assets, depreciation, debt, interest | Purchases, useful lives, principal, rates, terms |
+| Equity | Equity and financing cash flow | Rounds, options, dilution |
+
+Use one currency and a stated period convention throughout. Reconcile ending cash on the cash-flow statement to the balance sheet. Accounting classification and recognition require the applicable accounting framework and professional review.
+
+## Revenue and Costs
+
+Build the base case from operational drivers. Use top-down market sizing as a reasonableness check, not the primary forecast.
+
+```
+Bottom-up revenue = customers x revenue per customer + expansion revenue
+```
+
+For a monthly subscription model, if all inputs are monthly:
+
+```
+Month N recurring revenue =
+  (prior-month customers x (1 - monthly logo churn) x monthly ARPU)
+  + (new customers x monthly ARPU)
+  + expansion revenue for the month
+```
+
+For usage-based revenue, model active accounts, usage per account, price per unit, and seasonality. For services, model billable headcount, utilization, billable rate, and billable days. Keep bookings, recognized revenue, invoicing, and cash collections separate when timing differs.
+
+| Cost type | Examples | Modeling approach |
+|---|---|---|
+| Fixed | Base salaries, rent, subscriptions | Step changes at hiring or capacity thresholds |
+| Variable | Hosting, payment processing, commissions | Per unit or percentage of the relevant driver |
+| Semi-variable | Support and sales capacity | Fixed base plus staffing tiers triggered by volume |
+
+Ratios such as R&D, sales and marketing, G&A, and gross margin as a percentage of revenue are context-dependent heuristics. Compare like-for-like business models, maturity, and accounting treatment rather than treating ranges as targets.
+
+## Scenarios and Sensitivity
+
+Always show a base, upside, and downside case. Change observable drivers, such as customer additions, churn, price, sales capacity, collection timing, headcount, and variable cost, rather than only changing the final revenue number.
+
+Use one- or two-way sensitivity tables to identify inputs that materially change ending cash, profitability, or a financing need. Label every illustrative percentage or dollar amount as hypothetical; do not mistake a scenario for a forecast.
+
+Common errors include linear growth assumptions, hidden customer concentration, automatic expansion assumptions, omitted churn, and confusing revenue timing with cash timing.
+
+## Runway
+
+Define monthly net cash burn as a positive cash outflow before calculating runway:
+
+```
+Net monthly cash burn = cash operating outflows - cash operating inflows
+Runway (months) = available cash / net monthly cash burn
+```
+
+Use a cash-flow forecast, not P&L loss, when receivables, payables, deferred revenue, capex, debt service, financing, or taxes are material. If the business is cash-generative, runway is not meaningful as a finite quotient; model the cash balance and liquidity risks instead.
+
+Runway bands, such as when to reduce spending or begin financing conversations, are management heuristics. They depend on financing access, contractual commitments, volatility, and the time needed to execute a contingency plan. Include one-time costs and test slower collections, delayed revenue, and higher spend.

--- a/financial-modeling/references/fundraising.md
+++ b/financial-modeling/references/fundraising.md
@@ -1,0 +1,46 @@
+# Fundraising
+
+Fundraising preparation makes the business case, financial assumptions, ownership effects, and financing terms inspectable. It is not legal, securities, tax, accounting, investment, or valuation advice; use qualified counsel and advisers for a transaction.
+
+## Valuation Methods
+
+| Method | Best for | Limitation |
+|---|---|---|
+| Comparable companies | Businesses with relevant public peers | Few peers are truly comparable; market prices move daily |
+| Comparable transactions | M&A or later-stage context | Terms and transaction data are often private |
+| Discounted cash flow | Predictable, cash-generative businesses | Highly sensitive to discount rate and terminal assumptions |
+| Venture-capital method | Early-stage scenario analysis | Depends on uncertain exit and dilution assumptions |
+| Market multiple | Fast directional comparison | Can hide differences in growth, margin, retention, and risk |
+
+Valuation multiples are market-cycle- and company-specific heuristics, not portable ranges. Do not reuse dated multiple tables or fabricate current figures. Obtain current, relevant comparables and disclose date, geography, revenue definition, growth, margin, retention, and capital structure. Public-cloud indices can provide market context but do not determine a private-company valuation.
+
+## Cap Table
+
+Track authorized shares, issued shares, the option pool, outstanding options, warrants, convertibles, and fully diluted shares. Model each financing round on a fully diluted basis before accepting terms.
+
+For each scenario, show pre-money valuation, new money, post-money valuation, option-pool changes, conversion assumptions, ownership by holder class, and dilution. The economic result depends on instrument terms, not only on the headline valuation. Do not present a typical dilution path as an expected outcome.
+
+## Term-Sheet Concepts
+
+| Term | Question to model |
+|---|---|
+| Liquidation preference | Who receives proceeds first, at what multiple, and with what seniority? |
+| Participation | Does preferred receive its preference and also share in remaining proceeds? |
+| Anti-dilution | How do down-round terms change conversion or ownership? |
+| Option pool | Is the pool increased pre- or post-money, and who bears dilution? |
+| Board and protective provisions | Who controls specified operating and financing decisions? |
+| Pro-rata, ROFR, and drag-along rights | How do future financings, transfers, and exits affect holders? |
+
+Model exit proceeds across several values and security classes. Market practice varies by stage, geography, investor, and cycle; do not assume a term is standard or acceptable without counsel.
+
+## Preparation and Process
+
+Prepare a reconciled financial model, current cap table, historical financial statements, customer and retention analysis, material contracts, corporate records, and a clear account of risks and assumptions. Plan for diligence, legal work, and timing uncertainty. Financing timelines and investor check sizes vary widely, so use a cash scenario rather than generic timing bands.
+
+## Common Pitfalls
+
+- Presenting an optimistic forecast as a commitment rather than an assumption-led scenario.
+- Starting a process without modeling cash needs if timing slips or terms change.
+- Ignoring convertibles, warrants, option-pool top-ups, or preference stacks.
+- Comparing valuation headlines without comparing security terms and dilution.
+- Sharing sensitive customer, financial, or legal records without appropriate access controls and counsel.

--- a/financial-modeling/references/pricing-strategy.md
+++ b/financial-modeling/references/pricing-strategy.md
@@ -1,0 +1,50 @@
+# Pricing Strategy
+
+Pricing communicates value, segments customers, and changes acquisition, retention, and cash flow. Treat it as a hypothesis to test, not a formula that produces a universally correct price.
+
+## Pricing Models
+
+| Model | Basis | Useful when | Limitation |
+|---|---|---|---|
+| Value-based | Customer value created | Value can be measured and differentiated | Requires credible value evidence and segmentation |
+| Cost-plus | Cost to serve plus margin | Cost establishes a viable floor | Does not measure willingness to pay |
+| Competitive | Relative market position | Buyers compare alternatives directly | Can obscure differentiated value or start a price war |
+| Freemium | Free access with paid upgrade | Marginal cost is low and upgrade triggers are clear | Free-serving cost and conversion must support the economics |
+| Tiered or usage-based | Segment, feature, capacity, or consumption | Different customers receive different value | Packaging can become hard to understand |
+
+For value-based pricing, identify the customer outcome, quantify the economic value where possible, and test willingness to pay by segment. Cost-plus pricing can set a floor but should not be the sole pricing decision. Enterprise contracts, multi-year commitments, compliance requirements, and services bundles require deal-specific analysis beyond a self-serve pricing framework.
+
+## Packaging
+
+Build tiers around distinct customer needs and clear upgrade triggers, such as users, usage, workflow complexity, support, or governance. Keep the price metric understandable and show material differences between packages. A three-tier structure and annual-billing discounts are common patterns, not rules; validate them with the target market and unit economics.
+
+Bundling works when features create more value together. Unbundling can help when needs vary materially. Mixed bundles trade flexibility against complexity and possible cannibalization.
+
+## Testing a Price Change
+
+1. State the goal: conversion, margin, expansion, cash collection, or a target segment.
+2. Define affected cohorts, existing-customer treatment, contract obligations, and the period to observe.
+3. Test with new customers or a controlled segment where practical. Track conversion, sales cycle, discounting, activation, retention, support demand, and contribution margin.
+4. Compare results against a contemporaneous control or historical baseline adjusted for seasonality and channel mix.
+5. Decide using an explicit trade-off, then monitor the affected cohorts after rollout.
+
+Surveys reveal stated preference and are weaker evidence than observed behavior. Conjoint studies and experiments can help, but their validity depends on sampling, design, and sufficient volume. For causal interpretation of price tests, use `data-scientist`.
+
+## Hypothetical LTV Trade-off
+
+With monthly units throughout, a price increase can reduce LTV if churn rises enough:
+
+```
+Current simple LTV = $100 monthly ARPU x 60% gross margin / 5% monthly churn = $1,200
+New simple LTV = $120 monthly ARPU x 60% gross margin / 8% monthly churn = $900
+```
+
+These are hypothetical figures. This simple LTV formulation assumes stable monthly churn and ARPU; use cohort analysis for a more complete view. Evaluate revenue, contribution margin, conversion, retention, and cash timing together rather than using LTV alone.
+
+## Common Pitfalls
+
+- Raising prices without a clear customer-value narrative or contractual review.
+- Treating a competitor's list price as evidence of willingness to pay.
+- Measuring only initial conversion while missing discounting, churn, or support costs.
+- Mixing monthly and annual prices, contract values, or churn rates in one comparison.
+- Leaving old prices unchanged without periodically reassessing value and costs.

--- a/financial-modeling/references/saas-metrics.md
+++ b/financial-modeling/references/saas-metrics.md
@@ -1,0 +1,81 @@
+# SaaS Metrics
+
+SaaS metrics are useful operating measures only when their revenue definitions, customer population, and time periods are consistent. They are management heuristics, not accounting standards or universal thresholds.
+
+## Growth and Retention
+
+### ARR and MRR
+
+```
+ARR = recurring monthly revenue x 12
+```
+
+Alternatively, ARR can be the annualized committed recurring value of active subscriptions. State whether usage above committed minimums, services, one-time fees, credits, or foreign exchange effects are included. Do not add monthly and annual measures without converting them first.
+
+```
+Net new ARR = new ARR + expansion ARR - contraction ARR - churned ARR
+```
+
+### Logo Churn and Retention
+
+```
+Monthly logo churn = customers churned during month / customers at start of month
+Annualized logo churn = 1 - (1 - monthly logo churn)^12
+```
+
+Annualization assumes a stable monthly rate. Segment churn by contract cadence, customer size, product, cohort, and channel before comparing it to a benchmark. Enterprise and SMB businesses can have materially different normal churn profiles.
+
+### Net Dollar Retention (NDR)
+
+```
+NDR = (starting recurring revenue + expansion - contraction - churn)
+      / starting recurring revenue
+```
+
+Use the same starting cohort and period for every component. NDR above or below 100% is informative, but its interpretation depends on segment, contract cadence, price changes, and whether expansion is durable. Do not use generic NDR bands as universal thresholds.
+
+## Efficiency Metrics
+
+### Rule of 40
+
+```
+Rule of 40 = revenue growth rate (%) + profit margin (%)
+```
+
+Specify the growth period and margin definition. EBITDA margin and free-cash-flow margin are common variants; neither is interchangeable with the other. The metric is generally more useful for scaled recurring-revenue businesses than for pre-revenue or early product-market-fit companies. Treat 40% and any score bands as contextual heuristics, and inspect the drivers and trend rather than optimizing one score.
+
+### Magic Number
+
+Magic Number compares sales and marketing investment with incremental recurring revenue. The numerator and denominator must represent compatible periods and units.
+
+If the numerator is the increase in **quarterly recurring revenue** (a quarterly amount), annualize it before comparing it with prior-quarter sales and marketing spend:
+
+```
+Magic Number = quarterly recurring revenue increase x 4
+               / prior-quarter sales and marketing spend
+```
+
+If the numerator is **net new ARR** (already an annualized contract-value measure), do **not** multiply it by four:
+
+```
+Magic Number = net new ARR for the quarter
+               / prior-quarter sales and marketing spend
+```
+
+The `x 4` factor annualizes a quarterly revenue increment; it does not turn quarterly spend into annual spend and must not annualize ARR twice. Prior-quarter spend is a lagging convention, not a law. Use the same accounting classification and a stated attribution lag consistently. Magic Number thresholds are context-dependent heuristics, especially where sales cycles, ramping, channel mix, or capitalization policies differ.
+
+### Burn Multiple
+
+```
+Burn multiple = net cash burn during a period / net new ARR during that period
+```
+
+Use positive cash burn and net new ARR from the same period. A ratio can be distorted by one-time cash events, large contracts, annual billing, and a very small denominator. Interpret it alongside cash flow, growth quality, gross margin, and retention rather than against a fixed universal band.
+
+## Metric Discipline
+
+- Keep bookings, billings, recognized revenue, cash collections, MRR, and ARR distinct.
+- Use comparable period lengths and consistent cohorts in every ratio.
+- Reconcile metric changes to customer-level or contract-level movements where possible.
+- Inspect segments rather than allowing a blended average to hide poor retention or inefficient channels.
+- Record definition changes, reclassifications, acquisitions, and currency effects alongside the metric trend.

--- a/financial-modeling/references/source-index.md
+++ b/financial-modeling/references/source-index.md
@@ -1,0 +1,23 @@
+# Source Index
+
+- **Source repository:** https://github.com/magnus919/hermes-profiles
+- **Source commit:** [`867a555`](https://github.com/magnus919/hermes-profiles/commit/867a555)
+- **Imported source directory:** `skills/financial-modeling`
+- **Access and review date:** 2026-07-13
+- **Porting boundary:** Retains portable methodology for financial models, unit economics, pricing, fundraising, and SaaS metrics. Removes profile-system instructions, task orchestration, artifact-format requirements, private paths, and dependencies on skills not present in this catalog. Corrects period alignment and adds currency, market-cycle, and professional-review boundaries.
+
+## Authoritative Sources
+
+These sources support definitions and primary frameworks. They do not turn management heuristics into universal thresholds.
+
+| Topic | Source | Use |
+|---|---|---|
+| Financial reporting | [FASB Accounting Standards Codification](https://asc.fasb.org/) | U.S. GAAP accounting standards and definitions |
+| Financial reporting | [IFRS Accounting Standards](https://www.ifrs.org/issued-standards/list-of-standards/) | IFRS accounting standards and definitions |
+| Venture financing documents | [NVCA Model Legal Documents](https://nvca.org/model-legal-documents/) | Term-sheet and financing-document concepts |
+| SaaS efficiency | [Bessemer Venture Partners: Rule of 40](https://www.bvp.com/atlas/the-rule-of-40) | Rule of 40 framing and context |
+| SaaS valuation currency | [BVP Cloud Index](https://cloudindex.bvp.com/) | Current public-cloud market context; not a private-company valuation rule |
+
+## Interpretation Boundary
+
+Accounting standards define reporting treatment; they are authoritative only in the applicable jurisdiction and reporting framework. CAC, LTV, payback, churn, NDR, Rule of 40, cost ratios, runway bands, and valuation multiples are management or investor heuristics. Define them consistently for the business being analyzed and do not present them as accounting standards or universal targets.

--- a/financial-modeling/references/unit-economics.md
+++ b/financial-modeling/references/unit-economics.md
@@ -1,0 +1,59 @@
+# Unit Economics
+
+Unit economics asks whether a customer or transaction creates value after the costs required to acquire and serve it. Define the customer segment, channel, currency, and measurement period before comparing metrics.
+
+## Core Metrics
+
+### Customer Acquisition Cost (CAC)
+
+```
+CAC = sales and marketing acquisition spend during a period
+      / new customers acquired during the same period
+```
+
+State whether CAC is blended, paid, or channel-specific. Acquisition spend can include sales and marketing compensation, commissions, advertising, acquisition tools, and attributable programs. Exclude R&D and retain/support costs unless the stated definition intentionally includes them. Align the spend window with the acquisition cohort and account for long sales cycles.
+
+### Lifetime Value (LTV)
+
+For a simple monthly subscription estimate with monthly ARPU and monthly logo churn:
+
+```
+Simple LTV = monthly ARPU x gross margin percentage / monthly churn rate
+```
+
+This assumes stable price, margin, and churn. Cohort LTV, calculated from actual customer revenue and service costs over time, is more reliable when history is available because it captures retention curves, expansion, contraction, and segment differences.
+
+### CAC Payback
+
+```
+Gross-margin payback (months) = CAC / (monthly ARPU x gross margin percentage)
+```
+
+This common measure uses gross margin. For a more conservative cash or operating view, substitute monthly contribution margin if its variable costs are defined consistently. Do not divide a CAC measured over a quarter by annual ARPU; convert both numerator and denominator to comparable units first.
+
+### Contribution Margin
+
+```
+Contribution margin = customer revenue - COGS - variable operating costs
+```
+
+Variable costs may include account-specific infrastructure, payment processing, support, onboarding, and per-seat licenses. Fixed R&D, G&A, and acquisition expense are normally analyzed separately.
+
+## Interpretation
+
+```
+LTV/CAC = LTV / CAC
+```
+
+LTV/CAC, payback, churn, and margin bands are context-dependent heuristics, not universal thresholds. A long payback can be reasonable for contracted enterprise customers; a high LTV/CAC ratio can also signal underinvestment in growth. Stage, contract duration, gross margin, channel mix, financing constraints, and retention quality determine the useful range.
+
+Segment analysis is essential. Calculate CAC, ARPU, margin, churn, LTV, and payback by meaningful customer segment and acquisition channel. Avoid averages that hide materially different enterprise, mid-market, SMB, self-serve, or partner economics.
+
+## Common Pitfalls
+
+- Mixing monthly churn with annual ARPU, or expenses from one period with customers from another.
+- Treating simple LTV as a forecast despite changing retention or expansion behavior.
+- Counting only current customers and omitting customers that already churned.
+- Treating all sales and marketing spend as short-term acquisition spend when brand investment has a longer horizon.
+- Applying VC-backed SaaS benchmarks to bootstrapped, usage-based, marketplace, services, or other business models without adjustment.
+- Failing to refresh definitions and cohorts as pricing, channel mix, and customer mix change.


### PR DESCRIPTION
## Summary

- add a host-neutral `financial-modeling` skill with progressive-disclosure references for financial models, unit economics, pricing, fundraising, and SaaS metrics
- correct period and unit handling for runway, Magic Number, retention, and efficiency calculations while treating benchmarks as contextual heuristics
- document source provenance, analytical-aid boundaries, catalog routing, and trigger routing
- remove a stale hard-coded skill count from `AGENTS.md`

Closes #5

## Validation

- [x] `ruby scripts/validate-skills.rb` — `Validated 80 canonical skills.`
- [x] Skill-specific checks, if applicable: <!-- command and result -->
  - `uv run --project /tmp/agentskills-reference/skills-ref skills-ref validate financial-modeling` — valid skill
  - `git diff --check`
  - Independent reviewer profile: binding PASS after full-file and formula review
  - Independent verifier profile: PASS against every acceptance criterion, internal links, public privacy, provenance, and cross-skill references

## Documentation

- [x] I updated the relevant `SKILL.md`, `README.md`, or reference files.
- [x] Links are relative and resolve from a fresh clone.
- [x] Root `README.md` catalog entry is alphabetically placed.
- [x] Root `AGENTS.md` includes trigger routing.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] I have disclosed meaningful AI assistance in the description or commit message.

## Review notes

- Ported from `magnus919/hermes-profiles` at commit `867a555` and substantively revised rather than copied unchanged.
- OpenCode assembled the implementation from Jasper's scoped brief and researcher artifact. Jasper performed a binding full-diff self-review, fixed the catalog-order finding, and independently re-ran validation.
- The skill is an analytical aid, not financial, investment, tax, accounting, or legal advice.

---

Filed and implemented by Jasper (AI agent on behalf of Magnus Hedemark), with OpenCode assistance.