### PR TITLE
feat: add chief-of-staff-methodology skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ When the user mentions these keywords, load the corresponding skill:
 | "default alive", "default dead", "runway", "burn rate", "burn multiple", "financial projection", "startup finances", "cash on hand", "breakeven", "how long until", "profitability" | [yc-default-alive-calculator](yc-default-alive-calculator/SKILL.md) |
 | "growth rate", "weekly growth", "monthly growth", "startup growth", "compound growth", "traction", "are we growing", "growth benchmark", "how fast should we grow", "YC growth", "product-market fit", "acceleration", "growth trajectory" | [yc-weekly-growth-compass](yc-weekly-growth-compass/SKILL.md) |
 | "artifact-pyramids", "artifact pyramids" | [artifact-pyramids](artifact-pyramids/SKILL.md) |
+| "chief of staff", "CoS", "executive office", "gatekeeping", "triage", "decision memo", "executive briefing", "board materials", "force multiplication", "leader effectiveness", "organizational sensing", "organizational radar", "team health", "institutional memory", "leadership transition", "calendar triage", "meeting audit", "strategic time", "attention allocation" | [chief-of-staff-methodology](chief-of-staff-methodology/SKILL.md) |
 | "site-reliability-engineering", "site reliability engineering" | [site-reliability-engineering](site-reliability-engineering/SKILL.md) |
 | "research-methodology", "research methodology" | [research-methodology](research-methodology/SKILL.md) |
 | "technical-documentation", "technical documentation" | [technical-documentation](technical-documentation/SKILL.md) |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Create comprehensive brand identity documentation for any brand. Guides you thro
 
 Make system boundaries, responsibilities, and relationships legible at the architectural level appropriate to the reader.
 
+### [chief-of-staff-methodology](chief-of-staff-methodology/SKILL.md)
+
+Prepare executive decisions, information triage, organizational sensing, institutional memory, and calendar choices with accountable human authority, transparent data use, and reviewable trade-offs.
+
 ### [cli-builder](cli-builder/SKILL.md)
 
 Build and refactor CLI tools for AI agent consumption. 10 universal patterns (non-interactive, `--json`, `--dry-run`, idempotent, lazy auth, progressive help), an agent-compatibility test suite, a Python API client pattern, and a bash scaffold template. Principles grounded in real failures from building 15+ agent-facing CLIs.

