### PR TITLE
docs: enforce complete root skill catalog coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,8 @@ When the user mentions these keywords, load the corresponding skill:
 | "langgraph", "multi-agent", "state machine", "graph-based workflow", "LangGraph", "supervisor pattern", "swarm pattern", "agent orchestration", "graph state", "subgraph", "agent routing", "tool-calling loop", "agent loop", "stateful agent", "durable execution", "human in the loop langgraph", "checkpointer", "langgraph persistence" | [langgraph](langgraph/SKILL.md) |
 | "debate", "council", "multi-perspective", "structured debate", "get multiple perspectives", "expert panel", "decision landscape", "what would experts say", "what are we missing", "convergence", "false consensus", "agent-council", "pre-mortem" | [agent-council](agent-council/SKILL.md) |
 | "skill format", "how do I make a skill", "agentskills.io" | [agent-skills](agent-skills/SKILL.md) |
-| "FlareSolverr", "Cloudflare challenge", "DDoS-GUARD", "browser-backed request" | [flaresolverr](flaresolverr/SKILL.md) |
+| "flaresolverr-cli", "FlareSolverr session", "request.get", "request.post", "return-only-cookies" | [flaresolverr-cli](flaresolverr-cli/SKILL.md) |
+| "Cloudflare challenge", "DDoS-GUARD", "browser-backed request" | [flaresolverr](flaresolverr/SKILL.md) |
 | "Three.js", "three.js", "WebGL", "3D scene", "GLTF", "browser 3D" | [three](three/SKILL.md) |
 | "last.fm", "scrobble", "music discovery", "listening history", "similar artists", "lastfm", "weekly top artists", "genre charts" | [lastfm](lastfm/SKILL.md) |
 | "MeshCore Companion", "meshcore-packet-capture", "MeshCore packet capture", "BLE radio capture", "serial radio capture", "MeshCore MQTT", "LetsMesh", "PACKETCAPTURE_", "meshcore-packet-capture Docker", "MeshCore NixOS" | [meshcore-packet-capture](meshcore-packet-capture/SKILL.md) |
@@ -136,6 +137,7 @@ When the user mentions these keywords, load the corresponding skill:
 | "artifact-pyramids", "artifact pyramids" | [artifact-pyramids](artifact-pyramids/SKILL.md) |
 | "chief of staff", "CoS", "executive office", "gatekeeping", "triage", "decision memo", "executive briefing", "board materials", "force multiplication", "leader effectiveness", "organizational sensing", "organizational radar", "team health", "institutional memory", "leadership transition", "calendar triage", "meeting audit", "strategic time", "attention allocation" | [chief-of-staff-methodology](chief-of-staff-methodology/SKILL.md) |
 | "site-reliability-engineering", "site reliability engineering" | [site-reliability-engineering](site-reliability-engineering/SKILL.md) |
+| "research and vault", "research-to-notes", "research to durable note", "research extraction and vault", "research-to-note pipeline" | [research-and-vault](bundles/research-and-vault/SKILL.md) |
 | "research-methodology", "research methodology" | [research-methodology](research-methodology/SKILL.md) |
 | "remote system administration", "remote administration", "remote SSH", "SSH administration", "Ansible administration", "Paramiko automation", "remote Linux", "remote FreeBSD", "remote NetBSD", "remote OpenBSD", "remote macOS", "remote service", "remote firewall", "remote package update", "fleet administration", "fleet rollout", "remote launchctl", "remote rcctl", "remote systemctl" | [remote-systems-administration](remote-systems-administration/SKILL.md) |
 | "technical-documentation", "technical documentation" | [technical-documentation](technical-documentation/SKILL.md) |

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Build and review assumptions-led financial models, unit economics, pricing, fund
 
 Use a private FlareSolverr service through a dependency-free JSON CLI when ordinary HTTP retrieval is blocked by a browser challenge.
 
+### [flaresolverr-cli](flaresolverr-cli/SKILL.md)
+
+Use the full stdlib FlareSolverr CLI for health checks, browser-session lifecycle, and challenge-solving GET or form-POST requests with structured output and dry-run support.
+
 ### [forgejo-cli](forgejo-cli/SKILL.md)
 
 Safe Forgejo API v1 CLI for issues, pull requests, repositories, file contents, metadata, webhooks, and user settings. Includes a guarded generic `/api/v1/` route for version-specific endpoints such as Actions and admin APIs.
@@ -228,6 +232,10 @@ Query, search, and download public datasets from the City of Raleigh Open Data p
 ### [remote-systems-administration](remote-systems-administration/SKILL.md)
 
 Administer and troubleshoot remote Linux, FreeBSD, NetBSD, OpenBSD, and macOS hosts safely, one system or a controlled fleet at a time. Covers SSH, Ansible, Paramiko, portable diagnostics, platform-specific services, packages, configuration, firewalls, rollback, and evidence-led verification.
