### PR TITLE
feat(jellyfin-cli): expose read-only navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Build, customize, and debug advanced Hugo CMS themes. Covers template architectu
 
 ### [jellyfin-cli](jellyfin-cli/SKILL.md)
 
-Jellyfin media server from the terminal. Check server info, browse recently added, search your library by type, list libraries, and view statistics.
+Jellyfin media server from the terminal. Check server info, browse recently added and library contents, search and inspect media, see next-up episodes, and view statistics.
 
 ### [jira-cli](jira-cli/SKILL.md)
 

--- a/jellyfin-cli/README.md
+++ b/jellyfin-cli/README.md
@@ -1,6 +1,6 @@
 # Jellyfin Media Server from the Terminal
 
-Query your Jellyfin media library — recently added movies and episodes, search across your library, browse libraries, and check server stats.
+Query your Jellyfin media library — recently added movies and episodes, search and inspect items, browse library contents, see next-up episodes, and check server stats.
 
 ## Why Install This Skill
 
@@ -8,7 +8,8 @@ When your agent loads this skill, it can **navigate your home media server** wit
 
 - **See what's new** — recently added movies and TV episodes
 - **Search your library** — find any movie, show, or episode by keyword
-- **Browse libraries** — list all configured media libraries
+- **Navigate your library** — inspect search results, browse collections, and page through items
+- **See what is next** — find the next unwatched episodes for a user
 - **Check server details** — server name, version, operating system, user count
 
 ## What You Get
@@ -24,10 +25,15 @@ When your agent loads this skill, it can **navigate your home media server** wit
 scripts/jellyfin-cli --help
 export JELLYFIN_URL="http://your-server:8096"
 export JELLYFIN_API_KEY="your-api-key"
-export JELLYFIN_USER_ID="your-jellyfin-user-id" # required by recent
+export JELLYFIN_USER_ID="your-jellyfin-user-id" # required by recent, next-up, and item
 ```
 
 API key from Dashboard → API Keys in the Jellyfin admin panel.
+
+```bash
+scripts/jellyfin-cli search --query "dune" --type Movie
+scripts/jellyfin-cli next-up --limit 5
+```
 
 ## Triggers
 
@@ -35,4 +41,4 @@ Load this when asking about Jellyfin, media server content, recently added movie
 
 ## Requirements
 
-Python 3.8+ with `requests` library. Jellyfin server with API key; `recent` also requires a Jellyfin user ID.
+Python 3.8+ with `requests` library. Jellyfin server with API key; `recent`, `next-up`, and `item` also require a Jellyfin user ID.

--- a/jellyfin-cli/SKILL.md
+++ b/jellyfin-cli/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: jellyfin-cli
-description: Query your Jellyfin media server from the terminal — recently added movies
-  and episodes, search across your library, browse libraries, and check server info
-  and stats. Use when the user asks about Jellyfin, media server, movies, TV shows,
-  recently added content, or their media library.
+description: Query your Jellyfin media server from the terminal — recently added media,
+  search, item details, next-up episodes, library browsing, server info, and stats. Use
+  when the user asks about Jellyfin, media server, movies, TV shows, next episodes, or
+  their media library.
 license: MIT
 compatibility: Requires JELLYFIN_URL (default http://localhost:8096) and JELLYFIN_API_KEY
-  env vars; `recent` also requires JELLYFIN_USER_ID or --user-id. Python 3.8+ and
-  the `requests` library. Generate an API key at Dashboard → API Keys in the Jellyfin admin panel.
+  env vars; `recent`, `next-up`, and `item` also require JELLYFIN_USER_ID or --user-id.
+  Python 3.8+ and the `requests` library. Generate an API key at Dashboard → API Keys in the Jellyfin admin panel.
 metadata:
   tags: jellyfin, media-server, movies, tv, episodes, recently-added, library, home-media,
     api-client
@@ -16,7 +16,7 @@ metadata:
 
 # jellyfin-cli — Jellyfin Media Server from the Terminal
 
-Query recently added movies and TV episodes, search your media library, list libraries, check server info, and view library statistics — all from your Jellyfin server's REST API.
+Query recently added movies and TV episodes, search and inspect media, browse libraries, see next-up episodes, check server info, and view library statistics — all from your Jellyfin server's REST API.
 
 ## Setup
 
@@ -27,7 +27,7 @@ Query recently added movies and TV episodes, search your media library, list lib
 ```bash
 export JELLYFIN_URL="http://your-server:8096"   # include protocol and port
 export JELLYFIN_API_KEY="your-api-key-here"
