### PR TITLE
fix(verification-methodology): own accessible evidence collection

### DIFF
--- a/verification-methodology/SKILL.md
+++ b/verification-methodology/SKILL.md
@@ -17,7 +17,7 @@ Pass/fail assessment against pre-defined criteria.
 
 1. **Receive** — restate the artifact, claim, or implementation being verified and the decision it will support.
 2. **Assess criteria** — convert requirements into observable pass/fail conditions; identify what would disprove each claim.
-3. **Investigate** — collect direct, reproducible evidence and record commands, source locations, or source URLs.
+3. **Investigate** — collect direct, reproducible evidence and record commands, source locations, or source URLs. Own this collection when the source is accessible: do not ask the user to relay evidence you can retrieve yourself. Ask only for access you genuinely lack.
 4. **Decide** — mark each criterion passed, failed, blocked, or not applicable. Do not convert missing evidence into a pass.
 5. **Report** — use the verdict template to distinguish verified facts, assumptions, and remaining work.
 


### PR DESCRIPTION
## Summary

Clarifies that verification agents must collect evidence from accessible sources themselves and only ask the user for access they genuinely lack.

## Validation

- [x] `ruby scripts/validate-skills.rb` — validated 97 canonical skills
- [x] Skill-specific checks — YAML/frontmatter, line-limit, and target instruction assertion passed

## Documentation

- [x] I updated the relevant `SKILL.md`, `README.md`, or reference files.
- [x] Links are relative and resolve from a fresh clone.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] I have disclosed meaningful AI assistance in the description or commit message.

## Review notes

Small documentation correction: no new abstraction or reference file.

Prepared by Jasper (AI agent on behalf of Magnus Hedemark).