+
+### [research-and-vault](bundles/research-and-vault/SKILL.md)
+
+Run a repeatable research-to-notes sequence: gather sources, record URLs and dates, extract independent atomic claims, then create a durable note with explicit coverage gaps.
 
 ### [research-methodology](research-methodology/SKILL.md)
 

--- a/flaresolverr-cli/SKILL.md
+++ b/flaresolverr-cli/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: flaresolverr-cli
-description: 'Interact with a FlareSolverr proxy server from the terminal: health
-  checks, session lifecycle (create/list/destroy), and challenge-solving HTTP requests
-  (GET/POST) through Cloudflare and DDoS-GUARD protection. Use when the user mentions
-  FlareSolverr, Cloudflare bypass, anti-bot proxy, headless browser proxy, or needs
-  to fetch a page behind Cloudflare protection.'
+description: 'Operate the full flaresolverr-cli command surface: named browser-session
+  lifecycle, structured health and service information, dry-run planning, cookie-only
+  returns, and challenge-solving GET or form-POST requests. Use for explicit
+  flaresolverr-cli or session-management requests; use the smaller flaresolverr skill
+  for a one-off health check or basic browser-backed retrieval.'
 license: MIT
 compatibility: >-
   Python 3.8+ (stdlib only, no pip deps). Requires a running FlareSolverr instance
@@ -20,6 +20,18 @@ metadata:
 Drive a FlareSolverr instance from the command line. FlareSolverr is a proxy server that launches a headless Chrome browser to solve Cloudflare and DDoS-GUARD JavaScript challenges, returning the unblocked HTML, cookies, and user-agent to your client.
 
 The CLI wraps all four API endpoints: service info, health check, the three `/v1` session commands (create/list/destroy), and both challenge-solving request commands (`request.get` and `request.post`). Every command supports `--json`, `--dry-run`, and `--timeout`.
+
+## Mutation Gate
+
+`health`, `info`, and `sessions list` are read-only discovery. Creating or destroying a session changes FlareSolverr state, and `request get` or `request post` sends traffic to an external target.
+
+> Confirm the target, scope, and rollback path before acting. Read-only discovery may proceed without confirmation.
+
+Use `--dry-run` to review a planned mutation first. Session destruction and any request intended to change target state require an explicit user directive; this skill does not authorize deletion, privilege changes, authentication bypass, or irreversible cleanup.
+
+## When not to use
+
+Use [flaresolverr](../flaresolverr/SKILL.md) for a one-off health check or basic GET/POST when named sessions, cookie-only returns, dry-run planning, and the full command surface are unnecessary. Do not use either skill to bypass authentication, authorization, paywalls, or access controls.
 
 ## Setup
 

--- a/flaresolverr/SKILL.md
+++ b/flaresolverr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flaresolverr
-description: Use FlareSolverr through a small CLI when a site requires a browser-backed request to pass Cloudflare or DDoS-GUARD challenges.
+description: Use the minimal FlareSolverr wrapper for a one-off health check or browser-backed GET/POST when ordinary retrieval is blocked by Cloudflare or DDoS-GUARD. Choose flaresolverr-cli instead for named session lifecycle, cookie-only returns, dry-run planning, or the full operational command surface.
 ---
 
 # FlareSolverr
