### PR TITLE
docs: add evidence gate to ESP32 development skill

### DIFF
--- a/esp32-development/SKILL.md
+++ b/esp32-development/SKILL.md
@@ -23,6 +23,16 @@ Treat the board, attached circuit, firmware, and host toolchain as one system. A
 6. Before the first flash or hardware mutation, confirm the target port, chip family, image/partition layout, rollback or reflashing path, and electrical safety. Never guess a flash offset.
 7. Preserve calibration controls for real sensors, clocks, ADCs, PWM devices, and actuators. Physical variation is expected.
 
+## Pre-response evidence gate
+
+Complete this gate before drafting a non-trivial plan or recommendation:
+
+1. Build a claim ledger for every material positive claim, negative claim, command, and numeric design choice. A URL in `source-index.md` is navigation, not evidence; retrieve the exact chip/current-version page or mark the claim `UNKNOWN`.
+2. Command help proves syntax only. Record required target state plus reset, DTR/RTS, download-mode, RAM-stub, port, and mutation effects from current documentation. If operational preconditions are unverified, do not present the command as executable.
+3. Missing hardware artifacts stay missing. Do not replace them with archetypes, examples, or words such as `usually`, `typical`, or `some modules`; state what the observed label does not establish.
+4. Do not invent thresholds, margins, intervals, durations, point counts, percentages, or model forms. Derive them from an authoritative source or a measurement criterion; otherwise leave them `UNKNOWN`.
+5. Audit the final response against the ledger. Remove or downgrade every material claim that lacks its required evidence.
+
 ## First read-only discovery
 
 ```sh


### PR DESCRIPTION
## Summary

- require a claim ledger before non-trivial ESP32 plans or recommendations
- distinguish command syntax from target-state, reset, control-line, download-mode, RAM-stub, port, and mutation effects
- keep missing hardware artifacts and unsupported numeric choices explicitly unknown
- audit the final response so unsupported claims are removed or downgraded

## SkillOpt evidence

This change is the single accepted edit from a controlled four-epoch SkillOpt run covering 36 distinct training and held-out scenarios. Its isolated held-out pass rate improved from 20% to 40%, and weighted score improved from 0.310 to 0.441. Three broader follow-up proposals were rejected because they failed independent acceptance gates or regressed held-out performance.

## Validation

- `ruby scripts/validate-skills.rb`
- `uvx --from skills-ref agentskills validate esp32-development`
- `python3 esp32-development/scripts/esp32-preflight.py --self-test`
- JSON validation for `esp32-development/evals/evals.json`
- `git diff --check`
- bounded read-only hardware gate for host inventory, chip identity, and flash identity

## AI assistance

This change was developed and validated with AI assistance. The four-epoch optimization artifacts and raw trajectories were kept outside the public repository; this PR contains only the accepted portable skill change.