### PR TITLE
fix: remove invalid Hermes skill metadata

### DIFF
--- a/scripts/validate-skills.rb
+++ b/scripts/validate-skills.rb
@@ -77,6 +77,7 @@ skills.each do |skill|
   if data.key?("metadata") && (!data["metadata"].is_a?(Hash) || !data["metadata"].all? { |key, value| key.is_a?(String) && value.is_a?(String) })
     errors << "#{relative}: metadata must map strings to strings"
   end
+  errors << "#{relative}: metadata.hermes is client-specific and not allowed" if data.dig("metadata", "hermes")
   errors << "#{relative}: must stay under 500 lines" unless text.lines.length < 500
 
   root = File.dirname(skill)

--- a/spec-driven-development/SKILL.md
+++ b/spec-driven-development/SKILL.md
@@ -11,9 +11,6 @@ compatibility: Tool-agnostic — methodology applies to any AI coding agent. Tem
 metadata:
   source: https://github.com/magnus919/agent-skills/spec-driven-development
   spec-version: 1.2.0
-  hermes: tags=["sdd", "specifications", "ai-code-generation", "software-factory",
-    "bdd", "gherkin", "quality-gates", "phase-gates"], related_skills=["sdd-authoring",
-    "sdd-review", "sdd-verification", "sdd-work-decomposition"]
 ---
 
 # Spec-Driven Development for AI Software Factories


### PR DESCRIPTION
## Summary

- remove malformed, client-specific `metadata.hermes` from the public Spec-Driven Development skill
- reject future `metadata.hermes` entries in the repository validator
- restore loading in Hermes, where the malformed scalar caused `'str' object has no attribute 'get'`

## Validation

- [x] `ruby scripts/validate-skills.rb` — `Validated 97 canonical skills.`
- [x] `uvx --from skills-ref agentskills validate spec-driven-development` — `Valid skill: spec-driven-development`
- [x] Regression probe: temporarily adding `metadata.hermes` makes the repository validator fail with the expected error.
- [x] `git diff --check`

## Documentation

- [x] I updated the relevant `SKILL.md`, `README.md`, or reference files.
- [x] Links are relative and resolve from a fresh clone.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] AI assistance: Hermes Agent diagnosed the loader failure, prepared the minimal fix, ran validation, and performed an independent review.

## Review notes

- [x] Final-head review evidence is tied to commit SHA `c67b83822f392c4cd0e87ede36a1f0bef27b8fcb`, and all actionable findings are resolved.

Independent review: PASS. The reviewer confirmed the two-file `+1/-3` diff removes the root cause, adds a minimal recurrence guard, and contains no unrelated changes.