-export JELLYFIN_USER_ID="your-jellyfin-user-id" # required by recent
+export JELLYFIN_USER_ID="your-jellyfin-user-id" # required by recent, next-up, and item
 ```
 
 Run the bundled CLI as `scripts/jellyfin-cli`. `--help` and `--dry-run` work without credentials.
@@ -70,6 +70,20 @@ scripts/jellyfin-cli search --query "dune" --json         # machine-readable
 
 The `--type` flag accepts a comma-separated list of item types (e.g. `Movie,Series,Episode`).
 
+### Navigation — Inspect media and browse libraries
+
+```bash
+scripts/jellyfin-cli search --query "dune" --type Movie    # find an item ID
+scripts/jellyfin-cli item --id ITEM_ID                      # inspect that item
+scripts/jellyfin-cli libraries                               # find a library ID
+scripts/jellyfin-cli browse --library-id LIBRARY_ID --type Movie --limit 20
+scripts/jellyfin-cli browse --library-id LIBRARY_ID --start-index 20
+scripts/jellyfin-cli next-up --limit 10                      # next episodes for JELLYFIN_USER_ID
+scripts/jellyfin-cli next-up --user-id USER_ID --json
+```
+
+Use `search -> item` to look up a result's metadata, and `libraries -> browse` to page through a collection. `next-up` returns the next unwatched episodes for the selected user. `item` and `next-up` require `JELLYFIN_USER_ID` or `--user-id`; all three commands are read-only.
+
 ### libraries — List media libraries
 
 ```bash
@@ -106,7 +120,7 @@ scripts/jellyfin-cli --dry-run search --query "dune"       # preview request wit
 ## Known Gotchas
 
 - **JELLYFIN_URL must include protocol and port** — Both are required, e.g. `http://192.168.1.100:8096`. A bare hostname or IP without `http://` and `:8096` will fail. The default is `http://localhost:8096`.
-- **Recent requires an explicit user** — Set `JELLYFIN_USER_ID` or pass `recent --user-id USER_ID`. The CLI never selects an administrator automatically. A real recent request without either value fails before network access; dry-run previews the request with a null user ID.
+- **User-scoped commands require an explicit user** — Set `JELLYFIN_USER_ID` or pass `--user-id USER_ID` to `recent`, `next-up`, or `item`. The CLI never selects an administrator automatically. A real request without either value fails before network access; dry-run previews the request with a null user ID.
 - **Recent type filtering is server-side** — `--movies` and `--episodes` become the `/Items/Latest` `includeItemTypes` parameter before `limit`; no local filtering is applied.
 - **Search type values** — The `--type` flag for `search` uses Jellyfin item type names (e.g. `Movie`, `Series`, `Episode`, `MusicArtist`, `MusicAlbum`). Multiple types are comma-separated without spaces.
 - **API key location** — Generate the key in the Jellyfin Dashboard under **Dashboard → API Keys**. The key is sent as the `X-Emby-Token` header.

--- a/jellyfin-cli/scripts/jellyfin-cli
+++ b/jellyfin-cli/scripts/jellyfin-cli
@@ -121,8 +121,8 @@ class JellyfinClient:
             params["includeItemTypes"] = ",".join(types)
         return self._get("/Items", params=params)
 
-    def get_item(self, item_id):
-        return self._get(f"/Items/{item_id}")
+    def get_item(self, item_id, user_id):
+        return self._get(f"/Items/{item_id}", params={"userId": user_id})
 
     def get_seasons(self, series_id, user_id):
         return self._get(f"/Shows/{series_id}/Seasons", params={"userId": user_id})
@@ -139,6 +139,25 @@ def fmt_date(ts):
     if not ts:
         return "?"
     return ts[:10] if len(ts) > 10 else ts
