### PR TITLE
feat: add strategy-frameworks skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,7 @@ When the user mentions these keywords, load the corresponding skill:
 | "adr-authoring", "adr authoring" | [adr-authoring](adr-authoring/SKILL.md) |
 | "c4-diagramming", "c4 diagramming" | [c4-diagramming](c4-diagramming/SKILL.md) |
 | "technology-radar", "technology radar" | [technology-radar](technology-radar/SKILL.md) |
+| "strategy", "strategic planning", "OKRs", "strategic narrative", "Five Forces", "Blue Ocean", "competitive positioning", "moat", "Ansoff", "Three Horizons", "market entry", "capital allocation", "M&A evaluation", "BCG Matrix", "portfolio management" | [strategy-frameworks](strategy-frameworks/SKILL.md) |
 | "verification-methodology", "verification methodology" | [verification-methodology](verification-methodology/SKILL.md) |
 | "seo-audit", "seo audit" | [seo-audit](seo-audit/SKILL.md) |
 ## Use-When Sections

--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ Reverse-engineer a software codebase to understand its architecture, data flow, 
 
 Spec-Driven Development (SDD) methodology for AI software factories — where structured specifications are the input, AI agents generate the code, and quality gates enforce correctness at each pipeline phase. Covers the 5-phase pipeline (SPECIFY → DECOMPOSE → IMPLEMENT → VERIFY → DELIVER), 4 phase gates with APPROVED/CONDITIONS/REJECTED verdicts, 7 spec quality gates, a methodology selection matrix (BDD, OpenAPI, AsyncAPI, DbC, TLA+, ADRs, C4), NFR encoding patterns, format translation (PRD → SPEC.md → Gherkin → OpenAPI), gate recovery and revision workflows, and a worked example SPEC.md. Ships 4 templates, 9 reference files, and 2 validation scripts. Tool-agnostic — works with Claude Code, Cursor, Hermes Agent, Devin, OpenHands, and droid.
 
