### PR TITLE
fix: complete eval ratchet verification

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,6 +34,8 @@ jobs:
         run: ruby scripts/gen-claude-marketplace.rb
       - name: Validate Codex plugin packaging
         run: ruby scripts/gen-codex-plugin.rb
+      - name: Test eval coverage ratchet
+        run: python3 scripts/test-eval-coverage.py
       - name: Report eval coverage
         run: python3 scripts/eval-coverage.py
       - name: Enforce eval coverage ratchet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ git clone https://github.com/magnus919/agent-skills.git
 cd agent-skills
 ruby scripts/validate-skills.rb
 ruby scripts/validate-skill-quality.rb --base origin/main
+python3 scripts/test-eval-coverage.py
 python3 scripts/eval-coverage.py
 ```
 

--- a/scripts/eval-coverage.py
+++ b/scripts/eval-coverage.py
@@ -48,6 +48,25 @@ def find_skills() -> list[Path]:
     return sorted(skills)
 
 
+def find_skills_at(ref: str) -> list[Path]:
+    """Find canonical skill directories tracked at a git revision."""
+    result = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", ref],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    skills = []
+    for name in result.stdout.splitlines():
+        if (
+            name.endswith("/SKILL.md")
+            and "/agent-council/profiles/skills/" not in name
+        ):
+            skills.append(Path(name).parent)
+    return sorted(skills)
+
+
 def load_grandfathered() -> set[str]:
     if not GRANDFATHER_FILE.exists():
         return set()
@@ -107,7 +126,13 @@ def modified_skills(base_ref: str) -> set[Path]:
     ]
     # Map each changed file to its owning skill directory by checking
     # whether the file path starts with a known skill directory prefix.
-    known_skills = find_skills()
+    # Include skills from both revisions so complete directory deletions
+    # remain observable under their old name.
+    known_skills = sorted(
+        set(find_skills()) | set(find_skills_at(base_ref)),
+        key=lambda path: len(path.parts),
+        reverse=True,
+    )
     modified: set[Path] = set()
     for changed in changed_files:
         changed_path = Path(changed)
@@ -119,6 +144,32 @@ def modified_skills(base_ref: str) -> set[Path]:
             except ValueError:
                 continue
     return modified
+
+
+def evaluate_ratchet(
+    modified: set[Path],
+    current: set[Path],
+    without_evals: set[Path],
+    coverage_pct: float,
+) -> tuple[list[str], list[str]]:
+    """Apply warning and failure thresholds to modified current skills."""
+    warnings: list[str] = []
+    errors: list[str] = []
+    for skill_dir in sorted(modified & current & without_evals):
+        name = str(skill_dir)
+        if coverage_pct >= FAIL_THRESHOLD:
+            errors.append(
+                f"{name}: modified skill has no evals "
+                f"(coverage {coverage_pct:.1f}% >= {FAIL_THRESHOLD}% — "
+                "evals required on modification)"
+            )
+        elif coverage_pct >= WARN_THRESHOLD:
+            warnings.append(
+                f"{name}: modified skill has no evals "
+                f"(coverage {coverage_pct:.1f}% >= {WARN_THRESHOLD}% — "
+                "evals recommended)"
+            )
+    return warnings, errors
 
 
 def coverage_decreased(base_ref: str) -> tuple[bool, float, float]:
@@ -207,20 +258,12 @@ def main() -> int:
     ratchet_errors: list[str] = []
     if args.modified_from:
         modified = modified_skills(args.modified_from)
-        for skill_dir in sorted(modified):
-            name = str(skill_dir)
-            has, _ = check_evals(skill_dir)
-            if not has:
-                if coverage_pct >= FAIL_THRESHOLD:
-                    ratchet_errors.append(
-                        f"{name}: modified skill has no evals "
-                        f"(coverage {coverage_pct:.1f}% >= {FAIL_THRESHOLD}% — evals required on modification)"
-                    )
-                elif coverage_pct >= WARN_THRESHOLD:
-                    ratchet_warnings.append(
-                        f"{name}: modified skill has no evals "
-                        f"(coverage {coverage_pct:.1f}% >= {WARN_THRESHOLD}% — evals recommended)"
-                    )
+        ratchet_warnings, ratchet_errors = evaluate_ratchet(
+            modified=modified,
+            current=set(skills),
+            without_evals={Path(name) for name in without_evals},
+            coverage_pct=coverage_pct,
+        )
 
         # Monotonic coverage floor: fail if coverage decreased.
         decreased, base_pct, head_pct = coverage_decreased(args.modified_from)

--- a/scripts/test-eval-coverage.py
+++ b/scripts/test-eval-coverage.py
@@ -104,6 +104,114 @@ class TestModifiedSkills(unittest.TestCase):
             eval_coverage.ROOT = old_root
         self.assertIn(Path("beta"), mods)
 
+    def test_added_skill_detected(self) -> None:
+        write_skill(self.repo, "existing")
+        base = self._commit("initial")
+        write_skill(self.repo, "added")
+        self._commit("add skill")
+        old_root = eval_coverage.ROOT
+        eval_coverage.ROOT = Path(self.repo)
+        try:
+            mods = eval_coverage.modified_skills(base)
+        finally:
+            eval_coverage.ROOT = old_root
+        self.assertIn(Path("added"), mods)
+
+    def test_renamed_skill_detected_under_new_name(self) -> None:
+        write_skill(self.repo, "before")
+        base = self._commit("initial")
+        git(self.repo, "mv", "before", "after")
+        self._commit("rename skill")
+        old_root = eval_coverage.ROOT
+        eval_coverage.ROOT = Path(self.repo)
+        try:
+            mods = eval_coverage.modified_skills(base)
+        finally:
+            eval_coverage.ROOT = old_root
+        self.assertIn(Path("after"), mods)
+        self.assertNotIn(Path("before"), mods)
+
+    def test_deleted_skill_detected_under_old_name(self) -> None:
+        write_skill(self.repo, "removed")
+        base = self._commit("initial")
+        git(self.repo, "rm", "-r", "removed")
+        self._commit("delete skill")
+        old_root = eval_coverage.ROOT
+        eval_coverage.ROOT = Path(self.repo)
+        try:
+            mods = eval_coverage.modified_skills(base)
+        finally:
+            eval_coverage.ROOT = old_root
+        self.assertIn(Path("removed"), mods)
+
+    def test_deleted_skill_flows_through_ratchet_without_eval_error(self) -> None:
+        write_skill(self.repo, "removed")
+        base = self._commit("initial")
+        git(self.repo, "rm", "-r", "removed")
+        self._commit("delete skill")
+        old_root = eval_coverage.ROOT
+        eval_coverage.ROOT = Path(self.repo)
+        try:
+            modified = eval_coverage.modified_skills(base)
+            current = set(eval_coverage.find_skills())
+            without_evals = {
+                skill for skill in current if not eval_coverage.check_evals(skill)[0]
+            }
+            warnings, errors = eval_coverage.evaluate_ratchet(
+                modified=modified,
+                current=current,
+                without_evals=without_evals,
+                coverage_pct=100.0,
+            )
+        finally:
+            eval_coverage.ROOT = old_root
+        self.assertIn(Path("removed"), modified)
+        self.assertEqual([], warnings)
+        self.assertEqual([], errors)
+
+    def test_script_fixture_and_readme_changes_detected(self) -> None:
+        paths = {
+            "scripted": Path("scripts") / "run.py",
+            "fixtured": Path("fixtures") / "case.txt",
+            "documented": Path("README.md"),
+        }
+        for skill, relative in paths.items():
+            write_skill(self.repo, skill)
+            target = Path(self.repo) / skill / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("v1")
+        base = self._commit("initial")
+        for skill, relative in paths.items():
+            (Path(self.repo) / skill / relative).write_text("v2")
+        self._commit("edit supporting files")
+        old_root = eval_coverage.ROOT
+        eval_coverage.ROOT = Path(self.repo)
+        try:
+            mods = eval_coverage.modified_skills(base)
+        finally:
+            eval_coverage.ROOT = old_root
+        self.assertTrue({Path(name) for name in paths}.issubset(mods))
+
+    def test_nested_change_maps_to_nearest_skill_owner(self) -> None:
+        parent = "bundles/example"
+        child = "bundles/example/skills/child"
+        write_skill(self.repo, parent)
+        write_skill(self.repo, child)
+        reference = Path(self.repo) / child / "references" / "guide.md"
+        reference.parent.mkdir(parents=True)
+        reference.write_text("v1")
+        base = self._commit("initial")
+        reference.write_text("v2")
+        self._commit("edit child reference")
+        old_root = eval_coverage.ROOT
+        eval_coverage.ROOT = Path(self.repo)
+        try:
+            mods = eval_coverage.modified_skills(base)
+        finally:
+            eval_coverage.ROOT = old_root
+        self.assertIn(Path(child), mods)
+        self.assertNotIn(Path(parent), mods)
+
     def test_eval_manifest_deletion_detected(self) -> None:
         write_skill(self.repo, "gamma", evals=[make_case("c1")])
         base = self._commit("initial")
@@ -197,6 +305,60 @@ class TestCoverageDecreased(unittest.TestCase):
         self.assertFalse(decreased)
         self.assertAlmostEqual(base_pct, 0.0)
         self.assertAlmostEqual(head_pct, 100.0)
+
+
+class TestRatchetThresholds(unittest.TestCase):
+    """Threshold policy must warn at 25% and fail at 50%."""
+
+    def test_below_warning_threshold_is_advisory_only(self) -> None:
+        warnings, errors = eval_coverage.evaluate_ratchet(
+            modified={Path("alpha")},
+            current={Path("alpha")},
+            without_evals={Path("alpha")},
+            coverage_pct=24.9,
+        )
+        self.assertEqual([], warnings)
+        self.assertEqual([], errors)
+
+    def test_warning_threshold_emits_warning(self) -> None:
+        warnings, errors = eval_coverage.evaluate_ratchet(
+            modified={Path("alpha")},
+            current={Path("alpha")},
+            without_evals={Path("alpha")},
+            coverage_pct=25.0,
+        )
+        self.assertEqual(1, len(warnings))
+        self.assertEqual([], errors)
+
+    def test_warning_band_remains_warning_below_failure_threshold(self) -> None:
+        warnings, errors = eval_coverage.evaluate_ratchet(
+            modified={Path("alpha")},
+            current={Path("alpha")},
+            without_evals={Path("alpha")},
+            coverage_pct=49.9,
+        )
+        self.assertEqual(1, len(warnings))
+        self.assertEqual([], errors)
+
+    def test_failure_threshold_emits_error(self) -> None:
+        warnings, errors = eval_coverage.evaluate_ratchet(
+            modified={Path("alpha")},
+            current={Path("alpha")},
+            without_evals={Path("alpha")},
+            coverage_pct=50.0,
+        )
+        self.assertEqual([], warnings)
+        self.assertEqual(1, len(errors))
+
+    def test_deleted_skill_does_not_require_new_evals(self) -> None:
+        warnings, errors = eval_coverage.evaluate_ratchet(
+            modified={Path("removed")},
+            current=set(),
+            without_evals=set(),
+            coverage_pct=100.0,
+        )
+        self.assertEqual([], warnings)
+        self.assertEqual([], errors)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Completes the eval coverage ratchet acceptance gate left open after #107:

- runs the ratchet regression suite in CI;
- adds explicit coverage for skill additions, renames, complete deletions, supporting-file edits, nested skill ownership, and threshold boundaries;
- detects deleted skill directories from the base revision without demanding evals for skills that no longer exist;
- maps nested changes to the nearest canonical skill owner rather than an enclosing bundle;
- documents the local regression-test command.

Closes #102.

## Why this follow-up exists

PR #107 merged the ratchet implementation, but its new test suite was not invoked by `.github/workflows/validate.yml`, and several acceptance cases remained untested. Issue #102 was reopened to finish the original contract rather than treating locally passing tests as delivery-boundary evidence.

## Test design

The suite now exercises:

- new skill detection;
- renamed skill detection under the new name;
- complete skill deletion detection under the old name;
- `SKILL.md`, references, scripts, fixtures, README, and eval-manifest changes;
- nearest-owner resolution for nested bundle skills;
- all-zero base coverage increasing safely;
- stable, increasing, and decreasing coverage;
- behavior below 25%, at the 25% warning boundary, and at the 50% failure boundary;
- deleted skills being excluded from missing-eval enforcement.

## Verification

Local checks:

```text
python3 scripts/test-eval-coverage.py
  18 tests, all passing

ruby scripts/validate-skills.rb
  107 canonical skills validated

ruby scripts/test-validate-skill-quality.rb
  19 runs, 159 assertions, 0 failures

ruby scripts/validate-skill-quality.rb --base origin/main
  no changed SKILL.md files

python3 scripts/check-artifacts.py
ruby scripts/gen-claude-marketplace.rb
ruby scripts/gen-codex-plugin.rb
ruby scripts/test-gen-llms-txt.rb
ruby scripts/gen-llms-txt.rb
  all passing; generated artifacts current

python3 scripts/eval-coverage.py
  5/107 skills, 4.7%; informational report succeeds

python3 -m py_compile scripts/eval-coverage.py scripts/test-eval-coverage.py
git diff --check
  both pass
```

The GitHub Actions result on this PR is the delivery-boundary check for the newly wired CI test step.

## Scope

This does not rewrite the already-merged commit from #107. It fixes the remaining functional and verification gaps with an additive follow-up commit.

Authored by Jasper (AI agent on behalf of @magnus919).