--- a/chief-of-staff-methodology/README.md
+++ b/chief-of-staff-methodology/README.md
@@ -1,0 +1,52 @@
+# Chief of Staff Methodology
+
+Prepare executive work with clear decision rights, useful context, and accountable human review.
+
+## Why Install This Skill
+
+Executive work can fail in two directions: leaders receive too much unstructured
+information, or a gatekeeper quietly becomes an unaccountable bottleneck. This
+skill gives your agent a practical way to prepare briefs, triage information, and
+coordinate work while keeping authority with the person who is responsible for the
+decision.
+
+It also makes organizational care safer. Your agent can help turn authorized,
+aggregate signals into questions worth investigating and retain documented decision
+context through transitions, without covert monitoring, personal dossiers, or
+speculative profiles of employees.
+
+## What You Get
+
+| Path | What it provides |
+|---|---|
+| `SKILL.md` | A host-neutral operating method, authority limits, and trigger guidance. |
+| `references/gatekeeping-and-triage.md` | Decision-rights routing and accessible escalation paths. |
+| `references/executive-briefing.md` | Reviewable decision briefs and update structures. |
+| `references/force-multiplication.md` | Observable leverage mechanisms for leader support. |
+| `references/organizational-sensing.md` | Transparent, proportionate team-health sensing. |
+| `references/institutional-memory.md` | Decision and commitment records with lifecycle controls. |
+| `references/meeting-and-calendar-triage.md` | Leader-specific meeting and calendar review guidance. |
+| `references/source-index.md` | Neutral provenance and scope notes. |
+
+## Quick Start
+
+Ask for a decision brief, information-triage design, meeting audit, or documented
+decision record. The result identifies the accountable decision-maker, distinguishes
+facts from assumptions, and states the applicable review or escalation path.
+
+## Triggers
+
+- Chief of staff, CoS, executive office, or leader effectiveness.
+- Gatekeeping, triage, decision rights, escalation paths, or executive access.
+- Decision memo, executive briefing, board materials, options, or trade-offs.
+- Force multiplication, strategic time, attention allocation, calendar triage, or meeting audit.
+- Organizational sensing, organizational radar, team health, or institutional memory.
+- Leadership transition, documented commitments, or decision history.
+
+## Requirements
+
+No runtime dependency. Use only information and systems that the organization has authorized for the stated purpose.
+
+## Source and maintenance
+
+This catalog skill is a substantial, host-neutral rewrite of [`chief-of-staff-methodology`](https://github.com/magnus919/hermes-profiles/tree/867a555/skills/chief-of-staff-methodology) from `magnus919/hermes-profiles` at commit [`867a555`](https://github.com/magnus919/hermes-profiles/commit/867a555). It retains general methodology while excluding host-bound operational workflows and adding explicit authority, privacy, and review boundaries. See `references/source-index.md` for the source treatment.

--- a/chief-of-staff-methodology/SKILL.md
+++ b/chief-of-staff-methodology/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: chief-of-staff-methodology
+description: >-
+  Prepare accountable executive decisions, information triage, briefing, calendar
+  choices, organizational sensing, and institutional memory without assuming authority
+  or monitoring people. Use when a chief of staff or CoS, executive office,
+  gatekeeping, decision memo, executive briefing, board materials, organizational
+  sensing, team health, institutional memory, calendar triage, meeting audit,
+  strategic time, or attention allocation is requested.
+license: MIT
+compatibility: No runtime dependency.
+metadata:
+  source_repo: https://github.com/magnus919/hermes-profiles
+  source_commit: "867a555"
+  source_path: skills/chief-of-staff-methodology
+  source_treatment: Adapted from supplied issue source material and substantially rewritten for host-neutral, privacy-aware use.
+---
+
+# Chief of Staff Methodology
+
+The Chief of Staff supports an accountable leader's capacity to operate across
+domains. This skill helps prepare, triage, coordinate, surface trade-offs, and
+preserve decision context; it does not transfer the leader's authority.
+
+## When to Load
+
+Load this skill for executive-office work involving:
+
+- Information triage, gatekeeping, escalation paths, or decision rights.
+- Decision memos, executive briefing, board materials, or preparation for an accountable decision-maker.
+- Calendar triage, meeting audits, strategic time, or attention allocation.
+- Cross-functional coordination where ownership, dependencies, or escalation need clarification.
+- Transparent organizational sensing or team-health concerns.
+- Institutional memory, leadership transitions, documented decisions, or commitments.
+- Chief of staff, CoS, or leader-effectiveness work that needs a bounded operating method.
+
+## What This Skill Provides
+
+This skill provides six methodology domains as progressive disclosure through
+`references/`. Load the reference matching the task using your agent's normal
+means; no specific profile, memory, calendar, or orchestration system is assumed.
+
+## Reference Files
+
+| Reference | Load when | File |
+|---|---|---|
+| Gatekeeping and triage | Mapping information to authority, access, and escalation | `references/gatekeeping-and-triage.md` |
+| Executive briefing | Preparing decision-ready material or an executive update | `references/executive-briefing.md` |
+| Leverage mechanisms | Improving the leader's operating system without false measurement | `references/force-multiplication.md` |
+| Organizational sensing | Addressing team-health or organizational signals responsibly | `references/organizational-sensing.md` |
+| Institutional memory | Recording decisions, commitments, and authorized handoffs | `references/institutional-memory.md` |
+| Meeting and calendar triage | Reviewing meetings and calendar choices with the leader | `references/meeting-and-calendar-triage.md` |
+| Source index | Checking provenance and the limits of source treatment | `references/source-index.md` |
+
+## Operating Method
+
+1. Identify the accountable human decision-maker, the decision rights already delegated, and the decision or outcome at stake.
+2. Gather authorized evidence and label it as verified fact, assumption, reported concern, or unknown. Do not invent costs, timelines, authority, or stakeholder views.
+3. Route ordinary work to its authorized owner. Keep direct, protected routes open for safety, ethics, legal, HR, fraud, retaliation, and whistleblowing concerns.
+4. Prepare options and trade-offs, then give a clearly labeled recommendation when the request calls for one. The accountable human reviews and decides.
+5. Record only decision-relevant material under the access, retention, correction, and handoff rules in the applicable reference.
+
+## Accountable Human Authority
+
+This skill supports an accountable human leader. It may prepare, advise, triage,
+synthesize, and surface trade-offs. It does not make employment, compensation,
+disciplinary, legal, fiduciary, or other reserved decisions, and it does not
+present an automated recommendation as a decision.
+
+Name the decision-maker and applicable approval or review path in consequential
+artifacts. A CoS function can coordinate delegated work, but it must route work
+outside that delegation to the authorized owner. Human review is required before
+material is issued as the leader's position.
+
+## Privacy, Confidentiality, and Ethics
+
+Use only authorized, purpose-limited information. Prefer aggregate information
+and the minimum data needed for the stated purpose. Be transparent about what is
+collected, who can access it, how it is retained, and how people can correct it.
+
+Do not use covert monitoring, individual trust scores, dossiers, gossip maps,
+quiet-quitting labels, hidden relationship profiling, or speculative judgments
+about people. Confidentiality has limits: safety, harassment, fraud, legal, and
+policy obligations may require escalation through authorized channels. Preserve
+anti-retaliation protections and involve qualified HR, legal, safety, or ethics
+professionals for matters in their remit.
+
+## Boundaries
+
+| Domain | Boundary | Use instead |
+|---|---|---|
+| Product definition and prioritization | This skill prepares or coordinates a decision; it does not define product strategy | `product-methodology` |
+| Corporate or business strategy | This skill structures a leader's operating work; it does not set strategy | `strategy-frameworks` |
+| Financial models and budgets | This skill may surface a resource question but does not build or validate a model | `financial-modeling` |
+| Verification claims | This skill prepares artifacts but does not turn missing evidence into a pass | `verification-methodology` |
+| Evidence presentation | This skill does not prescribe a research-artifact hierarchy | `artifact-pyramids` |
+| Operational tooling | It does not automate mail, calendars, personal data stores, or task systems | Use the organization's authorized tools and policies |
+
+## Pitfalls
+
+- Treating triage as a private veto instead of a transparent route to the authorized owner.
+- Hiding uncertainty, weak evidence, or an unresolved conflict to make a brief look decisive.
+- Speaking as the leader without review, approval, and clear authorship.
+- Treating people signals as proof of individual performance, intent, or protected-status issues.
+- Storing personal impressions instead of durable, documented decision context.
+
+## Related Skills
+
+- `artifact-pyramids` for layered, inspectable decision artifacts.
+- `financial-modeling` for assumptions-led financial analysis.
+- `product-methodology` for product decisions and prioritization.
+- `strategy-frameworks` for strategy choices and trade-offs.
+- `verification-methodology` for evidence-backed completion claims.
+
+## Portability
+
+This skill is intentionally host-neutral. Use your agent's normal mechanisms to
+load the references listed here. Do not assume a particular profile system, task
+orchestrator, memory service, calendar provider, or response-handoff format.

--- a/chief-of-staff-methodology/references/executive-briefing.md
+++ b/chief-of-staff-methodology/references/executive-briefing.md
@@ -1,0 +1,71 @@
+# Executive Briefing
+
+A brief should help an accountable human understand a decision without disguising
+uncertainty or authorship. It is an operating template, not a published standard;
+adapt its shape to the decision, audience, and available evidence.
+
+[Army Regulation 25-50](https://armypubs.army.mil/epubs/DR_pubs/DR_a/ARN42124-AR_25-50-007-WEB-13.pdf)
+requires Army correspondence to put the main point at the beginning. That narrow
+correspondence rule supports leading with the decision at hand; it does not make
+any memo format a universal executive-communication standard.
+
+## Prepare the Decision Artifact
+
+Use the fields that the situation needs. Do not invent a fixed section count, page
+limit, bullet quota, reading time, cost, timeline, or consensus.
+
+| Element | What to show |
+|---|---|
+| Decision and accountable decision-maker | The decision requested and the human authorized to make it. |
+| Verified facts | Evidence with provenance and material gaps. |
+| Assumptions and unknowns | What could change the conclusion. |
+| Options | Viable paths, including an explicit defer or decline option when real. |
+| Trade-offs | Benefits, costs, risks, dependencies, and affected parties. |
+| Recommendation | The preparer's reasoned view, clearly labeled as advice. |
+| Review and next action | Approval, consultation, implementation, or reassessment path. |
+| Authorship | Preparer, contributors, and accountable reviewer or approver. |
+
+## Drafting Practice
+
+Lead with the decision or status that matters. Put verified information before
+interpretation, and make the source or basis available for consequential claims.
+If an option is not viable, explain why rather than manufacturing alternatives.
+
+Adapt tone to the leader's approved communication style, but do not impersonate
+them. A draft prepared for a leader remains a draft until that leader or another
+authorized reviewer approves it. Do not represent an agent-produced document as
+the leader's words or decision.
+
+## Bad News and Escalation
+
+State material bad news plainly: what is known, what has been done, what remains
+uncertain, and what action or escalation is needed. Avoid minimizing harm or
+claiming an investigation is complete before authorized reviewers confirm it.
+
+For safety, legal, HR, fraud, harassment, retaliation, or ethics concerns, follow
+the designated escalation route. Confidentiality may be limited by law, policy, or
+safety obligations; state those limits rather than promising absolute secrecy.
+
+## Hypothetical Example
+
+**Decision:** The accountable technology executive must choose whether to renew a
+cloud-capacity arrangement.
+
+**Verified facts:** Current usage and contract terms need validation from the
+organization's records. No savings claim is assumed.
+
+**Options and trade-offs:** Renew, renegotiate, or retain a flexible arrangement.
+Each option may affect price, commitment, operational flexibility, and procurement
+timing; quantify only with current, attributable evidence.
+
+**Recommendation:** Request a current usage and contract review before choosing.
+The technology executive decides after finance and procurement complete their
+authorized reviews.
+
+## Review Checklist
+
+- Are facts, assumptions, and unknowns visibly distinct?
+- Are costs, dates, and claims supported or explicitly unverified?
+- Does the recommendation expose its trade-offs?
+- Is the accountable human decision-maker named?
+- Are authorship, approval, and any required escalation clear?

--- a/chief-of-staff-methodology/references/force-multiplication.md
+++ b/chief-of-staff-methodology/references/force-multiplication.md
@@ -1,0 +1,45 @@
+# Leader Leverage Mechanisms
+
+"Force multiplication" is a metaphor for improving a leader's capacity, not a
+measurable equation or universal claim. Evaluate support through observable
+outcomes in the organization's context, not a formula or a promise of leverage.
+
+## Where Support Can Help
+
+| Mechanism | Useful outcome to observe |
+|---|---|
+| Attention stewardship | The leader spends less effort reconstructing routine context and more on work reserved to their role. |
+| Decision preparation | Decisions arrive with evidence, trade-offs, an accountable owner, and fewer avoidable surprises. |
+| Cross-functional coordination | Dependencies, owners, and unresolved conflicts are visible early enough to act. |
+| Pattern surfacing | Authorized aggregate signals and recurring operational issues become questions for the right owners. |
+| Continuity | Documented decisions and commitments remain understandable through staff changes. |
+
+None of these outcomes proves individual performance on its own. Agree with the
+leader on what improvement would look like, what evidence is appropriate, and
+when to reconsider the support model.
+
+## Prepare Rather Than Decide
+
+Before presenting a consequential item, establish the authority, purpose,
+available evidence, material assumptions, affected owners, and implementation
+constraints. Narrowing options is useful only when it does not hide a viable path
+or preempt a person who has decision rights.
+
+Use a decision artifact that separates verified facts, assumptions, options,
+trade-offs, recommendation, accountable decision-maker, review path, and
+authorship. The recommendation is advice; the authorized human makes the decision.
+
+## Guardrails
+
+- Do not become a shadow leader or require every decision to pass through the CoS.
+- Do not treat access to meetings, messages, or personal information as a license to monitor people.
+- Do not claim a system improves output without context-specific evidence.
+- Design handoffs, documented ownership, and backup coverage so the organization does not depend on one intermediary.
+- Revisit the operating arrangement when it creates delay, obscures authority, or reduces direct access to protected channels.
+
+## Reflection Prompts
+
+- Which decision or coordination burden is the leader uniquely responsible for?
+- What preparation would make that work clearer without taking it over?
+- What observable evidence would show that the arrangement is helping or harming?
+- What should be stopped, delegated, documented, or escalated through an authorized owner?

--- a/chief-of-staff-methodology/references/gatekeeping-and-triage.md
+++ b/chief-of-staff-methodology/references/gatekeeping-and-triage.md
@@ -1,0 +1,66 @@
+# Gatekeeping and Triage
+
+Gatekeeping is a routing service, not a wall around a leader. Its purpose is to
+put information and decisions with the people authorized to act while preserving
+direct access when a protected escalation route is needed.
+
+## Start With Decision Rights
+
+For each incoming item, establish the requested outcome, the authorized owner,
+the relevant policy or delegation, urgency, and anyone who must be consulted. Do
+not silently decide an item merely because it reached a CoS function.
+
+Use a routing model that fits the organization. A useful model may distinguish:
+
+| Route | Use when | Response |
+|---|---|---|
+| Owner action | An existing owner can decide or act | Route with context and a clear handoff. |
+| Leader awareness | The leader should know but need not decide | Provide a concise, factual update. |
+| Leader decision | A reserved authority, material trade-off, or cross-domain conflict is present | Prepare options, recommendation, and named decision-maker. |
+| Protected escalation | Safety, ethics, legal, HR, fraud, harassment, retaliation, or whistleblowing concerns arise | Preserve direct access to the appropriate authorized channel. |
+
+These are adaptable operating templates, not a reason to withhold information.
+Make the routes and their owners understandable to the people who need them.
+
+## Triage Questions
+
+- What decision, action, or awareness is actually requested?
+- Who has explicit authority to respond?
+- What facts are verified, and what remains reported, assumed, or unknown?
+- What is the consequence of delay and what escalation rule applies?
+- Does a safety, ethics, legal, HR, or protected-reporting route override ordinary triage?
+- What response lets the requester progress without creating a CoS bottleneck?
+
+## Make Access Work Both Ways
+
+Redirect routine work with an explanation and a useful next step. Do not use
+triage to conceal a leader, punish escalation, or block criticism. A leader may
+need to hear a concern directly even when another owner handles the response.
+
+Keep channels for safety, ethics, legal, HR, fraud, retaliation, and whistleblowing
+available without requiring CoS approval. Respect the organization's reporting and
+anti-retaliation policies; do not promise secrecy beyond what those channels allow.
+
+## Decision-Artifact Structure
+
+For a consequential routed item, capture:
+
+| Field | Purpose |
+|---|---|
+| Request and outcome | States what is being sought. |
+| Authority and escalation rule | Names the owner and any protected route. |
+| Evidence status | Separates verified facts, reports, assumptions, and unknowns. |
+| Options and trade-offs | Makes viable paths inspectable. |
+| Recommendation | Advises without replacing the authorized decision. |
+| Decision and review | Records who decides and what review follows. |
+| Authorship | Identifies preparer, contributors, and approver where applicable. |
+
+## Failure Modes and Misuse
+
+| Failure | Correction |
+|---|---|
+| CoS bottleneck | Publish decision rights, route directly, and provide a backup path. |
+| Private veto | Escalate or route according to explicit authority; record the reason. |
+| Filtered bad news | Preserve direct escalation and label uncertainty rather than softening it. |
+| False confidentiality | State the limits and use authorized reporting channels. |
+| Automated authority | Treat agent output as preparation subject to accountable human review. |

--- a/chief-of-staff-methodology/references/institutional-memory.md
+++ b/chief-of-staff-methodology/references/institutional-memory.md
@@ -1,0 +1,58 @@
+# Institutional Memory
+
+Institutional memory should preserve decision-relevant context, not private
+judgments about people. A useful record explains what was decided, why, who had
+authority, what evidence supported it, and what follow-up remains.
+
+## What to Record
+
+Create a record only when it has a defined operational purpose and authorized
+audience. A decision record can include:
+
+| Field | Purpose |
+|---|---|
+| Decision and status | What was decided, deferred, superseded, or still open. |
+| Accountable decision-maker | The authorized human who made or will make the decision. |
+| Date and provenance | When the record was made and links or references to its evidence. |
+| Facts and assumptions | What was verified, assumed, reported, or unknown at the time. |
+| Options and rationale | Material alternatives and the trade-offs considered. |
+| Commitments and owners | Documented follow-up, owner, and any agreed review condition. |
+| Access and retention | Who may use the record, when it expires, and how it is deleted. |
+| Correction history | How an authorized person can correct or supersede it. |
+
+Track commitments only when they are documented or confirmed by an authorized
+owner. Do not indiscriminately capture hallway remarks, private messages, or
+unverified promises.
+
+## What Not to Store
+
+Do not maintain relationship rankings, trust scores, loyalty assessments, private
+dossiers, private grievance narratives, trigger profiles, gossip maps, or inferred
+views of individuals. Do not store sensitive people judgments merely because they
+might be useful later. Refer employment, legal, safety, and HR records to their
+authorized systems and retention rules.
+
+## Lifecycle Controls
+
+Give each record an owner, access rule, retention or review date, and deletion
+process. Limit access to people with a stated need. Preserve provenance so a future
+reader can distinguish contemporaneous evidence from later interpretation.
+
+At handoff, transfer only records that the recipient is authorized to receive.
+Provide documented decisions, active commitments, known constraints, and open
+questions. Do not transfer informal personal assessments as organizational memory.
+
+## AI-Assisted Memory
+
+An agent may retrieve or summarize authorized decision records when it is useful
+to a current task. Minimize what is stored and returned, preserve provenance, and
+allow correction or removal through the record owner. Do not infer, persist, or
+cross-reference sensitive judgments about people. Do not make an agent's memory
+the authoritative source when an approved system of record exists.
+
+## Review Prompts
+
+- Does this record support a defined future decision, commitment, or handoff?
+- Is every claim attributable, current enough, and distinguishable from assumption?
+- Who may access it, correct it, and authorize its deletion?
+- Has a decision changed, expired, or been superseded?

--- a/chief-of-staff-methodology/references/meeting-and-calendar-triage.md
+++ b/chief-of-staff-methodology/references/meeting-and-calendar-triage.md
@@ -1,0 +1,69 @@
+# Meeting and Calendar Triage
+
+A calendar is a leader-specific operating tool, not a universal schedule. Review
+meetings and time commitments with the leader's decision rights, accessibility
+needs, responsibilities, and preferences in view. A CoS may support calendar work
+only within explicit delegation; the leader may retain any scheduling authority.
+
+## Audit by Purpose and Outcome
+
+Classify time by its purpose, for example: reserved leadership decisions,
+cross-functional coordination, relationship work, operational review, external
+commitments, preparation, recovery, or unplanned response. Do not impose target
+percentages, fixed blocks, energy assumptions, or a default cadence.
+
+For each recurring commitment, ask:
+
+- What outcome requires this meeting or block?
+- Is the leader the authorized participant, or can another owner act?
+- What preparation, accessibility, or follow-up is necessary?
+- Does the current format, duration, and recurrence still serve the purpose?
+- What would be the consequence of changing, delegating, making asynchronous, or ending it?
+
+Review when circumstances, outcomes, or the leader's needs warrant it rather than
+on an arbitrary schedule.
+
+## Optional Cost Estimate
+
+When a rough opportunity-cost estimate will clarify a choice, use compatible units:
+
+```
+estimated labor cost = participants * (minutes / 60) * loaded hourly rate
+```
+
+This is a rough estimator, not financial accounting and not a complete value
+measure. State its assumptions: attendee count, meeting duration, applicable loaded
+hourly rate, and excluded costs or benefits. Do not fabricate any input or use the
+estimate as a coercive reason to cancel necessary work.
+
+## Meeting Preparation
+
+Prepare only what the meeting needs. A useful preparation artifact can identify
+purpose, expected role, decision rights, relevant verified context, open questions,
+participants' stated responsibilities, accessible materials, and the intended
+follow-up. Do not create hidden profiles of attendees or attribute motives without
+authorized, attributable evidence.
+
+For a decision meeting, use the decision-artifact structure: facts, assumptions,
+options, trade-offs, recommendation, accountable decision-maker, review, and
+authorship.
+
+## Calendar Changes and Access
+
+Make calendar changes transparently with the person who holds scheduling authority.
+Offer alternatives rather than silently declining access. Preserve routes for urgent
+safety, ethics, legal, HR, fraud, and whistleblowing concerns; ordinary calendar
+triage must not delay them.
+
+Avoid coercive defaults such as a universal meeting length, mandatory time of day,
+or a claim that one role must own every booking. Accessibility, caregiving,
+time-zone, operational, and relationship needs can make different arrangements
+appropriate.
+
+## Misuse Checks
+
+- Are we optimizing a number rather than the meeting's stated outcome?
+- Is the leader's authority and preference explicit?
+- Are attendees being evaluated through attendance or calendar data?
+- Could a change reduce access to a protected escalation channel?
+- Are estimates labeled, dimensionally correct, and based on provided inputs?

--- a/chief-of-staff-methodology/references/organizational-sensing.md
+++ b/chief-of-staff-methodology/references/organizational-sensing.md
@@ -1,0 +1,66 @@
+# Organizational Sensing
+
+Organizational sensing helps leaders ask better questions about the conditions of
+work. It is not employee surveillance, informal investigation, or a way to infer
+individual intent. Use only transparent, authorized, purpose-limited methods and
+prefer aggregate information where it can answer the question.
+
+## Safeguards Before Collection
+
+Define the purpose, sponsor, authorized collection method, audience, access
+controls, retention period, and correction or challenge route. Tell participants
+what is being collected and how it will be used, subject to applicable policy and
+law. Collect the minimum information needed.
+
+Work with qualified HR, legal, safety, ethics, or employee-relations professionals
+when a concern implicates employment conditions, protected characteristics,
+harassment, retaliation, fraud, safety, or legal obligations. Protected-class
+disparities call for qualified handling, not amateur diagnosis.
+
+## Authorized Signal Sources
+
+Choose methods proportionate to the question and organization, such as:
+
+| Source | Appropriate use | Guardrail |
+|---|---|---|
+| Approved aggregate surveys | Understanding trends in stated experience | Use voluntary, transparent design and report aggregate results. |
+| Documented operational indicators | Identifying where work outcomes warrant inquiry | Do not infer motivation or individual performance from a signal alone. |
+| Facilitated listening channels | Hearing concerns through authorized HR or leadership processes | Explain confidentiality limits and protect against retaliation. |
+| Decision or process reviews | Checking whether affected perspectives and owners were included | Review the process, not private relationships or loyalty. |
+
+Do not covertly observe meetings, track attendance as a proxy for commitment, mine
+private communications, build gossip maps, or label people as disengaged or
+"quiet quitting." Do not create individual trust scores, dossiers, or hidden
+relationship profiles.
+
+## Interpret With Care
+
+A signal is a prompt for inquiry, not a conclusion. Separate what was measured,
+what participants reported, alternative explanations, and what remains unknown.
+Use aggregate-first reporting where possible, avoid small-group disclosure, and
+seek corroboration through authorized channels before recommending action.
+
+When sharing a finding, identify its purpose, evidence quality, uncertainty,
+limitations, accountable owner, and escalation path. An agent may summarize
+authorized material but must not infer sensitive personal judgments or retain them.
+
+## Confidentiality and Trust
+
+Explain confidentiality boundaries before a conversation or survey. Information
+may need to be shared through authorized channels for safety, harassment, fraud,
+legal, or policy reasons. Never promise that a report will remain secret when that
+cannot be honored.
+
+Maintain a clear separation between listening and decision-making. People should
+know where to raise concerns directly, how retaliation is prohibited, and who can
+act. A CoS function may surface patterns, but qualified authorized humans handle
+employment and protected-status matters.
+
+## Misuse Checks
+
+- Is the purpose legitimate, specific, and communicated?
+- Can aggregate or de-identified information answer the question?
+- Would the people affected reasonably understand and authorize this use?
+- Are we treating a signal as proof of a person's intent or character?
+- Is there a qualified escalation path for sensitive findings?
+- Can the record be minimized, access-controlled, corrected, and retired?

--- a/chief-of-staff-methodology/references/source-index.md
+++ b/chief-of-staff-methodology/references/source-index.md
@@ -1,0 +1,19 @@
+# Source Index
+
+## Source Treatment
+
+This catalog skill was developed from the [`chief-of-staff-methodology` source](https://github.com/magnus919/hermes-profiles/tree/867a555/skills/chief-of-staff-methodology) in `magnus919/hermes-profiles` at commit [`867a555`](https://github.com/magnus919/hermes-profiles/commit/867a555). The material was treated as input for a substantial rewrite, not as text to reproduce unchanged.
+
+## Retained Scope
+
+The public skill retains general methodology for executive preparation, routing,
+calendar review, organizational sensing, and institutional memory. It replaces
+unsupported prescriptions and unsafe practices with adaptable guidance, explicit
+human authority, transparent data handling, and review paths.
+
+## Excluded Scope
+
+Host-bound operational workflows and assumptions about a specific profile,
+orchestration, mail, calendar, or memory system are excluded. This skill makes no
+claim about the legal status, licensing, or public availability of the source
+material beyond the `license: MIT` metadata in this catalog skill.


### PR DESCRIPTION
## Summary

Closes #8.

Adds a portable `chief-of-staff-methodology` skill for accountable executive preparation, information triage, executive briefing, leader-support mechanisms, organizational sensing, institutional memory, and meeting/calendar review.

The implementation substantially rewrites the source material rather than reproducing unsafe or unsupported prescriptions. It:

- Keeps authority with named, accountable human decision-makers.
- Routes work through explicit decision rights while preserving direct safety, ethics, legal, HR, fraud, retaliation, and whistleblowing channels.
- Separates verified facts, assumptions, options, trade-offs, recommendations, review, and authorship in decision artifacts.
- Rejects covert monitoring, individual trust scores, dossiers, gossip maps, hidden relationship profiling, and speculative employee judgments.
- Adds purpose limitation, aggregate-first sensing, provenance, access, retention, correction, and deletion controls.
- Removes fixed calendar allocations, generic cadences, executive-energy assumptions, fixed memo formats, bullet quotas, page limits, and force-multiplier equations.
- Corrects the optional meeting-cost estimator to use compatible units and labels it as a rough decision aid rather than accounting.
- Defines boundaries with `product-methodology`, `strategy-frameworks`, `financial-modeling`, `verification-methodology`, and `artifact-pyramids`.
- Adds root catalog and trigger routing.

## Validation

- [x] `ruby scripts/validate-skills.rb` — `Validated 83 canonical skills.`
- [x] Skill-specific checks, if applicable: `uv run --project /tmp/agentskills-reference/skills-ref skills-ref validate chief-of-staff-methodology` — `Valid skill: chief-of-staff-methodology`; `git diff --check`; internal-link, privacy, host-residue, unsupported-prescription, routing, whitespace, dimensional-units, and five outcome-oriented behavior probes all passed.

## Documentation

- [x] I updated the relevant `SKILL.md`, `README.md`, or reference files.
- [x] Links are relative and resolve from a fresh clone.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] I have disclosed meaningful AI assistance in the description or commit message.

## Review notes

BLUF is attributed narrowly to Army Regulation 25-50's requirement to put the main point at the beginning of Army correspondence. The skill does not generalize that source into a universal executive memo standard. Host-bound daily-briefing and meeting-preparation workflows were intentionally excluded.

Research and the implementation brief were produced with DeepSeek V4 Flash subagents. OpenCode produced the canonical implementation from the brief, binding safety addendum, and immutable source files. Jasper performed the final line-by-line review, corrected provenance and a truncated meeting-preparation sentence, and ran validation. All AI work was performed on behalf of Magnus Hedemark.

Authored by Jasper (AI agent on behalf of Magnus Hedemark)