+
+
+def normalize_item(item):
+    """Return available Jellyfin item metadata with stable CLI field names."""
+    fields = {
+        "id": item.get("Id"),
+        "name": item.get("Name"),
+        "type": item.get("Type"),
+        "year": item.get("ProductionYear"),
+        "series": item.get("SeriesName"),
+        "season_number": item.get("ParentIndexNumber"),
+        "episode_number": item.get("IndexNumber"),
+        "overview": item.get("Overview"),
+        "date_added": fmt_date(item["DateCreated"]) if item.get("DateCreated") else None,
+        "community_rating": item.get("CommunityRating"),
+        "official_rating": item.get("OfficialRating"),
+        "runtime_ticks": item.get("RunTimeTicks"),
+    }
+    return {key: value for key, value in fields.items() if value is not None and value != ""}
 
 
 def cmd_info(client, args):
@@ -234,6 +253,78 @@ def cmd_search(client, args):
     emit(f"{len(hints)} result(s):\n" + "\n".join(lines), {"results": out})
 
 
+def cmd_next_up(client, args):
+    p = argparse.ArgumentParser(prog="jellyfin-cli next-up")
+    p.add_argument("--user-id", default=ENV_USER_ID)
+    p.add_argument("--limit", type=int, default=10)
+    parsed, _ = p.parse_known_args(args)
+
+    params = {"userId": parsed.user_id or None, "limit": parsed.limit}
+    if client.dry_run:
+        return emit("[dry-run] GET /Shows/NextUp " + json.dumps(params), {
+            "dry_run": True, "path": "/Shows/NextUp", "params": params,
+        })
+    if not parsed.user_id:
+        die("next-up requires --user-id or JELLYFIN_USER_ID.")
+
+    data = client.get_next_up(parsed.user_id, limit=parsed.limit) or {}
+    items = [normalize_item(item) for item in data.get("Items", [])]
+    lines = [f"  {item.get('name', '?')}  [{item.get('type', '?')}]" for item in items]
+    emit("Next up:\n" + "\n".join(lines) if lines else "No next-up episodes.", {
+        "items": items, "total_record_count": data.get("TotalRecordCount", 0),
+    })
+
+
+def cmd_item(client, args):
+    p = argparse.ArgumentParser(prog="jellyfin-cli item")
+    p.add_argument("--id", required=True)
+    p.add_argument("--user-id", default=ENV_USER_ID)
+    parsed, _ = p.parse_known_args(args)
+
+    params = {"userId": parsed.user_id or None}
+    path = f"/Items/{parsed.id}"
+    if client.dry_run:
+        return emit("[dry-run] GET " + path + " " + json.dumps(params), {
+            "dry_run": True, "path": path, "params": params,
+        })
+    if not parsed.user_id:
+        die("item requires --user-id or JELLYFIN_USER_ID.")
+
+    item = normalize_item(client.get_item(parsed.id, parsed.user_id) or {})
+    emit(f"{item.get('name', '?')}  [{item.get('type', '?')}]", item)
+
+
+def cmd_browse(client, args):
+    p = argparse.ArgumentParser(prog="jellyfin-cli browse")
+    p.add_argument("--library-id", required=True)
+    p.add_argument("--type")
+    p.add_argument("--limit", type=int, default=50)
+    p.add_argument("--start-index", type=int, default=0)
+    parsed, _ = p.parse_known_args(args)
+
+    types = parsed.type.split(",") if parsed.type else None
+    params = {
+        "parentId": parsed.library_id, "limit": parsed.limit, "sortBy": "SortName",
+        "sortOrder": "Ascending", "startIndex": parsed.start_index, "recursive": True,
+    }
+    if types:
+        params["includeItemTypes"] = ",".join(types)
+    if client.dry_run:
+        return emit("[dry-run] GET /Items " + json.dumps(params), {
+            "dry_run": True, "path": "/Items", "params": params,
+        })
+
+    data = client.get_items(parsed.library_id, types=types, limit=parsed.limit,
+                            start_index=parsed.start_index) or {}
+    items = [normalize_item(item) for item in data.get("Items", [])]
+    lines = [f"  {item.get('name', '?')}  [{item.get('type', '?')}]" for item in items]
+    emit("Browse results:\n" + "\n".join(lines) if lines else "No items found.", {
+        "items": items,
+        "start_index": data.get("StartIndex", parsed.start_index),
+        "total_record_count": data.get("TotalRecordCount", 0),
+    })
+
+
 def cmd_libraries(client, args):
     if client.dry_run:
         return emit("[dry-run] GET /Library/MediaFolders {}", {
@@ -274,7 +365,8 @@ def main():
     if GLOBAL_FLAGS.get("json", False):
         warnings.simplefilter("ignore")
 
-    parser = argparse.ArgumentParser(prog="jellyfin-cli", description="Jellyfin media server CLI.")
+    parser = argparse.ArgumentParser(prog="jellyfin-cli", description="Jellyfin media server CLI.",
+                                     epilog="Example: jellyfin-cli search --query dune")
     parser.add_argument("--json", action="store_true", help="Output machine-readable JSON")
     parser.add_argument("--dry-run", action="store_true", help="Preview API requests without network access")
     sub = parser.add_subparsers(dest="command")
@@ -289,6 +381,17 @@ def main():
     se.add_argument("--query", "-q", required=True, help="Text to search for")
     se.add_argument("--type", help="Comma-separated item types, such as Movie,Series")
     se.add_argument("--limit", type=int, default=20, help="Maximum results to return (default: 20)")
+    nu = sub.add_parser("next-up", help="Next unwatched episodes", description="Show the next unwatched episodes for a Jellyfin user.", epilog="Example: jellyfin-cli next-up --user-id USER_ID --limit 5")
+    nu.add_argument("--user-id", help="Jellyfin user ID (default: JELLYFIN_USER_ID)")
+    nu.add_argument("--limit", type=int, default=10, help="Maximum episodes to return (default: 10)")
+    it = sub.add_parser("item", help="Show item details", description="Show metadata for one Jellyfin library item.", epilog="Example: jellyfin-cli item --id ITEM_ID --user-id USER_ID")
+    it.add_argument("--id", required=True, help="Jellyfin item ID")
+    it.add_argument("--user-id", help="Jellyfin user ID (default: JELLYFIN_USER_ID)")
+    br = sub.add_parser("browse", help="Browse a library", description="List items in a Jellyfin media library.", epilog="Example: jellyfin-cli browse --library-id LIBRARY_ID --type Movie --limit 20")
+    br.add_argument("--library-id", required=True, help="Jellyfin library ID")
+    br.add_argument("--type", help="Comma-separated item types, such as Movie,Series")
+    br.add_argument("--limit", type=int, default=50, help="Maximum items to return (default: 50)")
+    br.add_argument("--start-index", type=int, default=0, help="Zero-based result offset (default: 0)")
     sub.add_parser("libraries", help="List libraries", description="List configured media libraries.", epilog="Example: jellyfin-cli libraries")
     sub.add_parser("stats", help="Library statistics", description="Show media library item counts.", epilog="Example: jellyfin-cli stats")
 
@@ -301,6 +404,7 @@ def main():
 
     cmd_map = {
         "info": cmd_info, "recent": cmd_recent, "search": cmd_search,
+        "next-up": cmd_next_up, "item": cmd_item, "browse": cmd_browse,
         "libraries": cmd_libraries, "stats": cmd_stats,
     }
     handler = cmd_map.get(args.command)

--- a/jellyfin-cli/tests/test_jellyfin_cli.py
+++ b/jellyfin-cli/tests/test_jellyfin_cli.py
@@ -29,6 +29,39 @@ class FakeClient:
         return [{"Name": "Arrival", "Type": "Movie", "Id": "movie-1"}]
 
 
+class NavigationFakeClient:
+    def __init__(self, dry_run=False):
+        self.dry_run = dry_run
+        self.next_up_calls = []
+        self.item_calls = []
+        self.items_calls = []
+
+    def get_next_up(self, user_id, limit=10):
+        self.next_up_calls.append((user_id, limit))
+        return {
+            "Items": [{"Name": "The Signal", "Type": "Episode", "Id": "episode-1",
+                       "SeriesName": "Voyagers", "IndexNumber": 4}],
+            "StartIndex": 0,
+            "TotalRecordCount": 9,
+        }
+
+    def get_item(self, item_id, user_id):
+        self.item_calls.append((item_id, user_id))
+        return {"Name": "The Signal", "Type": "Episode", "Id": item_id,
+                "SeriesName": "Voyagers", "IndexNumber": 4,
+                "Overview": "A message arrives."}
+
+    def get_items(self, parent_id, types=None, limit=50, sort_by="SortName",
+                  sort_order="Ascending", start_index=0):
+        self.items_calls.append((parent_id, types, limit, sort_by, sort_order, start_index))
+        return {
+            "Items": [{"Name": "Arrival", "Type": "Movie", "Id": "movie-1",
+                       "ProductionYear": 2016}],
+            "StartIndex": start_index,
+            "TotalRecordCount": 1,
+        }
+
+
 class JellyfinCliTests(unittest.TestCase):
     def setUp(self):
         self.flags = jellyfin_cli.GLOBAL_FLAGS
@@ -87,6 +120,101 @@ class JellyfinCliTests(unittest.TestCase):
             "params": {"userId": None, "includeItemTypes": "Movie", "limit": 2, "fields": "DateCreated"},
         })
         self.assertEqual(dry_run.recent_calls, [])