@@ -12,6 +12,18 @@ python3 scripts/flaresolverr --server http://localhost:8191 health
 ```
 
 Use this skill when ordinary HTTP retrieval is blocked by a browser challenge. FlareSolverr must already be running; this skill does not bypass authentication or authorize access to restricted content.
+
+## When not to use
+
+Use [flaresolverr-cli](../flaresolverr-cli/SKILL.md) when the task names that CLI, requires creating/listing/destroying named sessions, needs cookie-only responses or dry-run planning, or needs the full operational command surface. Keep this skill for the smaller one-off health, GET, or POST path.
+
+## Mutation Gate
+
+The health command is read-only discovery. GET and POST send traffic to an external target, and POST may change target state.
+
+> Confirm the target, scope, and rollback path before acting. Read-only discovery may proceed without confirmation.
+
+A POST or any request intended to change target state requires an explicit user directive. This skill does not authorize deletion, privilege changes, authentication bypass, or irreversible cleanup.
 
 ## CLI
 

--- a/scripts/validate-skills.rb
+++ b/scripts/validate-skills.rb
@@ -12,15 +12,36 @@ skills = Dir.glob("#{ROOT}/**/SKILL.md").sort.reject do |skill|
   skill.include?("/agent-council/profiles/skills/")
 end
 
-catalog_names = File.read(File.join(ROOT, "README.md")).scan(
-  /^### \[([a-z0-9]+(?:-[a-z0-9]+)*)\]\([^)]+\/SKILL\.md\)\s*$/
-).flatten
+catalog_entries = File.read(File.join(ROOT, "README.md")).scan(
+  /^### \[([a-z0-9]+(?:-[a-z0-9]+)*)\]\(([^)]+\/SKILL\.md)\)\s*$/
+)
+catalog_names = catalog_entries.map(&:first)
 expected_catalog_names = catalog_names.sort_by { |name| [name.downcase, name] }
 unless catalog_names == expected_catalog_names
   mismatch = catalog_names.zip(expected_catalog_names).index { |actual, expected| actual != expected }
   errors << "README.md: skill catalog headings must be sorted case-insensitively; " \
             "position #{mismatch + 1} is #{catalog_names[mismatch].inspect}, " \
             "expected #{expected_catalog_names[mismatch].inspect}"
+end
+
+catalog_paths = catalog_entries.map(&:last).sort
+expected_catalog_paths = (Dir.glob("#{ROOT}/*/SKILL.md") + Dir.glob("#{ROOT}/bundles/*/SKILL.md"))
+                         .map { |path| path.delete_prefix("#{ROOT}/") }
+                         .sort
+missing_catalog_paths = expected_catalog_paths - catalog_paths
+unexpected_catalog_paths = catalog_paths - expected_catalog_paths
+duplicate_catalog_names = catalog_names.group_by { |name| name }.select { |_name, values| values.length > 1 }.keys.sort
+duplicate_catalog_paths = catalog_paths.group_by { |path| path }.select { |_path, values| values.length > 1 }.keys.sort
+mislabeled_catalog_entries = catalog_entries.reject do |name, path|
+  name == File.basename(File.dirname(path))
+end
+errors << "README.md: missing catalog path(s): #{missing_catalog_paths.join(', ')}" unless missing_catalog_paths.empty?
+errors << "README.md: unexpected catalog path(s): #{unexpected_catalog_paths.join(', ')}" unless unexpected_catalog_paths.empty?
+errors << "README.md: duplicate catalog name(s): #{duplicate_catalog_names.join(', ')}" unless duplicate_catalog_names.empty?
+errors << "README.md: duplicate catalog path(s): #{duplicate_catalog_paths.join(', ')}" unless duplicate_catalog_paths.empty?
+unless mislabeled_catalog_entries.empty?
+  labels = mislabeled_catalog_entries.map { |name, path| "#{name.inspect} -> #{path}" }
+  errors << "README.md: catalog label/path mismatch(es): #{labels.join(', ')}"
 end
 
 skills.each do |skill|


### PR DESCRIPTION
## Summary

Closes #39.

The final post-#28 audit found that the root catalog was sorted but incomplete. This PR adds the two missing canonical entry points and makes completeness a deterministic CI invariant.

Catalog and routing changes:

- Adds `flaresolverr-cli` immediately after `flaresolverr`.
- Adds the `research-and-vault` bundle immediately before `research-methodology`.
- Routes explicit full-CLI/session commands to `flaresolverr-cli`, generic browser-challenge work to `flaresolverr`, and full research-to-durable-note sequences to `research-and-vault`.
- Gives both overlapping FlareSolverr skills explicit selection boundaries, `When not to use` sections, public-safety limits, and the repository's state-mutation confirmation gate.

Validator changes make the root catalog exactly cover top-level `*/SKILL.md` and bundle umbrellas at `bundles/*/SKILL.md`. Nested bundle skills remain excluded. Validation now rejects missing or unexpected paths, duplicate names or paths, label/path mismatches, and ordering regressions while preserving aggregate errors.

## Validation

- [x] `ruby scripts/validate-skills.rb` — `Validated 89 canonical skills.`
- [x] Skill-specific checks, if applicable: `skills-ref validate` passed for `flaresolverr`, `flaresolverr-cli`, and `bundles/research-and-vault`; `git diff --check`; independent 79-entry order/coverage/uniqueness/label assertion; missing, duplicate, mislabeled, and aggregate-error probes; routing-collision check; mutation-gate check — all passed.

TDD began with the old validator incorrectly accepting the two missing catalog entries. Isolated negative probes now exit nonzero and name the exact defect. Temporary probe worktrees were removed.

## Documentation

- [x] I updated the relevant `SKILL.md`, `README.md`, or reference files.
- [x] Links are relative and resolve from a fresh clone.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] I have disclosed meaningful AI assistance in the description or commit message.

## Review notes

Scope is five files: root `README.md`, root `AGENTS.md`, both overlapping FlareSolverr skill entry points, and `scripts/validate-skills.rb`.

Three independent OpenCode review rounds found and drove correction of two real adjacent defects: ambiguous FlareSolverr selection boundaries and missing mutation gates. The final exact-head review passed with no blocking findings. Jasper implemented, tested, and reviewed the changes on behalf of Magnus Hedemark.

Authored by Jasper (AI agent on behalf of Magnus Hedemark)
