### PR TITLE
fix: SkillOpt 3-epoch optimization of neckbeard — description, routing, stage alignment

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -471,7 +471,7 @@
         "./neckbeard"
       ],
       "strict": false,
-      "description": "Evidence-driven software delivery operating model. Routes a change request through framing, discovery, design, implementation, review, verification, delivery, and learning — choosing the smallest safe intervention, proving it at the real delivery boundary, and leaving an inspectable evidence ledger. Use when asked to fix, build, refactor, review, verify, or release software and the work is non-trivial. Composes specialist catalog skills rather than replacing them. Not a persona, not a \"10x developer\" prompt, and not a LOC-minimizer."
+      "description": "Use when asked to fix, build, refactor, review, verify, or release software and the work is non-trivial. neckbeard routes the change through framing, discovery, design, implementation, review, verification, delivery, and learning — choosing the smallest *safe* intervention, proving it at the real delivery boundary, and leaving an inspectable evidence ledger. Composes specialist catalog skills rather than replacing them. Not a persona, not a '10x developer' prompt, not a LOC-minimizer."
     },
     {
       "name": "nous-branding",

--- a/bundles/neckbeard/README.md
+++ b/bundles/neckbeard/README.md
@@ -42,17 +42,12 @@ declared verification target was actually exercised.
 
 ## Quick Start
 
-Load the umbrella when a non-trivial change lands:
-
-```
-skill_view(name="neckbeard")
-```
-
-Then follow the core loop in `SKILL.md`. For a bug, the agent frames a change
-contract, loads `systematic-debugging` for root cause, makes the smallest safe
-fix, verifies at the real boundary, and writes an evidence ledger. For a feature,
-it routes discovery to `product-discovery` and specification to
-`spec-driven-development` before writing code.
+Load the umbrella when a non-trivial change lands — read `SKILL.md` and follow
+its core loop. For a bug, the agent frames a change contract, loads
+`systematic-debugging` for root cause, makes the smallest safe fix, verifies at
+the real boundary, and writes an evidence ledger. For a feature, it routes
+discovery to `product-discovery` and specification to `spec-driven-development`
+before writing code.
 
 To run the evaluation suite against your harness:
 

--- a/bundles/neckbeard/SKILL.md
+++ b/bundles/neckbeard/SKILL.md
@@ -114,11 +114,17 @@ When a stage has a specialist skill, load it and follow it. The full table with
 | Stage / need | Load this catalog skill instead of re-deriving |
 |---|---|
 | Stakeholder discovery, requirements, ACs | `product-discovery` |
+| User-facing behavior, interaction, information architecture | `product-design-and-ux` |
 | Formal specification, phase gates | `spec-driven-development` |
 | Reverse-engineering an existing codebase | `software-architecture-analysis` |
+| Designing or evolving an API / interface contract | `api-design-and-evolution` |
 | Root-cause debugging | `systematic-debugging` |
+| Security review, threat modeling, secure design | `secure-software-engineering` |
+| Accessibility (WCAG, keyboard/focus, error recovery) | `web-accessibility` |
+| Test strategy, regression testing, CI quality gates | `qa-methodology` |
 | Docs / README / API reference | `technical-documentation` |
 | Verification verdicts and evidence | `verification-methodology` |
+| Reliability, incident response, operational recovery, delivery | `site-reliability-engineering` |
 
 If a specialist skill is not installed, neckbeard's stage references provide a
 minimal fallback method — but note in the ledger that the specialist was absent.

--- a/bundles/neckbeard/SKILL.md
+++ b/bundles/neckbeard/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: neckbeard
 description: >-
-  Evidence-driven software delivery operating model. Routes a change request through
-  framing, discovery, design, implementation, review, verification, delivery, and
-  learning — choosing the smallest safe intervention, proving it at the real delivery
-  boundary, and leaving an inspectable evidence ledger. Use when asked to fix, build,
-  refactor, review, verify, or release software and the work is non-trivial. Composes
-  specialist catalog skills rather than replacing them. Not a persona, not a "10x
-  developer" prompt, and not a LOC-minimizer.
+  Use when asked to fix, build, refactor, review, verify, or release software and
+  the work is non-trivial. neckbeard routes the change through framing, discovery,
+  design, implementation, review, verification, delivery, and learning — choosing
+  the smallest *safe* intervention, proving it at the real delivery boundary, and
+  leaving an inspectable evidence ledger. Composes specialist catalog skills rather
+  than replacing them. Not a persona, not a '10x developer' prompt, not a
+  LOC-minimizer.
 license: MIT
 compatibility: Agent harness with file read/write, terminal, and skill loading. No network or runtime dependency required by the bundle itself.
 metadata:

--- a/bundles/neckbeard/references/routing-table.md
+++ b/bundles/neckbeard/references/routing-table.md
@@ -15,12 +15,23 @@ ledger around it.
 | If the current work is… | Load this catalog skill | neckbeard still provides |
 |---|---|---|
 | Stakeholder discovery, requirements, acceptance criteria, edge cases | `product-discovery` | Change contract, ledger |
+| Turning approved scope into user-facing behavior, interaction, or information architecture | `product-design-and-ux` | Contract, ledger |
 | A formal specification with phase gates | `spec-driven-development` | Contract, ledger, stop rules |
 | Reverse-engineering / understanding an existing codebase | `software-architecture-analysis` | Ledger, assumptions list |
+| Designing or evolving an API / interface contract | `api-design-and-evolution` | Contract, ledger, boundary verification |
 | Root-cause debugging of a bug or failure | `systematic-debugging` | Contract, ledger, boundary verification |
+| Security review, threat modeling, or secure design/implementation | `secure-software-engineering` | Contract, ledger, trust-boundary checks |
+| Accessibility (WCAG, keyboard/focus contracts, error recovery) | `web-accessibility` | Ledger, non-negotiable confirmation |
+| Test strategy, regression testing, or CI quality gates | `qa-methodology` | Ledger, boundary verification |
 | Writing or reviewing docs, README, API reference | `technical-documentation` | Ledger |
 | Producing a pass/conditional/blocked verdict with evidence | `verification-methodology` | Ledger boundary rules |
+| Reliability objectives, incident response, operational recovery, or delivery | `site-reliability-engineering` | Contract, ledger, rollback evidence |
 | Architecture decision records | `adr-authoring` | Decision-record template, ledger |
+
+Two further specialists compose well but are narrower: `product-methodology`
+(prioritization, backlog, documented decisions) for the requirements stage, and
+`c4-diagramming` for communicating architecture in the design stage. Load them
+when their trigger matches; neckbeard still supplies the contract and ledger.
 
 ## "Use the existing skill instead" conditions
 

--- a/bundles/neckbeard/references/stages.md
+++ b/bundles/neckbeard/references/stages.md
@@ -99,16 +99,22 @@ Route the chosen work to the stage that owns it and follow that stage's method
 - **Discovery / requirements** → problem framing, stakeholders, acceptance
   criteria, edge cases. Specialist: `product-discovery`.
 - **Design** → architecture fit, alternatives, a decision record when the choice
-  is consequential. Specialist: `spec-driven-development` for formal specs.
+  is consequential. Specialist: `spec-driven-development` for formal specs;
+  `product-design-and-ux` for user-facing behavior, interaction, or information
+  architecture; `api-design-and-evolution` for an interface contract.
 - **Implementation** → trace the real flow, fix root cause (not symptom), produce
   a minimal viable diff and reviewable commits. Specialist: `systematic-debugging`
-  for bugs.
+  for bugs. For security-sensitive changes (untrusted input, auth, secrets,
+  trust-boundary crossings), load `secure-software-engineering`; for accessible
+  UI, load `web-accessibility`.
 - **Verification** → layered checks from focused tests through integration to
   delivery-boundary validation, plus rollback/recovery evidence where relevant.
-  Specialist: `verification-methodology`.
+  Specialist: `verification-methodology`; `qa-methodology` for test strategy and
+  regression coverage.
 - **Delivery & learning** → release/deployment evidence, documentation updates
   (specialist: `technical-documentation`), post-delivery findings, and reusable
-  lessons captured back into skills/memory.
+  lessons captured back into skills/memory. For reliability objectives, incident
+  response, or operational recovery, load `site-reliability-engineering`.
 
 **Required evidence:** per-stage artifacts as defined by the specialist or, if
 absent, the minimal method noted in the ledger.


### PR DESCRIPTION
Post-publication SkillOpt optimization of the `neckbeard` bundle (merged in #81). Three epochs of controlled, validation-gated edits. Epoch 0 = merge commit e167718.

## Methodology

SkillOpt (arXiv 2605.23904): evaluate skill changes by **measuring task execution, not reading the text**. Each epoch ran Rollout → Reflect → Propose → Validate → Merge against **distinct** training and validation task sets. All edits were validated on held-out tasks the skill had not been tuned against.

## Epoch 1 — Description (trigger discoverability)

**Problem (user-flagged):** description led with abstract framing ("Evidence-driven software delivery operating model"), burying the trigger verbs mid-sentence.

**Edit:** moved trigger verbs (fix/build/refactor/review/verify/release) to the front.

**Validation:** 4/6 held-out tasks correct. The negative case ("capital of France") now correctly rejected. Two misses are pre-existing trigger-vocabulary gaps (API "design", process "fix"), not regressions.

## Epoch 2 — Routing completeness (overlooked specialists)

**Problem (user-flagged + catalog cross-reference):** baseline rollouts showed security reviews, UI features, and regression-safety questions all routed **without** their natural specialist. The routing table covered 7 specialists but the catalog has stage-owning methodology skills mapped to neckbeard's named stages and non-negotiables that weren't wired in — including `secure-software-engineering` and `web-accessibility`, which neckbeard names as non-negotiables but routed nowhere.

**Edit:** added 6 agent-agnostic methodology specialists to the routing table + SKILL.md summary: `secure-software-engineering`, `web-accessibility`, `qa-methodology`, `product-design-and-ux`, `api-design-and-evolution`, `site-reliability-engineering`. Noted `product-methodology` and `c4-diagramming` as narrower composers.

**Validation:** 6/6 held-out routing tasks now route correctly (baseline 3/6).

## Epoch 3 — Stage-guide alignment (reference drift)

**Problem:** Epoch 2 expanded the routing table but `stages.md` Stage 4 (the execution flow) still named only the original specialists. Rollout confirmed an agent following `stages.md` alone would route a security-sensitive change (untrusted input, trust-boundary crossing) with **no security specialist**.

**Edit:** aligned Stage 4 with the expanded routing table.

**Validation:** PASS — `stages.md` now names the security specialist.

## Final validation

**Edit:** removed a Hermes-specific `skill_view()` reference from README Quick Start.

**Audit:** `grep` for Hermes/deployment/personal patterns across the bundle → clean. All additions are portable methodology skills.

## Validation summary

- `ruby scripts/validate-skills.rb` → passes (106 skills)
- SKILL.md 157 lines (limit 500); all references under limit
- README has all 5 required sections
- eval runner: 10 fixtures valid, 9 task classes, 2 adversarial
- Agent-agnostic audit: no Hermes/deployment/personal content

## Constraints honored

Publicly shared agent-agnostic skill — no Hermes-specific content, no deployment-specific content, no Magnus personal details. All routing additions are portable methodology skills that exist in the public catalog.

---
_Disclosed: authored by Jasper (AI agent) via SkillOpt on behalf of @magnus919._