### PR TITLE
fix: SkillOpt remote systems administration hardening

### DIFF
--- a/remote-systems-administration/SKILL.md
+++ b/remote-systems-administration/SKILL.md
@@ -21,6 +21,16 @@ Use this as an operating decision layer, not a bag of remote commands. Unix-like
 4. **Preview, constrain, verify.** Limit the target set; use native validation, dry-run, diff, or a canary when available; then verify the affected service and its user-visible boundary. A zero exit code proves only that command ran.
 5. **Report evidence, not a story.** Preserve bounded per-host results: target, command category, before/after evidence, failures, rollback state, and the remaining uncertainty. Never paste secrets, keys, full configuration files, or unbounded logs into the response.
 
+## Read-only discovery handoff
+
+Use this compact format after a preflight. Fill a field only from observed evidence; otherwise write `unknown` or `not supplied`.
+
+- **Target and scope:**
+- **Observed platform and control planes:**
+- **Bounded evidence:**
+- **Unknown or blocked:**
+- **Next safe action:**
+
 ## First response: classify the job
 
 | Situation | Default path | Do not do |
@@ -41,6 +51,8 @@ Before the first state-changing command, confirm:
 - access identity, elevation method, and whether the connection traverses a bastion;
 - intended state, expected blast radius, rollback command or artifact, and stop condition;
 - validation at both the component layer and the relevant external boundary.
+
+> **Connectivity/access pre-execution gate:** explicitly name authorization, retained session, independent recovery path, tested rollback, stop condition, and component plus external-boundary verification. If any is unknown, stop before execution.
 
 Read-only discovery may proceed without confirmation. **Read-only means no persistent state:** do not create rollback scripts or captures, stage update metadata, alter files, or call a state-changing operation `preflight`. Stop once the needed platform and control-plane evidence is established. Destructive actions, privilege changes, firewall/remote-access changes, package removals, storage operations, and reboot/shutdown require an explicit directive after this preflight.
 

--- a/remote-systems-administration/SKILL.md
+++ b/remote-systems-administration/SKILL.md
@@ -42,7 +42,7 @@ Before the first state-changing command, confirm:
 - intended state, expected blast radius, rollback command or artifact, and stop condition;
 - validation at both the component layer and the relevant external boundary.
 
-Read-only discovery may proceed without confirmation. Destructive actions, privilege changes, firewall/remote-access changes, package removals, storage operations, and reboot/shutdown require an explicit directive after this preflight.
+Read-only discovery may proceed without confirmation. **Read-only means no persistent state:** do not create rollback scripts or captures, stage update metadata, alter files, or call a state-changing operation `preflight`. Stop once the needed platform and control-plane evidence is established. Destructive actions, privilege changes, firewall/remote-access changes, package removals, storage operations, and reboot/shutdown require an explicit directive after this preflight.
 
 ## Routing references
 

--- a/remote-systems-administration/SKILL.md
+++ b/remote-systems-administration/SKILL.md
@@ -25,7 +25,7 @@ Use this as an operating decision layer, not a bag of remote commands. Unix-like
 
 | Situation | Default path | Do not do |
 |---|---|---|
-| Diagnose or make one bounded change on one host | Native `ssh` with a read-only preflight | Do not open an interactive shell and make unrecorded edits |
+| Diagnose or make one bounded change on one host | Native `ssh` with a read-only preflight and bounded command/range; do not use a live-follow stream such as `tail -f` | Do not open an interactive shell and make unrecorded edits |
 | Repeat the same desired state across hosts | Ansible inventory + playbook, canary/serial rollout | Do not loop `ssh` blindly across production hosts |
 | Python must coordinate SSH channels, SFTP, or a custom protocol flow | Paramiko with strict host-key verification and explicit timeouts | Do not disable host-key checks or turn a script into ad hoc fleet control |
 | The platform/control plane is unknown | Run bounded discovery from `references/portable-operations.md` | Do not use `systemctl`, `apt`, `pfctl`, or `launchctl` based on a guess |

--- a/remote-systems-administration/references/linux.md
+++ b/remote-systems-administration/references/linux.md
@@ -54,6 +54,12 @@ Changes to network configuration, DNS, SSH, sudo, PAM, routing, firewall state, 
 
 Linux firewall control planes include nftables and systems layered above it, such as firewalld or distribution tooling. Discover which system owns rules before changing anything. Do not mix direct nftables edits with a higher-level manager unless its documentation permits it, and never mechanically translate PF, iptables, or cloud firewall rules.
 
+| Evidence | Decision |
+|---|---|
+| A firewall binary exists or `firewalld` is active | Ownership is still unknown. Inspect the managed configuration and sanctioned control path; do not select a tool from presence or service state alone, and do not use a trial rule or any other mutation to decide ownership. |
+| firewalld is the confirmed policy owner | Use its documented interface; do not add direct nftables rules beside it. |
+| Native nftables configuration is the confirmed policy owner | Use nftables only through that configuration's documented management path. |
+
 For nftables, inspect the existing ruleset and ownership before edits. Policy changes can sever the live SSH session. Validate rule syntax where available, retain a recovery path, apply a bounded change, and verify both expected traffic and retained administrative access.
 
 ## Reboot and lifecycle


### PR DESCRIPTION
## Summary
- complete three autonomous greenfield SkillOpt epochs for `remote-systems-administration`
- tighten read-only preflight and bounded SSH evidence rules
- add explicit Linux firewall-ownership decision guidance
- add compact discovery-handoff and connectivity/access pre-execution output gates

## SkillOpt evidence

| Epoch | Focus | Held-out result |
|---|---|---|
| 1 | Read-only boundary prominence | 3/3 → 3/3 (accepted on non-regression plus rollout safety signal) |
| 2 | Control-plane decision guidance | 2/3 → 3/3 |
| 3 | Evidence handoff and pre-execution output shape | 1/3 → 3/3 |

One unsafe Epoch 2 proposal was rejected: its first candidate still allowed a trial firewall mutation to establish ownership. The accepted replacement explicitly forbids mutation during ownership discovery.

## Validation
- `git diff --check origin/main...HEAD`
- `ruby scripts/validate-skills.rb`
- `uvx --from skills-ref agentskills validate remote-systems-administration`
- read-only remote smoke against the user-authorized test host
- independent final diff review: PASS

AI-assisted with Hermes Agent and the SkillOpt methodology.