### PR TITLE
feat: add harness adapter contract and reproducible eval run artifacts

### DIFF
--- a/eval_runner/__init__.py
+++ b/eval_runner/__init__.py
@@ -1,0 +1,3 @@
+"""Repository-level evaluation runner with harness adapter contract."""
+
+__version__ = "0.1.0"

--- a/eval_runner/__main__.py
+++ b/eval_runner/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running as `python3 -m eval_runner`."""
+
+from .runner import main
+
+raise SystemExit(main())

--- a/eval_runner/adapter.py
+++ b/eval_runner/adapter.py
@@ -1,0 +1,37 @@
+"""Adapter protocol defining the harness contract."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .models import AdapterInput, AdapterOutput
+
+
+@runtime_checkable
+class HarnessAdapter(Protocol):
+    """Contract for executing an eval case against a candidate skill.
+
+    Implementations must be non-interactive and deterministic given the same
+    inputs (modulo model non-determinism in real adapters). Raw traces may
+    remain adapter-specific; only evidence required by declared graders is
+    normalized in AdapterOutput.
+    """
+
+    @property
+    def name(self) -> str:
+        """Stable adapter identifier, e.g. 'fake', 'cli-subprocess'."""
+        ...
+
+    @property
+    def version(self) -> str:
+        """Adapter implementation version."""
+        ...
+
+    def execute(self, input: AdapterInput) -> AdapterOutput:
+        """Run one eval case and return normalized results.
+
+        Must not raise on expected failure modes (timeout, model error, skill
+        not found). Encode failures in AdapterOutput.exit_status and .error.
+        Unexpected infrastructure errors may raise.
+        """
+        ...

