### PR TITLE
fix(research): require durable artifact preservation

### DIFF
--- a/research-methodology/README.md
+++ b/research-methodology/README.md
@@ -4,7 +4,7 @@ Turn an open question into a bounded, evidence-led investigation rather than a p
 
 ## Why Install This Skill
 
-Turn an open question into a bounded, evidence-led investigation rather than a plausible-sounding synthesis. It preserves a practical method, local reference material, and reusable templates so an agent can do more than produce a generic answer.
+Turn an open question into a bounded, evidence-led investigation rather than a plausible-sounding synthesis. It preserves a practical method, local reference material, and reusable templates so an agent can do more than produce a generic answer. The method requires research to leave behind durable, source-linked artifacts that others can discover and reuse.
 
 Use it when the work needs a repeatable process and an inspectable result. It is portable across Agent Skills-compatible clients and does not require a profile system or a particular task orchestrator.
 
@@ -14,11 +14,11 @@ Use it when the work needs a repeatable process and an inspectable result. It is
 |---|---|
 | `SKILL.md` | Trigger conditions, workflow, and guidance for loading deeper resources. |
 | `references/` | Reference material: `industry-analysis.md`, `journalistic-research.md`, `research-lifecycle.md`, `source-evaluation.md`, `structured-analytic-techniques.md`, `synthesis-patterns.md`, `technical-verification.md` |
-| `assets/` | Assets: `research-brief.md`, `research-log.md` |
+| `assets/` | Assets: `research-brief.md`, `research-log.md`, including a durable-artifact inventory and source-to-artifact preservation ledger. |
 
 ## Quick Start
 
-Choose the research track in `SKILL.md`, then start from `assets/research-brief.md` and maintain a research log.
+Choose the research track in `SKILL.md`, then start from `assets/research-brief.md` and maintain a research log. Preserve the retained evidence and extracted claims in the long-lived research surface your agent and users normally use before delivering the synthesis.
 
 Install or expose this directory using your agent's standard Agent Skills loading mechanism, then ask for work that matches the triggers below.
 

--- a/research-methodology/SKILL.md
+++ b/research-methodology/SKILL.md
@@ -25,6 +25,20 @@ All three share the same lifecycle (Scope → Gather → Evaluate → Analyze �
 SCOPE → GATHER → EVALUATE → ANALYZE → SYNTHESIZE → REPORT
 ```
 
+## Durable Artifact Gate
+
+Research is not complete when an agent has produced a plausible answer. It is complete when the reusable evidence and reasoning have been preserved in the durable format that is natural to the host system and its users.
+
+Before reporting, make the preservation decision explicit:
+
+1. **Identify the durable destination.** Use the host's normal long-lived research surface: linked knowledge records, a tracked report package, a research database, a project document, or another user-visible artifact. Do not leave the only useful output in chat, a transient workspace, or an untracked scratch file.
+2. **Extract at the source's natural granularity.** Capture every distinct, reusable claim, data point, method, contradiction, and open question that materially changes future reasoning. Do not use a fixed atom, finding, or note count as a stopping rule. Continue until each retained source is accounted for in the extraction log.
+3. **Preserve provenance and relationships.** Each durable artifact must retain its source URL or citation, access date, evidence strength, and links to the question, related artifacts, and any synthesis that depends on it.
+4. **Separate extraction from synthesis.** A brief or report explains the conclusion; it does not replace the underlying evidence records. Preserve source-level records and reusable claims before compacting them into a synthesis.
+5. **Record what was not preserved.** If a source was rejected, too weak, inaccessible, redundant, or out of scope, record that decision in the research log. A future researcher must be able to distinguish an intentional exclusion from an overlooked source.
+
+The right artifact shape depends on the environment. Do not assume a particular database, note-taking application, or orchestration system. The invariant is durable, navigable, evidence-linked research that a later user or agent can discover and build on.
+
 ## Reference Files
 
 ### Tracks
@@ -50,6 +64,8 @@ SCOPE → GATHER → EVALUATE → ANALYZE → SYNTHESIZE → REPORT
 |-------|-----------------|
 | `assets/research-brief.md` | Structured brief with findings, confidence assessment, evidence table, open questions |
 | `assets/research-log.md` | Traceable record of searches, sources, and decisions |
+
+Use both assets for every substantial investigation. Before closing the work, complete their durable-artifact sections and verify that retained sources and extracted claims are represented in the destination system.
 
 ## Pre-Publication Gateway
 

--- a/research-methodology/assets/research-brief.md
+++ b/research-methodology/assets/research-brief.md
@@ -68,3 +68,20 @@
 |---|-------|-----|------|-----------------|
 | 1 | | | Paper / Blog / Doc | |
 | 2 | | | | |
+
+---
+
+## 7. Durable Artifact Inventory
+
+*A research brief is a synthesis, not the only deliverable. List the long-lived artifacts created or updated so a future user or agent can find the source-level evidence and reusable claims.*
+
+| Artifact | Type | Destination / path | What it preserves | Source coverage |
+|----------|------|--------------------|-------------------|-----------------|
+| | Evidence record / claim record / synthesis / dataset / other | | | Source # / source URL |
+
+### Preservation check
+
+- [ ] Every retained source has a durable evidence record or an explicit exclusion decision in the research log.
+- [ ] Every material reusable claim, contradiction, and open question has been extracted at an appropriate granularity.
+- [ ] Every artifact preserves provenance, access date, and relationships to the research question and synthesis.
+- [ ] No essential evidence exists only in chat or a temporary workspace.

--- a/research-methodology/assets/research-log.md
+++ b/research-methodology/assets/research-log.md
@@ -29,3 +29,19 @@ A traceable record of every search, source, and decision made during a research 
 | Included/excluded topic X | | |
 | Stopped searching after N sources | | |
 | Changed research question | | |
+
+## Extraction and Preservation Ledger
+
+*Research is incomplete until retained evidence is preserved in the host's durable research surface. Track every source so that extraction is exhaustive rather than driven by a convenient round number.*
+
+| Source | Retain / reject | Material claims, data, or contradictions extracted | Durable artifact(s) | Destination / path | Reason if not preserved |
+|--------|-----------------|---------------------------------------------------|---------------------|--------------------|-------------------------|
+| Source A | Retain | | | | |
+| Source B | Reject | | | | |
+
+## Completion Gate
+
+- [ ] Each retained source appears in the preservation ledger.
+- [ ] All material reusable findings are represented by durable, navigable artifacts, not only the final report.
+- [ ] The synthesis links to the evidence artifacts it depends on.
+- [ ] Rejected or inaccessible sources have a recorded reason.


### PR DESCRIPTION
## Summary
- add a host-neutral durable-artifact gate to the research lifecycle
- require source-level extraction, provenance, and explicit preservation decisions
- add preservation inventory and source-to-artifact ledger templates

## Validation
- `ruby scripts/validate-skills.rb`
- `uvx --from skills-ref agentskills validate research-methodology`

## Disclosure
Created with AI assistance; reviewed and validated by Jasper.