+### [strategy-frameworks](strategy-frameworks/SKILL.md)
+
+Structure organizational strategy decisions about direction, industry structure, growth, capital allocation, acquisitions, and portfolios. Uses frameworks as prompts for evidence and trade-offs, not automatic recommendations.
+
 ### [systematic-debugging](systematic-debugging/SKILL.md)
 
 4-phase root cause debugging protocol: understand bugs before fixing. Covers schema/environment divergence, exception type specificity in fallback chains, progressive characterization grids for API/retrieval failures, dependency source detection (editable dev forks), macOS sandboxed application debugging, and the Rule of Three for recognizing architectural problems. Adapted from [obra/superpowers](https://github.com/obra/superpowers) (MIT) with significant expansion from real-world use.

--- a/strategy-frameworks/README.md
+++ b/strategy-frameworks/README.md
@@ -1,0 +1,31 @@
+# Strategy Frameworks — Structure consequential strategic choices
+
+## Why Install This Skill
+
+Turn an ambiguous strategic question into an explicit decision: what is being decided, which alternatives exist, what evidence matters, and which assumptions could change the answer. The skill gives your agent frameworks for direction-setting, competition, growth, capital allocation, acquisitions, and portfolios without treating any framework as a formula.
+
+It helps produce decision-ready prompts, comparisons, and records that explain uncertainty and trade-offs. Use it alongside customer research, financial analysis, and technical due diligence when those inputs are material.
+
+
+## What You Get
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | Host-neutral index, routing, boundaries, and completion criteria |
+| `references/strategic-planning.md` | Prompts for direction, OKRs, values, and strategic narratives |
+| `references/competitive-analysis.md` | Industry structure, value-curve, advantage, and positioning analysis |
+| `references/growth-strategy.md` | Growth-option, maturity-state, and market-entry analysis |
+| `references/resource-allocation.md` | Capital, acquisition, and portfolio decision prompts |
+| `references/source-index.md` | Neutral provenance and current skill boundaries |
+
+## Quick Start
+
+No setup required. The skill is loaded by your agent framework when trigger conditions match.
+
+## Triggers
+
+Load this skill for strategic planning, OKRs, values, strategic narratives, industry structure, Five Forces, competitive positioning, growth options, Ansoff, Three Horizons, market entry, capital allocation, acquisition evaluation, BCG growth-share analysis, or portfolio decisions.
+
+## Requirements
+
+None. Reference-only skill — no API keys, scripts, or system dependencies. Works with any agent framework that supports the Agent Skills format.

--- a/strategy-frameworks/SKILL.md
+++ b/strategy-frameworks/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: strategy-frameworks
+description: >-
+  Structure organizational strategy work: strategic direction, competitive and
+  industry analysis, growth options, capital allocation, acquisitions, and
+  portfolio choices. Use when framing consequential choices about where to
+  compete, how to pursue an opportunity, or how to compare strategic options.
+license: MIT
+metadata:
+  source_repo: https://github.com/magnus919/hermes-profiles
+  source_commit: 867a555
+  source_path: skills/strategy-frameworks
+---
+
+# Strategy Frameworks
+
+Use a framework to make assumptions, alternatives, evidence, and trade-offs visible. Select a reference for the decision at hand rather than applying every framework.
+
+| Need | Load |
+|---|---|
+| Direction, OKRs, values, or a narrative | `references/strategic-planning.md` |
+| Industry structure, positioning, or potential advantages | `references/competitive-analysis.md` |
+| Growth options, maturity states, or market entry | `references/growth-strategy.md` |
+| Capital choices, acquisitions, or a business portfolio | `references/resource-allocation.md` |
+| Provenance and catalog boundaries | `references/source-index.md` |
+
+## Working Method
+
+1. State the decision, decision owner, constraints, and evidence available.
+2. Use the relevant framework to generate questions and options, not a verdict.
+3. Record assumptions, uncertainties, trade-offs, and conditions that would change the recommendation.
+4. Pair strategic logic with appropriate financial, customer, technical, legal, or operational analysis.
+
+## When Not to Use
+
+- For stakeholder interviews and raw requirement discovery, use `product-discovery`.
+- For feature prioritization, specifications, and product communications, use `product-methodology`.
+- For quantitative scenarios, valuation, unit economics, or capital-model calculations, use `financial-modeling`.
+- For technology adoption posture and architecture governance, use `technology-radar`.
+
+## Completion
+
+Stop when the artifact names the decision, alternatives, evidence, key assumptions, trade-offs, and next validation or decision step. It should not present a framework classification as a prediction or decision by itself.

--- a/strategy-frameworks/references/competitive-analysis.md
+++ b/strategy-frameworks/references/competitive-analysis.md
@@ -1,0 +1,59 @@
+# Competitive Analysis
+
+Use these lenses to investigate a market and an organization's relative position. Their output is a set of questions, evidence needs, and hypotheses, not a profitability forecast.
+
+## Five Forces
+
+*Attribution: Michael E. Porter described the framework in "How Competitive Forces Shape Strategy" (1979).*
+
+Analyze industry structure by examining rivalry, potential entrants, substitutes, buyer power, and supplier power. Define the market boundary first, then ask for each force:
+
+- Who has choices or negotiating leverage, and why?
+- Which costs, constraints, regulation, channels, standards, or relationships shape that leverage?
+- What evidence supports the assessment, and what is changing?
+- Which relevant complements, ecosystems, or nonmarket factors are outside the model?
+
+The framework helps compare structural pressures and identify questions for further research. It does not determine an industry's or firm's profitability; firm capabilities, timing, regulation, execution, and market definition also matter.
+
+## Value-Curve Exploration
+
+*Attribution: value-innovation and "Blue Ocean Strategy" tools are associated with W. Chan Kim and Renee Mauborgne.*
+
+Map the factors customers use to compare alternatives, then describe how each alternative emphasizes those factors. Challenge the current value curve with four prompts:
+
+- Which factors could be removed because they add little value for the chosen customer?
+- Which could be reduced?
+- Which could be increased?
+- What new factor or combination of factors might be worth testing?
+
+This is an exploratory exercise, not evidence that a new market exists. Validate customer value, cost implications, adoption barriers, and competitive response before acting.
+
+## Potential Advantages
+
+An advantage may arise from network participation, switching friction, scale economics, intangible assets, distinctive capabilities, data access, relationships, or another context-specific source. Avoid assigning a categorical durability rating.
+
+For each claimed advantage, ask:
+
+1. What mechanism creates value or lowers cost?
+2. For whom does it matter, and what evidence shows that it affects behavior or economics?
+3. What would a competitor, supplier, customer, regulator, or substitute need to do to weaken it?
+4. What investment, maintenance, or dependencies does it require?
+5. Under which scenarios does it strengthen, weaken, or become irrelevant?
+
+## Positioning
+
+Describe a position relative to the alternatives customers actually consider. A useful draft can answer: for whom is the offering intended, what job or problem does it address, which category or frame is relevant, what outcome is promised, and what evidence distinguishes it from alternatives?
+
+A two-axis map can help discuss perceptions, but its axes may omit important dimensions and its placement can reflect analyst judgment. Test the map with customer evidence. Neither narrow nor broad positioning is inherently superior; fit depends on the customers, market, capabilities, and chosen trade-offs.
+
+## Competitive-Assessment Artifact
+
+Record enough evidence that another analyst can challenge the result:
+
+- Market boundary, customer set, geography, time context, and alternatives included or excluded.
+- Evidence and uncertainty for each relevant force, plus direction of change.
+- Complements, ecosystems, regulation, or other material factors the selected framework omits.
+- Value-curve hypotheses and the customer or cost evidence needed to test them.
+- Each claimed advantage as a mechanism, not a label: who benefits, how value or cost changes, dependencies, counterfactuals, and erosion scenarios.
+- Positioning alternatives, supporting customer evidence, and trade-offs.
+- Strategic implications framed as options and validation needs, not as conclusions mechanically produced by a framework.

--- a/strategy-frameworks/references/growth-strategy.md
+++ b/strategy-frameworks/references/growth-strategy.md
@@ -1,0 +1,59 @@
+# Growth Strategy
+
+These frameworks organize growth hypotheses. Pair them with customer research, operational feasibility, financial scenarios, and applicable regulatory analysis.
+
+## Ansoff Matrix
+
+*Attribution: H. Igor Ansoff, "Strategies for Diversification" (1957).*
+
+Classify an option by product novelty and market novelty:
+
+| | Existing market | New market |
+|---|---|---|
+| Existing offering | Market penetration | Market development |
+| New offering | Product development | Diversification |
+
+The matrix is a vocabulary for discussing uncertainty, not a ranking of risk or a forecast of results. For any quadrant, assess the relevant unknowns: customer need, willingness to pay, distribution, capabilities, competition, regulation, capital, reversibility, and learning path. The materiality of each unknown depends on the specific option.
+
+## Three Horizons
+
+*Attribution: the Three Horizons framework is associated with Baghai, Coley, and White's* The Alchemy of Growth *(1999).*
+
+Treat the horizons as concurrent maturity states, not calendar buckets:
+
+| Horizon | Maturity state | Questions |
+|---|---|---|
+| H1 | Established activities | What sustains and improves current value creation? |
+| H2 | Emerging growth activities | What evidence would show the activity can become repeatable or material? |
+| H3 | Exploratory options | What uncertainty is being investigated, and what would justify further learning or stopping? |
+
+An initiative can move between states as evidence changes. Choose allocation, governance, metrics, ownership, and review moments according to strategic importance, constraints, uncertainty, and decision reversibility. Do not infer a required allocation from the framework.
+
+## Market Entry
+
+Entry modes can include building organically, acquiring, partnering, forming a joint venture, licensing, or other arrangements. Their commitment, risk exposure, control, speed, and reversibility are contextual, shaped by the market, counterparties, regulation, capabilities, financing, and desired learning.
+
+Before deciding, investigate:
+
+- Which customer segment, use case, and unmet need form the initial thesis?
+- What evidence supports demand, pricing, channel access, and ability to serve the market?
+- Which incumbents, substitutes, partners, legal constraints, and local conditions matter?
+- What would a plausible competitive response look like?
+- Which capabilities are owned, missing, or better accessed through a partner?
+- What investment, operating assumptions, decision points, and exit or adaptation paths are acceptable?
+
+Avoid treating market size as sufficient evidence, assuming a uniform competitor response, or presenting a mode of entry as an all-or-nothing commitment. Use scenario analysis to surface downside, upside, and adaptation paths.
+
+## Growth-Options Artifact
+
+For every option under consideration, capture:
+
+- The customer, offering, market, and maturity assumptions that determine how it is classified.
+- Evidence already available and the unknowns that matter most.
+- Required capabilities, channels, partners, capital, approvals, and organizational attention.
+- Strategic fit and interaction with established, emerging, and exploratory activities.
+- Reversible learning steps, decision points, and conditions for expanding, adapting, pausing, or stopping.
+- Downside, base, and upside scenarios with assumptions rather than unsupported point forecasts.
+- The decision owner, recommendation, dissenting view, and next evidence-gathering action.
+
+Compare options on decision-relevant dimensions. Do not convert Ansoff quadrants, horizon labels, or entry modes into an automatic ranking.

--- a/strategy-frameworks/references/resource-allocation.md
+++ b/strategy-frameworks/references/resource-allocation.md
@@ -1,0 +1,56 @@
+# Resource Allocation
+
+Use these prompts to compare uses of capital and organizational attention. The criteria, measures, and review approach should reflect the organization's objectives, financing, constraints, stakeholders, and uncertainty.
+
+## Capital Allocation
+
+Potential uses include reinvestment, acquisitions, debt reduction, distributions, reserves, and options not listed here. Compare them through scenarios rather than a blanket ordering.
+
+For each option, document:
+
+- Strategic fit and the capabilities it supports or constrains.
+- Expected outcomes, assumptions, and sensitivity to changed conditions.
+- Cash needs, liquidity, financing terms, and opportunity cost.
+- Risk exposure, reversibility, governance needs, and stakeholder effects.
+- Alternatives considered and the evidence needed before commitment.
+
+Financial measures such as return on invested capital, cost of capital, cash flow, and leverage may be relevant, but their use and interpretation depend on the decision and accounting context. Use `financial-modeling` for quantitative scenario construction.
+
+## Acquisition Evaluation
+
+An acquisition can be assessed for market access, capabilities, product fit, talent, distribution, competitive effects, financial value, or another stated rationale. Synergy is one possible rationale, not a universal requirement.
+
+Separate the strategic thesis from the valuation and integration assumptions. Ask:
+
+1. What problem or opportunity does the transaction address, and what alternatives could address it?
+2. Which claims about customers, capabilities, economics, regulation, and competitors require diligence?
+3. Which valuation methods and scenarios fit the target's circumstances?
+4. If benefits depend on integration, what specific changes, owners, costs, dependencies, and risks are assumed?
+5. What integration approach fits the operating model: preserve, combine selectively, or integrate more deeply?
+6. What evidence or changed conditions would alter the recommendation?
+
+Plan pre-close and post-close work according to the deal's legal, operational, technical, cultural, and customer dependencies. The sequence and duration are deal-specific. Guard against confirmation bias with independent challenge, explicit assumptions, and documented counterarguments; do not attribute that risk to a particular role or personality type.
+
+## Portfolio Management and the Growth-Share Matrix
+
+*Attribution: the growth-share matrix is associated with the Boston Consulting Group and Bruce Henderson.*
+
+The matrix places a business or offering on relative market share and market growth axes. Common labels for the resulting quadrants are stars, cash cows, question marks, and dogs. It is descriptive: it helps organize a portfolio conversation and does not prescribe investment, harvesting, or divestment.
+
+The two axes are limited proxies. They can omit profitability, cash needs, competitive dynamics, strategic interdependence, option value, regulation, management capacity, and the reliability of market data. Use supplementary analysis before a capital decision.
+
+For each portfolio element, assess strategic role, competitive position, customer value, economics, dependencies, future scenarios, and feasible actions. Compare actions such as invest, maintain, partner, reposition, harvest, or exit based on those conditions rather than quadrant alone.
+
+## Allocation Decision Artifact
+
+Document the allocation decision so the logic can be revisited after conditions change:
+
+- Decision owner, scope, constraints, stakeholders, and alternatives considered.
+- Strategic rationale and explicit connection to the organization's chosen direction.
+- Financial scenarios and assumptions, with sensitivity analysis delegated to `financial-modeling` where appropriate.
+- Customer, employee, operational, technical, legal, financing, and integration effects that are material to the option.
+- Opportunity costs, dependencies, reversibility, and concentration risks.
+- Evidence for the acquisition or portfolio thesis, including disconfirming evidence and independent challenge.
+- Governance, accountable owners, decision points, and indicators that would support continuing, adapting, or exiting.
+
+Keep framework classifications separate from the recommendation. A portfolio label, synergy hypothesis, or valuation model is one input to judgment, not the judgment itself.

--- a/strategy-frameworks/references/source-index.md
+++ b/strategy-frameworks/references/source-index.md
@@ -1,0 +1,30 @@
+# Source Index — strategy-frameworks
+
+## Provenance
+
+This skill was adapted from the [`strategy-frameworks` material](https://github.com/magnus919/hermes-profiles/tree/867a555/skills/strategy-frameworks) in `magnus919/hermes-profiles` at commit [`867a555`](https://github.com/magnus919/hermes-profiles/commit/867a555). This repository version reorganizes the material into a host-neutral index and decision prompts. It adds no scripts or templates.
+
+## Framework References
+
+| Framework or topic | Reference |
+|---|---|
+| Objectives and key results | Andy Grove; John Doerr, *Measure What Matters* (2018) |
+| Five Forces | Michael E. Porter, "How Competitive Forces Shape Strategy" (1979) |
+| Value-innovation tools | W. Chan Kim and Renee Mauborgne, *Blue Ocean Strategy* (2005) |
+| Ansoff Matrix | H. Igor Ansoff, "Strategies for Diversification" (1957) |
+| Three Horizons | Mehrdad Baghai, Stephen Coley, and David White, *The Alchemy of Growth* (1999) |
+| Growth-share matrix | Bruce Henderson and the Boston Consulting Group |
+| Capital allocation and M&A | Synthesized from strategy and finance literature; use deal-specific and financial sources for decisions |
+
+These references identify intellectual provenance. The explanations in this skill are paraphrased working prompts and should be checked against the cited work when primary-source interpretation matters.
+
+## Current Skill Boundaries
+
+| Skill | Use it for |
+|---|---|
+| `product-discovery` | Stakeholder and customer discovery, interviews, and requirements evidence |
+| `product-methodology` | Product prioritization, decision records, specifications, and stakeholder communication |
+| `financial-modeling` | Assumptions-led financial models, valuation scenarios, unit economics, and operating metrics |
+| `technology-radar` | Technology adoption posture, build-versus-buy analysis, and architecture governance |
+
+Strategy-frameworks organizes organizational choices across these inputs; it does not replace the specialized analysis.

--- a/strategy-frameworks/references/strategic-planning.md
+++ b/strategy-frameworks/references/strategic-planning.md
@@ -1,0 +1,58 @@
+# Strategic Planning
+
+Use these structures to clarify direction and test alignment. Adapt the prompts to the organization's decision context and evidence.
+
+## OKRs
+
+*Attribution: the objectives-and-key-results approach is commonly associated with Andy Grove and was later popularized by John Doerr.*
+
+An objective describes a meaningful change or direction. Key results state observable evidence that would indicate progress or achievement. Choose the number, level of aggregation, time boundary, and scoring convention to fit the work; they are design choices, not universal rules.
+
+### Prompts
+
+- What decision or strategic priority does this objective support?
+- What outcome would a relevant audience be able to observe?
+- Which measures are useful signals, and what could distort them?
+- Which activities or milestones enable the outcome but should remain separate from it?
+- Is the result a commitment, a hypothesis, or an aspiration, and how will that distinction affect interpretation?
+- Who owns the result, what dependencies matter, and when should the assumptions be revisited?
+
+Review results as learning about the strategy, environment, and measurement design. Do not treat a score alone as a judgment of a person or team.
+
+## Purpose, Direction, and Values
+
+These labels vary among organizations. Use them only if they help distinguish durable purpose, desired direction, and behavioral commitments.
+
+| Element | Useful prompt |
+|---|---|
+| Purpose or mission | What contribution does the organization intend to make, for whom, and why? |
+| Direction or vision | What future condition are we trying to help create or reach? |
+| Values | Which behaviors and trade-offs should guide decisions, especially under pressure? |
+
+Test a draft against real decisions: does it clarify a trade-off, distinguish the organization from plausible alternatives, and remain understandable to the people expected to use it? Revise when evidence, ownership, or context changes.
+
+## Strategic Narrative
+
+A narrative can make a strategy easier to discuss; it is not a required format or a substitute for analysis. Select and adapt only the prompts that serve the audience:
+
+1. What external change, customer need, or internal constraint makes a choice necessary?
+2. What evidence supports the organization's understanding of the situation?
+3. What ambition or direction is being proposed?
+4. What approach, capabilities, and trade-offs would make that direction credible?
+5. What uncertainties, risks, or counterarguments should remain visible?
+6. What decisions, measures, or experiments connect the narrative to action?
+
+Use a narrative alongside supporting analysis when communicating a strategy. Keep its claims traceable to evidence, and label hypotheses as hypotheses.
+
+## Decision Artifact
+
+A strategic-planning artifact should stand alone for a reader who was not in the planning session. Include:
+
+- The decision and accountable decision owner.
+- Current evidence, constraints, and unresolved disagreements.
+- The proposed purpose, direction, values, narrative, or OKRs, with the choices each is intended to clarify.
+- Measures or observations that would test the strategy, including known measurement weaknesses.
+- Dependencies, assumptions, counterarguments, and conditions that would trigger revision.
+- The next decision, validation activity, or review event and its owner.
+
+Do not hide uncertainty behind polished language. If stakeholders disagree about purpose, evidence, or trade-offs, record the disagreement rather than manufacturing consensus.


### PR DESCRIPTION
## Summary

Closes #7.

Adds the portable `strategy-frameworks` skill for organizational direction, competitive and industry analysis, growth options, capital allocation, acquisition evaluation, and portfolio decisions.

The skill:

- Uses a thin `SKILL.md` index with five locally bundled references.
- Treats frameworks as prompts for evidence, alternatives, assumptions, and trade-offs rather than mechanical verdicts.
- Defines boundaries with `product-discovery`, `product-methodology`, `financial-modeling`, and `technology-radar`.
- Adds decision-artifact guidance for strategic planning, competitive assessment, growth options, and allocation decisions.
- Removes source-material prescriptions that were not supported as universal rules, including fixed OKR scores, Three Horizons time buckets and allocations, generic market-entry timelines, automatic BCG quadrant actions, and fixed M&A integration expectations.
- Adds the root catalog entry and trigger routing.

## Validation

- [x] `ruby scripts/validate-skills.rb` — `Validated 82 canonical skills.`
- [x] Skill-specific checks, if applicable: `uv run --project /tmp/agentskills-reference/skills-ref skills-ref validate strategy-frameworks` — `Valid skill: strategy-frameworks`; `git diff --check`; internal-link, privacy, claim-calibration, whitespace, routing, and six behavior probes all passed.

## Documentation

- [x] I updated the relevant `SKILL.md`, `README.md`, or reference files.
- [x] Links are relative and resolve from a fresh clone.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] I have disclosed meaningful AI assistance in the description or commit message.

## Review notes

The framework explanations are intentionally paraphrased and source-attributed. They avoid legal conclusions about framework names or source material. Quantitative analysis, stakeholder discovery, product methodology, and technology governance remain delegated to their specialized skills.

Research and an initial draft were produced with DeepSeek V4 Flash subagents. OpenCode performed a corrective implementation pass. Jasper performed the final line-by-line review, added the decision-artifact sections, and ran validation. All AI work was performed on behalf of Magnus Hedemark.

Authored by Jasper (AI agent on behalf of Magnus Hedemark)