--- a/eval_runner/cli_adapter.py
+++ b/eval_runner/cli_adapter.py
@@ -1,0 +1,134 @@
+"""Subprocess-based adapter for non-interactive CLI agent harnesses.
+
+Executes a configurable command with the case prompt piped to stdin or passed
+as an argument. Captures stdout as the response, stderr for diagnostics, and
+records exit code, timing, and any artifacts produced in the output directory.
+
+This is the first real harness adapter. It supports any agent CLI that can:
+  - accept a prompt non-interactively (via stdin or --prompt flag)
+  - write its response to stdout
+  - operate within a working directory
+
+Configuration via harness_config:
+  command: list[str]  — the command to run (e.g. ["opencode", "--print"])
+  prompt_mode: "stdin" | "arg"  — how to pass the prompt (default: "stdin")
+  prompt_flag: str  — flag name if prompt_mode is "arg" (default: "--prompt")
+  timeout_seconds: int  — max wall time (default: 120)
+  extra_args: list[str]  — additional CLI arguments
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+from .models import AdapterInput, AdapterOutput, ExitStatus, ToolEvent
+
+
+class CliSubprocessAdapter:
+    """Runs an agent CLI as a subprocess and normalizes the result."""
+
+    def __init__(
+        self,
+        command: list[str],
+        *,
+        prompt_mode: str = "stdin",
+        prompt_flag: str = "--prompt",
+        timeout_seconds: int = 120,
+        extra_args: list[str] | None = None,
+    ):
+        self._command = command
+        self._prompt_mode = prompt_mode
+        self._prompt_flag = prompt_flag
+        self._timeout_seconds = timeout_seconds
+        self._extra_args = extra_args or []
+
+    @property
+    def name(self) -> str:
+        return "cli-subprocess"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    def execute(self, input: AdapterInput) -> AdapterOutput:
+        timeout = input.limits.get("timeout_seconds", self._timeout_seconds)
+        cmd = list(self._command) + list(self._extra_args)
+
+        stdin_data: str | None = None
+        if self._prompt_mode == "stdin":
+            stdin_data = input.case.prompt
+        elif self._prompt_mode == "arg":
+            cmd += [self._prompt_flag, input.case.prompt]
+
+        env = dict(os.environ)
+        env.update(input.env)
+
+        input.work_dir.mkdir(parents=True, exist_ok=True)
+        input.output_dir.mkdir(parents=True, exist_ok=True)
+
+        start = time.monotonic()
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=stdin_data,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=str(input.work_dir),
+                env=env,
+            )
+            elapsed_ms = (time.monotonic() - start) * 1000
+
+            if proc.returncode == 0:
+                exit_status = ExitStatus.COMPLETED
+            else:
+                exit_status = ExitStatus.ERROR
+
+            artifacts = [
+                f.name
+                for f in input.output_dir.iterdir()
+                if f.is_file()
+            ]
+
+            tool_events = []
+            if proc.stderr:
+                tool_events.append(
+                    ToolEvent(
+                        name="subprocess_stderr",
+                        arguments={"command": " ".join(cmd)},
+                        result_summary=proc.stderr[:500],
+                    )
+                )
+
+            return AdapterOutput(
+                exit_status=exit_status,
+                response=proc.stdout or None,
+                activation_evidence=None,
+                artifacts=artifacts,
+                environment_state={"returncode": proc.returncode},
+                tool_events=tool_events,
+                duration_ms=elapsed_ms,
+                token_usage=None,
+                raw_trace_path=None,
+                error=proc.stderr[:1000] if proc.returncode != 0 else None,
+            )
+
+        except subprocess.TimeoutExpired:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            return AdapterOutput(
+                exit_status=ExitStatus.TIMEOUT,
+                response=None,
+                error=f"process exceeded {timeout}s timeout",
+                duration_ms=elapsed_ms,
+            )
+        except FileNotFoundError as exc:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            return AdapterOutput(
+                exit_status=ExitStatus.ERROR,
+                response=None,
+                error=f"command not found: {exc}",
+                duration_ms=elapsed_ms,
+            )

--- a/eval_runner/fake_adapter.py
+++ b/eval_runner/fake_adapter.py
@@ -1,0 +1,67 @@
+"""Deterministic fake adapter for unit and CI testing without model credentials."""
+
+from __future__ import annotations
+
+import time
+
+from .models import AdapterInput, AdapterOutput, ExitStatus, ToolEvent
+
+
+class FakeAdapter:
+    """Returns canned responses derived from the case prompt.
+
+    Behavior is fully deterministic: the response echoes the case ID, tool
+    events are synthesized from the assertion count, and timing is fixed.
+    Useful for validating the runner pipeline, manifest serialization, and
+    grader bindings without any external dependencies.
+    """
+
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    def execute(self, input: AdapterInput) -> AdapterOutput:
+        start = time.monotonic()
+
+        case = input.case
+        response = (
+            f"[fake] Processed case '{case.id}': {case.prompt[:80]}"
+        )
+        activation_evidence = f"skill loaded from {input.skill_path.name}/SKILL.md"
+
+        tool_events = [
+            ToolEvent(
+                name="read_file",
+                arguments={"path": f"{input.skill_path.name}/SKILL.md"},
+                result_summary="skill content loaded",
+                timestamp="2025-01-01T00:00:00Z",
+            ),
+        ]
+        for i, assertion in enumerate(case.assertions):
+            tool_events.append(
+                ToolEvent(
+                    name="assert_check",
+                    arguments={"index": i, "assertion": assertion[:60]},
+                    result_summary="pass",
+                    timestamp="2025-01-01T00:00:00Z",
+                )
+            )
+
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        return AdapterOutput(
+            exit_status=ExitStatus.COMPLETED,
+            response=response,
+            activation_evidence=activation_evidence,
+            artifacts=[],
+            environment_state={"work_dir": str(input.work_dir)},
+            tool_events=tool_events,
+            duration_ms=elapsed_ms,
+            token_usage={"input_tokens": 100, "output_tokens": 50},
+            raw_trace_path=None,
+            error=None,
+        )

--- a/eval_runner/manifest.py
+++ b/eval_runner/manifest.py
@@ -1,0 +1,120 @@
+"""Run manifest construction and serialization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .models import AdapterInput, AdapterOutput, EvalCase
+
+MANIFEST_SCHEMA_VERSION = 1
+
+
+def _git_tree_hash(skill_path: Path) -> str:
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%T", "--", str(skill_path)],
+        capture_output=True,
+        text=True,
+        cwd=skill_path,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()[:16]
+    return "unknown"
+
+
+def _skill_name(skill_path: Path) -> str:
+    skill_md = skill_path / "SKILL.md"
+    if skill_md.is_file():
+        return skill_path.name
+    return skill_path.name
+
+
+def build_manifest(
+    *,
+    adapter_name: str,
+    adapter_version: str,
+    harness_name: str,
+    harness_version: str,
+    model_provider: str,
+    model_id: str,
+    adapter_input: AdapterInput,
+    adapter_output: AdapterOutput,
+    started_at: datetime,
+    finished_at: datetime,
+) -> dict[str, Any]:
+    case = adapter_input.case
+    skill_path = adapter_input.skill_path
+
+    artifact_digests: dict[str, str] = {}
+    for artifact_rel in adapter_output.artifacts:
+        artifact_path = adapter_input.output_dir / artifact_rel
+        if artifact_path.is_file():
+            artifact_digests[artifact_rel] = hashlib.sha256(
+                artifact_path.read_bytes()
+            ).hexdigest()[:16]
+        else:
+            artifact_digests[artifact_rel] = "missing"
+
+    failures: list[dict[str, str]] = []
+    if adapter_output.error:
+        failures.append({"type": "execution_error", "message": adapter_output.error})
+
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "trial_id": str(uuid.uuid4()),
+        "candidate": {
+            "skill_name": _skill_name(skill_path),
+            "skill_path": str(skill_path),
+            "tree_hash": _git_tree_hash(skill_path),
+        },
+        "case": {
+            "case_id": case.id,
+            "prompt_hash": case.prompt_hash,
+            "fixture_hashes": case.fixture_hashes(skill_path),
+        },
+        "adapter": {
+            "name": adapter_name,
+            "version": adapter_version,
+        },
+        "harness": {
+            "name": harness_name,
+            "version": harness_version,
+        },
+        "model": {
+            "provider": model_provider,
+            "model_id": model_id,
+        },
+        "permissions": adapter_input.permissions,
+        "network_policy": adapter_input.limits.get("network_policy", "unspecified"),
+        "limits": adapter_input.limits,
+        "cache_state": adapter_input.harness_config.get("cache_state", "unspecified"),
+        "started_at": started_at.isoformat(),
+        "finished_at": finished_at.isoformat(),
+        "status": adapter_output.exit_status.value,
+        "outputs": {
+            "response": adapter_output.response,
+            "activation_evidence": adapter_output.activation_evidence,
+            "artifact_digests": artifact_digests,
+            "tool_event_count": len(adapter_output.tool_events),
+        },
+        "duration_ms": adapter_output.duration_ms,
+        "token_usage": adapter_output.token_usage,
+        "failures": failures,
+        "missing_evidence": adapter_output.missing_evidence(),
+    }
+
+
+def write_manifest(manifest: dict[str, Any], output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    trial_id = manifest.get("trial_id", "unknown")
+    case_id = manifest.get("case", {}).get("case_id", "unknown")
+    filename = f"{case_id}--{trial_id[:8]}.manifest.json"
+    path = output_dir / filename
+    path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return path

--- a/eval_runner/models.py
+++ b/eval_runner/models.py
@@ -1,0 +1,88 @@
+"""Typed data models for the eval runner adapter contract."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class ExitStatus(str, Enum):
+    COMPLETED = "completed"
+    ERROR = "error"
+    TIMEOUT = "timeout"
+    STOPPED = "stopped"
+
+
+@dataclass(frozen=True)
+class EvalCase:
+    id: str
+    prompt: str
+    expected_output: str
+    assertions: list[str]
+    files: list[str] = field(default_factory=list)
+
+    @property
+    def prompt_hash(self) -> str:
+        return hashlib.sha256(self.prompt.encode()).hexdigest()[:16]
+
+    def fixture_hashes(self, skill_root: Path) -> dict[str, str]:
+        hashes: dict[str, str] = {}
+        for rel in self.files:
+            target = skill_root / rel
+            if target.is_file():
+                hashes[rel] = hashlib.sha256(target.read_bytes()).hexdigest()[:16]
+            else:
+                hashes[rel] = "missing"
+        return hashes
+
+
+@dataclass
+class AdapterInput:
+    skill_path: Path
+    case: EvalCase
+    work_dir: Path
+    output_dir: Path
+    permissions: dict[str, Any] = field(default_factory=dict)
+    limits: dict[str, Any] = field(default_factory=dict)
+    env: dict[str, str] = field(default_factory=dict)
+    model: str = ""
+    harness_config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ToolEvent:
+    name: str
+    arguments: dict[str, Any] = field(default_factory=dict)
+    result_summary: str = ""
+    timestamp: str = ""
+
+
+@dataclass
+class AdapterOutput:
+    exit_status: ExitStatus
+    response: str | None = None
+    activation_evidence: str | None = None
+    artifacts: list[str] = field(default_factory=list)
+    environment_state: dict[str, Any] | None = None
+    tool_events: list[ToolEvent] = field(default_factory=list)
+    duration_ms: float = 0.0
+    token_usage: dict[str, Any] | None = None
+    raw_trace_path: str | None = None
+    error: str | None = None
+
+    def missing_evidence(self) -> list[str]:
+        missing: list[str] = []
+        if self.response is None:
+            missing.append("response")
+        if self.activation_evidence is None:
+            missing.append("activation_evidence")
+        if self.environment_state is None:
+            missing.append("environment_state")
+        if self.token_usage is None:
+            missing.append("token_usage")
+        if not self.tool_events:
+            missing.append("tool_events")
+        return missing

--- a/eval_runner/runner.py
+++ b/eval_runner/runner.py
@@ -1,0 +1,181 @@
+"""Eval runner CLI — loads cases, dispatches to an adapter, writes manifests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .adapter import HarnessAdapter
+from .cli_adapter import CliSubprocessAdapter
+from .fake_adapter import FakeAdapter
+from .manifest import build_manifest, write_manifest
+from .models import AdapterInput, EvalCase
+
+
+def load_cases(manifest_path: Path) -> list[EvalCase]:
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    cases: list[EvalCase] = []
+    for entry in data.get("evals", []):
+        cases.append(
+            EvalCase(
+                id=entry["id"],
+                prompt=entry["prompt"],
+                expected_output=entry["expected_output"],
+                assertions=entry.get("assertions", []),
+                files=entry.get("files", []),
+            )
+        )
+    return cases
+
+
+def resolve_skill_path(manifest_path: Path) -> Path:
+    return manifest_path.parent.parent
+
+
+def build_adapter(args: argparse.Namespace) -> HarnessAdapter:
+    if args.adapter == "fake":
+        return FakeAdapter()
+    if args.adapter == "cli":
+        if not args.command:
+            print("error: --command required for cli adapter", file=sys.stderr)
+            raise SystemExit(2)
+        import shlex
+
+        command = shlex.split(args.command)
+        return CliSubprocessAdapter(
+            command,
+            prompt_mode=args.prompt_mode,
+            prompt_flag=args.prompt_flag,
+            timeout_seconds=args.timeout,
+            extra_args=args.extra_args.split() if args.extra_args else [],
+        )
+    print(f"error: unknown adapter '{args.adapter}'", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def run_trial(
+    adapter: HarnessAdapter,
+    case: EvalCase,
+    skill_path: Path,
+    output_dir: Path,
+    model: str,
+) -> Path:
+    work_dir = output_dir / "work" / case.id
+    case_output_dir = output_dir / "trials" / case.id
+
+    adapter_input = AdapterInput(
+        skill_path=skill_path,
+        case=case,
+        work_dir=work_dir,
+        output_dir=case_output_dir,
+        model=model,
+        limits={"timeout_seconds": 120, "network_policy": "unspecified"},
+    )
+
+    started_at = datetime.now(timezone.utc)
+    result = adapter.execute(adapter_input)
+    finished_at = datetime.now(timezone.utc)
+
+    manifest = build_manifest(
+        adapter_name=adapter.name,
+        adapter_version=adapter.version,
+        harness_name=adapter.name,
+        harness_version=adapter.version,
+        model_provider="unspecified" if not model else model.split("/")[0],
+        model_id=model or "unspecified",
+        adapter_input=adapter_input,
+        adapter_output=result,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+
+    return write_manifest(manifest, output_dir / "manifests")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="eval-runner",
+        description="Run eval cases against a candidate skill via a harness adapter.",
+    )
+    parser.add_argument(
+        "manifest",
+        type=Path,
+        help="path to an evals.json manifest",
+    )
+    parser.add_argument(
+        "--adapter",
+        choices=["fake", "cli"],
+        default="fake",
+        help="adapter to use (default: fake)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("eval-output"),
+        help="directory for run artifacts (default: eval-output)",
+    )
+    parser.add_argument(
+        "--model",
+        default="",
+        help="model identifier (e.g. anthropic/claude-sonnet-4-20250514)",
+    )
+    parser.add_argument(
+        "--case",
+        dest="case_id",
+        default=None,
+        help="run only this case ID",
+    )
+    parser.add_argument("--command", default=None, help="CLI command for cli adapter")
+    parser.add_argument("--prompt-mode", default="stdin", choices=["stdin", "arg"])
+    parser.add_argument("--prompt-flag", default="--prompt")
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--extra-args", default=None)
+    args = parser.parse_args()
+
+    manifest_path = args.manifest.resolve()
+    if not manifest_path.is_file():
+        print(f"error: manifest not found: {manifest_path}", file=sys.stderr)
+        return 2
+
+    cases = load_cases(manifest_path)
+    if not cases:
+        print(f"error: no cases found in {manifest_path}", file=sys.stderr)
+        return 2
+
+    if args.case_id:
+        cases = [c for c in cases if c.id == args.case_id]
+        if not cases:
+            print(f"error: case '{args.case_id}' not found", file=sys.stderr)
+            return 2
+
+    skill_path = resolve_skill_path(manifest_path)
+    adapter = build_adapter(args)
+    output_dir = args.output_dir.resolve()
+
+    print(f"adapter: {adapter.name} v{adapter.version}")
+    print(f"skill:   {skill_path.name}")
+    print(f"cases:   {len(cases)}")
+    print(f"output:  {output_dir}")
+    print()
+
+    failures = 0
+    for case in cases:
+        print(f"  [{case.id}] running...", end=" ", flush=True)
+        manifest_file = run_trial(adapter, case, skill_path, output_dir, args.model)
+        status = json.loads(manifest_file.read_text(encoding="utf-8"))["status"]
+        if status == "completed":
+            print(f"ok -> {manifest_file.name}")
+        else:
+            print(f"{status} -> {manifest_file.name}")
+            failures += 1
+
+    print()
+    print(f"done: {len(cases)} trial(s), {failures} failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval_runner/tests/test_runner.py
+++ b/eval_runner/tests/test_runner.py
@@ -1,0 +1,202 @@
+"""Tests for the eval runner using the fake adapter."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from eval_runner import models as models
+from eval_runner import fake_adapter as fake_adapter_mod
+from eval_runner import manifest as manifest_mod
+
+EvalCase = models.EvalCase
+AdapterInput = models.AdapterInput
+AdapterOutput = models.AdapterOutput
+ExitStatus = models.ExitStatus
+FakeAdapter = fake_adapter_mod.FakeAdapter
+build_manifest = manifest_mod.build_manifest
+write_manifest = manifest_mod.write_manifest
+
+from datetime import datetime, timezone
+
+
+def _make_case() -> EvalCase:
+    return EvalCase(
+        id="test-case-01",
+        prompt="Do the thing",
+        expected_output="The thing is done",
+        assertions=["assertion one", "assertion two"],
+        files=[],
+    )
+
+
+def _make_skill_dir(tmp: Path) -> Path:
+    skill = tmp / "test-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: test-skill\n---\n# Test\n")
+    evals_dir = skill / "evals"
+    evals_dir.mkdir()
+    manifest = {
+        "schema_version": 1,
+        "skill_name": "test-skill",
+        "evals": [
+            {
+                "id": "test-case-01",
+                "prompt": "Do the thing",
+                "expected_output": "The thing is done",
+                "assertions": ["assertion one", "assertion two"],
+            }
+        ],
+    }
+    (evals_dir / "evals.json").write_text(json.dumps(manifest, indent=2))
+    return skill
+
+
+def test_fake_adapter_returns_completed():
+    adapter = FakeAdapter()
+    assert adapter.name == "fake"
+    assert adapter.version == "0.1.0"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        skill = _make_skill_dir(tmp_path)
+        case = _make_case()
+
+        adapter_input = AdapterInput(
+            skill_path=skill,
+            case=case,
+            work_dir=tmp_path / "work",
+            output_dir=tmp_path / "output",
+        )
+
+        result = adapter.execute(adapter_input)
+        assert result.exit_status == ExitStatus.COMPLETED
+        assert result.response is not None
+        assert "test-case-01" in result.response
+        assert result.activation_evidence is not None
+        assert len(result.tool_events) == 3  # 1 read + 2 assertions
+        assert result.error is None
+        assert result.duration_ms >= 0
+
+
+def test_fake_adapter_missing_evidence():
+    result = AdapterOutput(exit_status=ExitStatus.COMPLETED)
+    missing = result.missing_evidence()
+    assert "response" in missing
+    assert "activation_evidence" in missing
+    assert "token_usage" in missing
+    assert "tool_events" in missing
+
+
+def test_manifest_serialization():
+    adapter = FakeAdapter()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        skill = _make_skill_dir(tmp_path)
+        case = _make_case()
+
+        adapter_input = AdapterInput(
+            skill_path=skill,
+            case=case,
+            work_dir=tmp_path / "work",
+            output_dir=tmp_path / "output",
+        )
+
+        result = adapter.execute(adapter_input)
+        now = datetime.now(timezone.utc)
+
+        manifest = build_manifest(
+            adapter_name=adapter.name,
+            adapter_version=adapter.version,
+            harness_name=adapter.name,
+            harness_version=adapter.version,
+            model_provider="fake",
+            model_id="fake-model",
+            adapter_input=adapter_input,
+            adapter_output=result,
+            started_at=now,
+            finished_at=now,
+        )
+
+        assert manifest["schema_version"] == 1
+        assert manifest["candidate"]["skill_name"] == "test-skill"
+        assert manifest["case"]["case_id"] == "test-case-01"
+        assert manifest["status"] == "completed"
+        assert manifest["adapter"]["name"] == "fake"
+        assert isinstance(manifest["missing_evidence"], list)
+
+        manifest_path = write_manifest(manifest, tmp_path / "manifests")
+        assert manifest_path.is_file()
+
+        loaded = json.loads(manifest_path.read_text())
+        assert loaded["trial_id"] == manifest["trial_id"]
+
+
+def test_manifest_validates_against_schema():
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        print("SKIP: jsonschema not installed")
+        return
+
+    schema_path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "schemas"
+        / "run-manifest-v1.schema.json"
+    )
+    schema = json.loads(schema_path.read_text())
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+
+    adapter = FakeAdapter()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        skill = _make_skill_dir(tmp_path)
+        case = _make_case()
+
+        adapter_input = AdapterInput(
+            skill_path=skill,
+            case=case,
+            work_dir=tmp_path / "work",
+            output_dir=tmp_path / "output",
+        )
+
+        result = adapter.execute(adapter_input)
+        now = datetime.now(timezone.utc)
+
+        manifest = build_manifest(
+            adapter_name=adapter.name,
+            adapter_version=adapter.version,
+            harness_name=adapter.name,
+            harness_version=adapter.version,
+            model_provider="fake",
+            model_id="fake-model",
+            adapter_input=adapter_input,
+            adapter_output=result,
+            started_at=now,
+            finished_at=now,
+        )
+
+        errors = list(validator.iter_errors(manifest))
+        assert not errors, f"Schema validation failed: {[e.message for e in errors]}"
+
+
+def test_eval_case_prompt_hash_deterministic():
+    case = _make_case()
+    assert case.prompt_hash == case.prompt_hash
+    assert len(case.prompt_hash) == 16
+
+
+if __name__ == "__main__":
+    test_fake_adapter_returns_completed()
+    test_fake_adapter_missing_evidence()
+    test_manifest_serialization()
+    test_manifest_validates_against_schema()
+    test_eval_case_prompt_hash_deterministic()
+    print("All tests passed.")

--- a/schemas/run-manifest-v1.schema.json
+++ b/schemas/run-manifest-v1.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/magnus919/agent-skills/schemas/run-manifest-v1.schema.json",
+  "title": "Eval run manifest v1",
+  "description": "Machine-readable record binding a single eval trial to its inputs, outputs, and execution context.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trial_id",
+    "candidate",
+    "case",
+    "adapter",
+    "harness",
+    "model",
+    "permissions",
+    "network_policy",
+    "limits",
+    "cache_state",
+    "started_at",
+    "finished_at",
+    "status",
+    "outputs",
+    "duration_ms",
+    "failures",
+    "missing_evidence"
+  ],
+  "properties": {
+    "schema_version": {"type": "integer", "const": 1},
+    "trial_id": {"type": "string", "format": "uuid"},
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["skill_name", "skill_path", "tree_hash"],
+      "properties": {
+        "skill_name": {"type": "string", "minLength": 1},
+        "skill_path": {"type": "string", "minLength": 1},
+        "tree_hash": {"type": "string", "minLength": 1}
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["case_id", "prompt_hash", "fixture_hashes"],
+      "properties": {
+        "case_id": {"type": "string", "minLength": 1},
+        "prompt_hash": {"type": "string", "minLength": 1},
+        "fixture_hashes": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        }
+      }
+    },
+    "adapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1}
+      }
+    },
+    "harness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1}
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "model_id"],
+      "properties": {
+        "provider": {"type": "string"},
+        "model_id": {"type": "string"}
+      }
+    },
+    "permissions": {"type": "object"},
+    "network_policy": {"type": "string"},
+    "limits": {"type": "object"},
+    "cache_state": {"type": "string"},
+    "started_at": {"type": "string", "format": "date-time"},
+    "finished_at": {"type": "string", "format": "date-time"},
+    "status": {
+      "type": "string",
+      "enum": ["completed", "error", "timeout", "stopped"]
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["response", "activation_evidence", "artifact_digests", "tool_event_count"],
+      "properties": {
+        "response": {"type": ["string", "null"]},
+        "activation_evidence": {"type": ["string", "null"]},
+        "artifact_digests": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "tool_event_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "duration_ms": {"type": "number", "minimum": 0},
+    "token_usage": {
+      "type": ["object", "null"],
+      "properties": {
+        "input_tokens": {"type": "integer"},
+        "output_tokens": {"type": "integer"}
+      }
+    },
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type", "message"],
+        "properties": {
+          "type": {"type": "string"},
+          "message": {"type": "string"}
+        }
+      }
+    },
+    "missing_evidence": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  }
+}


### PR DESCRIPTION
Implements #104.

## Summary

Adds a repository-level evaluation runner with a typed harness adapter interface and reproducible run artifacts.

## What's included

- **`eval_runner/adapter.py`** — `HarnessAdapter` Protocol defining the typed contract
- **`eval_runner/models.py`** — `EvalCase`, `AdapterInput`, `AdapterOutput`, `ToolEvent`, `ExitStatus`
- **`eval_runner/fake_adapter.py`** — Deterministic adapter for CI (no model credentials)
- **`eval_runner/cli_adapter.py`** — Subprocess adapter for any non-interactive CLI agent
- **`eval_runner/manifest.py`** — Run manifest builder + writer
- **`eval_runner/runner.py`** — CLI entry point (`python3 -m eval_runner`)
- **`schemas/run-manifest-v1.schema.json`** — JSON Schema for trial manifests
- **`eval_runner/tests/test_runner.py`** — Unit tests including schema validation

## Acceptance criteria

- [x] Documented adapter interface with typed inputs/outputs
- [x] One non-interactive harness adapter executes a case end to end
- [x] Fake adapter provides deterministic unit and CI coverage without credentials
- [x] Every trial writes a reproducible run manifest; failures preserved
- [x] Missing telemetry fields explicit, never fabricated
- [x] No candidate-versus-baseline policy (single-arm runner only)

## Usage

```sh
# Fake adapter (CI, no credentials)
python3 -m eval_runner <skill>/evals/evals.json --adapter fake --output-dir out/

# Real CLI adapter
python3 -m eval_runner <skill>/evals/evals.json --adapter cli --command "opencode --print" --output-dir out/
```