### PR TITLE
test(raleigh): fix arrivals service date

### DIFF
--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -618,7 +618,8 @@ class TransitTests(unittest.TestCase):
     def test_get_arrivals_for_stop(self):
         data = self._make_gtfs_zip()
         feed = transit.parse_gtfs_zip(data)
-        arrivals = transit.get_arrivals_for_stop("S2", feed=feed)
+        with patch("raleighlib.transit._today_date", return_value="20260723"):
+            arrivals = transit.get_arrivals_for_stop("S2", feed=feed)
         self.assertEqual(len(arrivals), 2)
 
     def test_enrich_realtime_with_static(self):


### PR DESCRIPTION
## Summary

Make the transit arrivals fixture deterministic by fixing its service date to the same known weekday used by the adjacent route-schedule test.

Fixes #134

## Verification

- Reproduced the failure under `TZ=UTC` before the change.
- Targeted test passes under both `TZ=UTC` and `TZ=Pacific/Auckland`.
- `python3 scripts/check-artifacts.py` passes all tracked artifact checks and 190 Raleigh tests.

AI assistance was used for diagnosis, implementation, and verification.