+
+    def test_navigation_client_contracts(self):
+        calls = []
+        client = jellyfin_cli.JellyfinClient()
+        client._get = lambda path, params=None: calls.append((path, params)) or {}
+
+        client.get_next_up("user-1", limit=3)
+        client.get_item("item-1", "user-1")
+        client.get_items("library-1", types=["Movie", "Series"], limit=4, start_index=2)
+
+        self.assertEqual(calls, [
+            ("/Shows/NextUp", {"userId": "user-1", "limit": 3}),
+            ("/Items/item-1", {"userId": "user-1"}),
+            ("/Items", {"parentId": "library-1", "limit": 4, "sortBy": "SortName",
+                        "sortOrder": "Ascending", "startIndex": 2, "recursive": True,
+                        "includeItemTypes": "Movie,Series"}),
+        ])
+
+    def test_next_up_item_and_browse_parse_results_as_json(self):
+        client = NavigationFakeClient()
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            jellyfin_cli.cmd_next_up(client, ["--user-id", "user-1", "--limit", "3"])
+        self.assertEqual(json.loads(output.getvalue()), {
+            "items": [{"id": "episode-1", "name": "The Signal", "type": "Episode",
+                       "series": "Voyagers", "episode_number": 4}],
+            "total_record_count": 9,
+        })
+        self.assertEqual(client.next_up_calls, [("user-1", 3)])
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            jellyfin_cli.cmd_item(client, ["--id", "episode-1", "--user-id", "user-1"])
+        self.assertEqual(json.loads(output.getvalue()), {
+            "id": "episode-1", "name": "The Signal", "type": "Episode",
+            "series": "Voyagers", "episode_number": 4, "overview": "A message arrives.",
+        })
+        self.assertEqual(client.item_calls, [("episode-1", "user-1")])
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            jellyfin_cli.cmd_browse(client, ["--library-id", "library-1", "--type", "Movie",
+                                              "--limit", "4", "--start-index", "2"])
+        self.assertEqual(json.loads(output.getvalue()), {
+            "items": [{"id": "movie-1", "name": "Arrival", "type": "Movie", "year": 2016}],
+            "start_index": 2,
+            "total_record_count": 1,
+        })
+        self.assertEqual(client.items_calls, [("library-1", ["Movie"], 4, "SortName", "Ascending", 2)])
+
+    def test_user_scoped_navigation_requires_user_before_network(self):
+        jellyfin_cli.ENV_USER_ID = ""
+        for handler, arguments in (
+            (jellyfin_cli.cmd_next_up, []),
+            (jellyfin_cli.cmd_item, ["--id", "item-1"]),
+        ):
+            client = NavigationFakeClient()
+            with self.subTest(handler=handler.__name__), contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+                handler(client, arguments)
+            self.assertEqual(client.next_up_calls, [])
+            self.assertEqual(client.item_calls, [])
+
+    def test_navigation_dry_runs_do_not_call_network_and_emit_requests(self):
+        cases = (
+            (jellyfin_cli.cmd_next_up, ["--limit", "3"], {"path": "/Shows/NextUp", "params": {"userId": None, "limit": 3}}),
+            (jellyfin_cli.cmd_item, ["--id", "item-1"], {"path": "/Items/item-1", "params": {"userId": None}}),
+            (jellyfin_cli.cmd_browse, ["--library-id", "library-1", "--type", "Movie,Series", "--limit", "4", "--start-index", "2"], {"path": "/Items", "params": {"parentId": "library-1", "limit": 4, "sortBy": "SortName", "sortOrder": "Ascending", "startIndex": 2, "recursive": True, "includeItemTypes": "Movie,Series"}}),
+        )
+        for handler, arguments, request in cases:
+            client = NavigationFakeClient(dry_run=True)
+            output = io.StringIO()
+            with self.subTest(handler=handler.__name__), contextlib.redirect_stdout(output):
+                handler(client, arguments)
+            self.assertEqual(json.loads(output.getvalue()), {"dry_run": True, **request})
+            self.assertEqual(client.next_up_calls, [])
+            self.assertEqual(client.item_calls, [])
+            self.assertEqual(client.items_calls, [])
+
+    def test_navigation_commands_dispatch_and_leaf_help_has_examples(self):
+        for command, arguments in (
+            ("next-up", ["--user-id", "user-1", "--limit", "2"]),
+            ("item", ["--id", "item-1", "--user-id", "user-1"]),
+            ("browse", ["--library-id", "library-1", "--limit", "2"]),
+        ):
+            result = subprocess.run([str(SCRIPT), "--json", "--dry-run", command, *arguments],
+                                    capture_output=True, text=True)
+            with self.subTest(command=command):
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertTrue(json.loads(result.stdout)["dry_run"])
+
+            help_result = subprocess.run([str(SCRIPT), command, "--help"], capture_output=True, text=True)
+            with self.subTest(help_command=command):
+                self.assertEqual(help_result.returncode, 0)
+                self.assertIn("Example:", help_result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #65.

Exposes the Jellyfin client’s existing read-only navigation paths:

- `next-up` for user-scoped upcoming episodes;
- `item` for inspecting a search result by ID;
- `browse` for paging through a library by ID.

The item request now sends the `userId` required by current Jellyfin API-key access. All three commands support JSON, dry-run, leaf examples, and focused regression coverage.

## Validation

- [x] `ruby scripts/validate-skills.rb`
- [x] Skill-specific checks, if applicable: <!-- command and result -->
- [x] `python3 -m unittest discover -s jellyfin-cli/tests -p 'test_*.py' -v` — 7 passed
- [x] `python3 -m py_compile jellyfin-cli/scripts/jellyfin-cli`
- [x] `uvx --from skills-ref agentskills validate jellyfin-cli`
- [x] `python3 scripts/check-artifacts.py`
- [x] Bounded live read-only smoke: `next-up`, `browse`, and `item` returned exit 0 and parseable JSON from a current Jellyfin server.

## Documentation

- [x] I updated the relevant `SKILL.md`, `README.md`, or reference files.
- [x] Links are relative and resolve from a fresh clone.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] I have disclosed meaningful AI assistance in the description or commit message.

Authored by Jasper (AI agent on behalf of Magnus Hedemark). Jasper performed the API-contract investigation, implementation orchestration, testing, live read-only validation, privacy scan, and final review.

## Review notes

- [x] Final-head review evidence is tied to commit SHA `<sha>`, and all actionable findings are resolved.

Final reviewed SHA: `0afa5c5ff04fd2371a686f4a3ea78ca11db83daf`.

OpenCode performed a fresh full-diff review at the final head and returned `PASS`.

Intentional scope: this PR exposes only client methods already present in the skill. Continue-watching, active sessions, playback, watched/favorite mutations, scans, and administration remain out of scope.
