### PR TITLE
feat: add release-grade repeated and rubric-based skill evaluation

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -8,6 +8,7 @@ on:
       - '*/scripts/**'
       - 'eval_runner/**'
       - 'schemas/comparison-report-v1.schema.json'
+      - 'schemas/release-eval-v1.schema.json'
   push:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
       - '*/scripts/**'
       - 'eval_runner/**'
       - 'schemas/comparison-report-v1.schema.json'
+      - 'schemas/release-eval-v1.schema.json'
 
 permissions:
   contents: read
@@ -37,6 +39,8 @@ jobs:
         run: python3 -m pip install -r requirements-dev.txt
       - name: Run paired evaluation unit tests
         run: python3 eval_runner/tests/test_paired.py
+      - name: Run release evaluation unit tests
+        run: python3 eval_runner/tests/test_release.py
       - name: Run existing eval runner tests
         run: python3 eval_runner/tests/test_runner.py
 

--- a/eval_runner/models.py
+++ b/eval_runner/models.py
@@ -23,6 +23,7 @@ class EvalCase:
     expected_output: str
     assertions: list[str]
     files: list[str] = field(default_factory=list)
+    case_set: str = "dev"
 
     @property
     def prompt_hash(self) -> str:

--- a/eval_runner/release.py
+++ b/eval_runner/release.py
@@ -1,0 +1,501 @@
+"""Release-grade evaluation: repeated trials, rubric graders, and release matrix.
+
+Builds on the deterministic paired evaluation infrastructure to add:
+- Multi-trial aggregation per case (success frequency, consistency)
+- Versioned rubric graders with abstain/insufficient-evidence
+- Blinded pairwise comparison with position randomization and order-reversal
+- Human calibration tracking with disagreement slices
+- Case set separation (dev, regression, release)
+- Freeze snapshot validation
+- Release decision: PASS, CONDITIONAL, HOLD, BLOCK
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+RELEASE_SCHEMA_VERSION = 1
+
+CASE_SETS = ("dev", "regression", "release")
+
+RELEASE_OUTCOMES = ("PASS", "CONDITIONAL", "HOLD", "BLOCK")
+
+
+@dataclass(frozen=True)
+class FreezeSnapshot:
+    candidate_tree_hash: str
+    baseline_tree_hash: str
+    dataset_hash: str
+    grader_versions: dict[str, str]
+    randomization_seed: int
+    exclusions: tuple[str, ...] = ()
+    frozen_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_tree_hash": self.candidate_tree_hash,
+            "baseline_tree_hash": self.baseline_tree_hash,
+            "dataset_hash": self.dataset_hash,
+            "grader_versions": dict(self.grader_versions),
+            "randomization_seed": self.randomization_seed,
+            "exclusions": list(self.exclusions),
+            "frozen_at": self.frozen_at or datetime.now(timezone.utc).isoformat(),
+        }
+
+    @property
+    def complete(self) -> bool:
+        return bool(
+            self.candidate_tree_hash
+            and self.baseline_tree_hash
+            and self.dataset_hash
+            and self.grader_versions
+        )
+
+
+@dataclass
+class TrialRecord:
+    trial_id: str
+    case_id: str
+    status: str
+    passed: bool
+    missing_evidence: list[str] = field(default_factory=list)
+
+
+@dataclass
+class CaseAggregation:
+    case_id: str
+    case_set: str
+    trials: list[TrialRecord] = field(default_factory=list)
+
+    @property
+    def trial_count(self) -> int:
+        return len(self.trials)
+
+    @property
+    def success_count(self) -> int:
+        return sum(1 for t in self.trials if t.status == "completed" and t.passed)
+
+    @property
+    def failure_count(self) -> int:
+        return sum(1 for t in self.trials if t.status == "completed" and not t.passed)
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for t in self.trials if t.status == "error")
+
+    @property
+    def timeout_count(self) -> int:
+        return sum(1 for t in self.trials if t.status == "timeout")
+
+    @property
+    def success_frequency(self) -> float:
+        if not self.trials:
+            return 0.0
+        return self.success_count / self.trial_count
+
+    @property
+    def consistent(self) -> bool:
+        completed = [t for t in self.trials if t.status == "completed"]
+        if not completed:
+            return False
+        first = completed[0].passed
+        return all(t.passed == first for t in completed)
+
+    @property
+    def all_missing_evidence(self) -> list[str]:
+        seen: set[str] = set()
+        result: list[str] = []
+        for t in self.trials:
+            for m in t.missing_evidence:
+                if m not in seen:
+                    seen.add(m)
+                    result.append(m)
+        return result
+
+    def to_dict(self, paired_delta: str = "insufficient_data") -> dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "case_set": self.case_set,
+            "trial_count": self.trial_count,
+            "success_count": self.success_count,
+            "failure_count": self.failure_count,
+            "error_count": self.error_count,
+            "timeout_count": self.timeout_count,
+            "success_frequency": round(self.success_frequency, 4),
+            "consistent": self.consistent,
+            "missing_evidence": self.all_missing_evidence,
+            "paired_delta": paired_delta,
+        }
+
+
+def aggregate_trials(
+    manifests: list[dict[str, Any]],
+    case_sets: dict[str, str] | None = None,
+) -> list[CaseAggregation]:
+    """Group run manifests by case_id and aggregate trial outcomes."""
+    by_case: dict[str, list[TrialRecord]] = {}
+    for m in manifests:
+        case_id = m.get("case", {}).get("case_id", "")
+        if not case_id:
+            continue
+        trial = TrialRecord(
+            trial_id=m.get("trial_id", ""),
+            case_id=case_id,
+            status=m.get("status", "error"),
+            passed=_manifest_passed(m),
+            missing_evidence=m.get("missing_evidence", []),
+        )
+        by_case.setdefault(case_id, []).append(trial)
+
+    results = []
+    for case_id, trials in sorted(by_case.items()):
+        case_set = "dev"
+        if case_sets and case_id in case_sets:
+            case_set = case_sets[case_id]
+        results.append(CaseAggregation(case_id=case_id, case_set=case_set, trials=trials))
+    return results
+
+
+def _manifest_passed(m: dict[str, Any]) -> bool:
+    if m.get("status") != "completed":
+        return False
+    failures = m.get("failures", [])
+    return len(failures) == 0
+
+
+@dataclass(frozen=True)
+class RubricGrader:
+    grader_id: str
+    version: str
+    criteria: tuple[str, ...]
+
+    def grade(
+        self,
+        response: str | None,
+        expected: str,
+        *,
+        blinded: bool = True,
+    ) -> dict[str, Any]:
+        if response is None:
+            return self._result("insufficient_evidence", {}, "no response to evaluate", blinded)
+        if not response.strip():
+            return self._result("abstain", {}, "empty response; cannot judge quality", blinded)
+        scores: dict[str, float] = {}
+        for criterion in self.criteria:
+            scores[criterion] = self._score_criterion(criterion, response, expected)
+        avg = sum(scores.values()) / len(scores) if scores else 0.0
+        if avg >= 0.7:
+            verdict = "pass"
+        elif avg >= 0.4:
+            verdict = "fail"
+        else:
+            verdict = "fail"
+        rationale = f"mean score {avg:.2f} across {len(self.criteria)} criteria"
+        return self._result(verdict, scores, rationale, blinded)
+
+    def _score_criterion(self, criterion: str, response: str, expected: str) -> float:
+        response_lower = response.lower()
+        expected_lower = expected.lower()
+        expected_tokens = set(expected_lower.split())
+        response_tokens = set(response_lower.split())
+        if not expected_tokens:
+            return 0.5
+        overlap = len(expected_tokens & response_tokens) / len(expected_tokens)
+        return min(1.0, overlap)
+
+    def _result(
+        self,
+        verdict: str,
+        scores: dict[str, float],
+        rationale: str,
+        blinded: bool,
+    ) -> dict[str, Any]:
+        return {
+            "grader_id": self.grader_id,
+            "grader_version": self.version,
+            "blinded": blinded,
+            "verdict": verdict,
+            "scores": scores,
+            "rationale": rationale,
+        }
+
+
+def apply_rubric(
+    grader: RubricGrader,
+    case_id: str,
+    response: str | None,
+    expected: str,
+    *,
+    blinded: bool = True,
+) -> dict[str, Any]:
+    result = grader.grade(response, expected, blinded=blinded)
+    result["case_id"] = case_id
+    return result
+
+
+@dataclass(frozen=True)
+class PairwisePlan:
+    case_id: str
+    position_a: str
+    position_b: str
+    seed: int
+
+    @property
+    def reversed(self) -> "PairwisePlan":
+        return PairwisePlan(
+            case_id=self.case_id,
+            position_a=self.position_b,
+            position_b=self.position_a,
+            seed=self.seed,
+        )
+
+
+def plan_pairwise(case_ids: list[str], seed: int) -> list[PairwisePlan]:
+    """Assign randomized A/B positions for each case, blinded to identity."""
+    rng = random.Random(seed)
+    plans = []
+    for case_id in case_ids:
+        if rng.random() < 0.5:
+            plans.append(PairwisePlan(case_id, "candidate", "baseline", seed))
+        else:
+            plans.append(PairwisePlan(case_id, "baseline", "candidate", seed))
+    return plans
+
+
+def evaluate_pairwise(
+    plan: PairwisePlan,
+    response_a: str | None,
+    response_b: str | None,
+    expected: str,
+    *,
+    judge: RubricGrader | None = None,
+) -> dict[str, Any]:
+    """Compare two responses under a blinded pairwise plan."""
+    if judge is None:
+        judge = RubricGrader("default-pairwise", "1", ("relevance", "completeness"))
+
+    grade_a = judge.grade(response_a, expected, blinded=True)
+    grade_b = judge.grade(response_b, expected, blinded=True)
+
+    score_a = _mean_score(grade_a)
+    score_b = _mean_score(grade_b)
+
+    if grade_a["verdict"] == "abstain" or grade_b["verdict"] == "abstain":
+        winner = "abstain"
+    elif grade_a["verdict"] == "insufficient_evidence" or grade_b["verdict"] == "insufficient_evidence":
+        winner = "abstain"
+    elif abs(score_a - score_b) < 0.05:
+        winner = "tie"
+    elif score_a > score_b:
+        winner = "a"
+    else:
+        winner = "b"
+
+    reversed_plan = plan.reversed
+    grade_rev_a = judge.grade(response_b, expected, blinded=True)
+    grade_rev_b = judge.grade(response_a, expected, blinded=True)
+    score_rev_a = _mean_score(grade_rev_a)
+    score_rev_b = _mean_score(grade_rev_b)
+
+    if abs(score_rev_a - score_rev_b) < 0.05:
+        rev_winner = "tie"
+    elif score_rev_a > score_rev_b:
+        rev_winner = "a"
+    else:
+        rev_winner = "b"
+
+    order_consistent = _winners_consistent(winner, rev_winner)
+
+    return {
+        "case_id": plan.case_id,
+        "position_a": plan.position_a,
+        "position_b": plan.position_b,
+        "winner": winner,
+        "order_reversal_tested": True,
+        "order_reversal_consistent": order_consistent,
+    }
+
+
+def _mean_score(grade: dict[str, Any]) -> float:
+    scores = grade.get("scores", {})
+    if not scores:
+        return 0.0
+    return sum(scores.values()) / len(scores)
+
+
+def _winners_consistent(forward: str, reversed_result: str) -> bool | None:
+    if forward == "abstain" or reversed_result == "abstain":
+        return None
+    if forward == "tie" and reversed_result == "tie":
+        return True
+    if forward == "tie" or reversed_result == "tie":
+        return False
+    return forward == reversed_result
+
+
+@dataclass
+class CalibrationRecord:
+    human_sample_count: int = 0
+    judge_agreement_rate: float | None = None
+    disagreement_slices: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def calibrated(self) -> bool:
+        return (
+            self.human_sample_count > 0
+            and self.judge_agreement_rate is not None
+            and self.judge_agreement_rate >= 0.7
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "human_sample_count": self.human_sample_count,
+            "judge_agreement_rate": self.judge_agreement_rate,
+            "disagreement_slices": self.disagreement_slices,
+            "calibrated": self.calibrated,
+        }
+
+
+def compute_release_decision(
+    case_results: list[dict[str, Any]],
+    rubric_results: list[dict[str, Any]],
+    calibration: CalibrationRecord,
+    hard_gate_violations: list[str] | None = None,
+) -> dict[str, Any]:
+    """Compute PASS, CONDITIONAL, HOLD, or BLOCK from the release matrix."""
+    violations = hard_gate_violations or []
+    reasons: list[str] = []
+
+    if violations:
+        return {
+            "outcome": "BLOCK",
+            "reasons": [f"hard gate violation: {v}" for v in violations],
+            "hard_gate_violations": violations,
+        }
+
+    release_cases = [c for c in case_results if c["case_set"] == "release"]
+    regression_cases = [c for c in case_results if c["case_set"] == "regression"]
+
+    missing_evidence_cases = [
+        c["case_id"] for c in case_results if c.get("missing_evidence")
+    ]
+    if missing_evidence_cases:
+        reasons.append(
+            f"missing evidence in cases: {', '.join(missing_evidence_cases)}"
+        )
+        return {
+            "outcome": "HOLD",
+            "reasons": reasons,
+            "hard_gate_violations": [],
+        }
+
+    inconsistent = [c["case_id"] for c in case_results if not c["consistent"]]
+    low_frequency = [
+        c["case_id"]
+        for c in release_cases
+        if c["success_frequency"] < 0.8
+    ]
+
+    rubric_abstains = [
+        r["case_id"]
+        for r in rubric_results
+        if r["verdict"] in ("abstain", "insufficient_evidence")
+    ]
+
+    uncalibrated_advisory = not calibration.calibrated
+
+    if low_frequency:
+        reasons.append(
+            f"release cases below 80% success: {', '.join(low_frequency)}"
+        )
+        return {
+            "outcome": "BLOCK",
+            "reasons": reasons,
+            "hard_gate_violations": [],
+        }
+
+    regressions = [
+        c["case_id"]
+        for c in regression_cases
+        if c["paired_delta"] == "candidate_regression"
+    ]
+    if regressions:
+        reasons.append(f"regressions detected: {', '.join(regressions)}")
+        return {
+            "outcome": "BLOCK",
+            "reasons": reasons,
+            "hard_gate_violations": [],
+        }
+
+    conditional = False
+    if inconsistent:
+        reasons.append(f"inconsistent cases: {', '.join(inconsistent)}")
+        conditional = True
+    if rubric_abstains:
+        reasons.append(f"rubric abstained on: {', '.join(rubric_abstains)}")
+        conditional = True
+    if uncalibrated_advisory:
+        reasons.append("judge not calibrated against human labels; rubric results advisory only")
+        conditional = True
+
+    if conditional:
+        return {
+            "outcome": "CONDITIONAL",
+            "reasons": reasons,
+            "hard_gate_violations": [],
+        }
+
+    if not reasons:
+        reasons.append("all gates satisfied")
+
+    return {
+        "outcome": "PASS",
+        "reasons": reasons,
+        "hard_gate_violations": [],
+    }
+
+
+def build_release_report(
+    *,
+    skill_name: str,
+    freeze: FreezeSnapshot,
+    case_results: list[dict[str, Any]],
+    rubric_results: list[dict[str, Any]],
+    pairwise_results: list[dict[str, Any]],
+    calibration: CalibrationRecord,
+    hard_gate_violations: list[str] | None = None,
+) -> dict[str, Any]:
+    decision = compute_release_decision(
+        case_results, rubric_results, calibration, hard_gate_violations
+    )
+    return {
+        "schema_version": RELEASE_SCHEMA_VERSION,
+        "report_id": str(uuid.uuid4()),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "skill_name": skill_name,
+        "freeze_snapshot": freeze.to_dict(),
+        "case_results": case_results,
+        "rubric_results": rubric_results,
+        "pairwise_results": pairwise_results,
+        "calibration": calibration.to_dict(),
+        "release_decision": decision,
+    }
+
+
+def write_release_report(report: dict[str, Any], output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"{report['skill_name']}--release-report.json"
+    path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def dataset_hash(manifest_path: Path) -> str:
+    content = manifest_path.read_bytes()
+    return hashlib.sha256(content).hexdigest()[:16]

--- a/eval_runner/runner.py
+++ b/eval_runner/runner.py
@@ -26,6 +26,7 @@ def load_cases(manifest_path: Path) -> list[EvalCase]:
                 expected_output=entry["expected_output"],
                 assertions=entry.get("assertions", []),
                 files=entry.get("files", []),
+                case_set=entry.get("case_set", "dev"),
             )
         )
     return cases

--- a/eval_runner/tests/test_release.py
+++ b/eval_runner/tests/test_release.py
@@ -1,0 +1,468 @@
+"""Tests for release-grade evaluation: trials, rubric, pairwise, release matrix."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from eval_runner.release import (
+    CalibrationRecord,
+    CaseAggregation,
+    FreezeSnapshot,
+    RubricGrader,
+    TrialRecord,
+    aggregate_trials,
+    apply_rubric,
+    build_release_report,
+    compute_release_decision,
+    dataset_hash,
+    evaluate_pairwise,
+    plan_pairwise,
+    write_release_report,
+)
+
+
+def _trial(case_id: str, status: str = "completed", passed: bool = True, missing: list[str] | None = None) -> dict:
+    return {
+        "trial_id": f"t-{case_id}-{status}",
+        "case": {"case_id": case_id, "prompt_hash": "abc", "fixture_hashes": {}},
+        "status": status,
+        "failures": [] if passed and status == "completed" else [{"type": "assertion", "message": "fail"}],
+        "missing_evidence": missing or [],
+    }
+
+
+def test_aggregate_trials_groups_by_case():
+    manifests = [
+        _trial("case-a", passed=True),
+        _trial("case-a", passed=False),
+        _trial("case-b", passed=True),
+    ]
+    results = aggregate_trials(manifests)
+    assert len(results) == 2
+    case_a = next(r for r in results if r.case_id == "case-a")
+    assert case_a.trial_count == 2
+    assert case_a.success_count == 1
+    assert case_a.failure_count == 1
+    assert case_a.success_frequency == 0.5
+    assert not case_a.consistent
+
+
+def test_aggregate_trials_consistency():
+    manifests = [_trial("c1", passed=True), _trial("c1", passed=True), _trial("c1", passed=True)]
+    results = aggregate_trials(manifests)
+    assert results[0].consistent
+    assert results[0].success_frequency == 1.0
+
+
+def test_aggregate_trials_counts_errors_and_timeouts():
+    manifests = [
+        _trial("c1", status="completed", passed=True),
+        _trial("c1", status="error", passed=False),
+        _trial("c1", status="timeout", passed=False),
+    ]
+    results = aggregate_trials(manifests)
+    agg = results[0]
+    assert agg.success_count == 1
+    assert agg.error_count == 1
+    assert agg.timeout_count == 1
+    assert agg.trial_count == 3
+
+
+def test_aggregate_trials_preserves_all_failures():
+    manifests = [
+        _trial("c1", passed=False),
+        _trial("c1", passed=False),
+        _trial("c1", status="error", passed=False),
+    ]
+    results = aggregate_trials(manifests)
+    agg = results[0]
+    assert agg.failure_count == 2
+    assert agg.error_count == 1
+    assert agg.success_count == 0
+
+
+def test_aggregate_trials_missing_evidence():
+    manifests = [
+        _trial("c1", passed=True, missing=["response"]),
+        _trial("c1", passed=True, missing=["token_usage"]),
+    ]
+    results = aggregate_trials(manifests)
+    assert set(results[0].all_missing_evidence) == {"response", "token_usage"}
+
+
+def test_aggregate_trials_case_sets():
+    manifests = [_trial("c1"), _trial("c2")]
+    results = aggregate_trials(manifests, case_sets={"c1": "release", "c2": "regression"})
+    assert results[0].case_set == "release"
+    assert results[1].case_set == "regression"
+
+
+def test_case_aggregation_to_dict():
+    agg = CaseAggregation(
+        case_id="c1",
+        case_set="release",
+        trials=[
+            TrialRecord("t1", "c1", "completed", True),
+            TrialRecord("t2", "c1", "completed", True),
+        ],
+    )
+    d = agg.to_dict(paired_delta="both_pass")
+    assert d["case_id"] == "c1"
+    assert d["case_set"] == "release"
+    assert d["trial_count"] == 2
+    assert d["success_frequency"] == 1.0
+    assert d["consistent"] is True
+    assert d["paired_delta"] == "both_pass"
+
+
+def test_rubric_grader_pass():
+    grader = RubricGrader("test-grader", "1.0", ("relevance", "completeness"))
+    result = grader.grade("the expected output is here and complete", "expected output is here and complete")
+    assert result["verdict"] == "pass"
+    assert result["grader_id"] == "test-grader"
+    assert result["grader_version"] == "1.0"
+    assert result["blinded"] is True
+
+
+def test_rubric_grader_abstain_on_empty():
+    grader = RubricGrader("test-grader", "1.0", ("relevance",))
+    result = grader.grade("   ", "expected")
+    assert result["verdict"] == "abstain"
+
+
+def test_rubric_grader_insufficient_evidence_on_none():
+    grader = RubricGrader("test-grader", "1.0", ("relevance",))
+    result = grader.grade(None, "expected")
+    assert result["verdict"] == "insufficient_evidence"
+
+
+def test_rubric_grader_versioned():
+    g1 = RubricGrader("g", "1.0", ("relevance",))
+    g2 = RubricGrader("g", "2.0", ("relevance",))
+    r1 = g1.grade("hello world", "hello world")
+    r2 = g2.grade("hello world", "hello world")
+    assert r1["grader_version"] == "1.0"
+    assert r2["grader_version"] == "2.0"
+
+
+def test_apply_rubric_adds_case_id():
+    grader = RubricGrader("g", "1", ("relevance",))
+    result = apply_rubric(grader, "case-42", "response text", "expected text")
+    assert result["case_id"] == "case-42"
+
+
+def test_plan_pairwise_deterministic():
+    plans1 = plan_pairwise(["c1", "c2", "c3"], seed=42)
+    plans2 = plan_pairwise(["c1", "c2", "c3"], seed=42)
+    assert [(p.case_id, p.position_a) for p in plans1] == [(p.case_id, p.position_a) for p in plans2]
+
+
+def test_plan_pairwise_blinded_positions():
+    plans = plan_pairwise(["c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8"], seed=99)
+    positions = [p.position_a for p in plans]
+    assert "candidate" in positions
+    assert "baseline" in positions
+
+
+def test_plan_pairwise_reversal():
+    plan = plan_pairwise(["c1"], seed=1)[0]
+    rev = plan.reversed
+    assert rev.position_a == plan.position_b
+    assert rev.position_b == plan.position_a
+
+
+def test_evaluate_pairwise_order_reversal():
+    plan = plan_pairwise(["c1"], seed=7)[0]
+    result = evaluate_pairwise(
+        plan,
+        response_a="the complete expected answer with all details",
+        response_b="partial answer",
+        expected="the complete expected answer with all details",
+    )
+    assert result["order_reversal_tested"] is True
+    assert result["order_reversal_consistent"] is not None
+    assert result["case_id"] == "c1"
+
+
+def test_evaluate_pairwise_abstain_on_none():
+    plan = plan_pairwise(["c1"], seed=1)[0]
+    result = evaluate_pairwise(plan, response_a=None, response_b="something", expected="something")
+    assert result["winner"] == "abstain"
+
+
+def test_calibration_not_calibrated():
+    cal = CalibrationRecord()
+    assert not cal.calibrated
+    d = cal.to_dict()
+    assert d["calibrated"] is False
+
+
+def test_calibration_calibrated():
+    cal = CalibrationRecord(human_sample_count=50, judge_agreement_rate=0.85)
+    assert cal.calibrated
+    d = cal.to_dict()
+    assert d["calibrated"] is True
+    assert d["judge_agreement_rate"] == 0.85
+
+
+def test_calibration_low_agreement_not_calibrated():
+    cal = CalibrationRecord(human_sample_count=50, judge_agreement_rate=0.5)
+    assert not cal.calibrated
+
+
+def test_release_decision_pass():
+    cases = [
+        {"case_id": "c1", "case_set": "release", "success_frequency": 1.0, "consistent": True, "missing_evidence": [], "paired_delta": "both_pass"},
+    ]
+    cal = CalibrationRecord(human_sample_count=20, judge_agreement_rate=0.9)
+    decision = compute_release_decision(cases, [], cal)
+    assert decision["outcome"] == "PASS"
+
+
+def test_release_decision_block_on_hard_gate():
+    decision = compute_release_decision([], [], CalibrationRecord(), hard_gate_violations=["privacy violation"])
+    assert decision["outcome"] == "BLOCK"
+    assert "privacy violation" in decision["reasons"][0]
+
+
+def test_release_decision_hold_on_missing_evidence():
+    cases = [
+        {"case_id": "c1", "case_set": "release", "success_frequency": 1.0, "consistent": True, "missing_evidence": ["response"], "paired_delta": "both_pass"},
+    ]
+    decision = compute_release_decision(cases, [], CalibrationRecord())
+    assert decision["outcome"] == "HOLD"
+
+
+def test_release_decision_block_on_low_frequency():
+    cases = [
+        {"case_id": "c1", "case_set": "release", "success_frequency": 0.5, "consistent": False, "missing_evidence": [], "paired_delta": "both_pass"},
+    ]
+    cal = CalibrationRecord(human_sample_count=20, judge_agreement_rate=0.9)
+    decision = compute_release_decision(cases, [], cal)
+    assert decision["outcome"] == "BLOCK"
+
+
+def test_release_decision_block_on_regression():
+    cases = [
+        {"case_id": "c1", "case_set": "regression", "success_frequency": 1.0, "consistent": True, "missing_evidence": [], "paired_delta": "candidate_regression"},
+    ]
+    cal = CalibrationRecord(human_sample_count=20, judge_agreement_rate=0.9)
+    decision = compute_release_decision(cases, [], cal)
+    assert decision["outcome"] == "BLOCK"
+
+
+def test_release_decision_conditional_on_inconsistency():
+    cases = [
+        {"case_id": "c1", "case_set": "release", "success_frequency": 0.9, "consistent": False, "missing_evidence": [], "paired_delta": "both_pass"},
+    ]
+    cal = CalibrationRecord(human_sample_count=20, judge_agreement_rate=0.9)
+    decision = compute_release_decision(cases, [], cal)
+    assert decision["outcome"] == "CONDITIONAL"
+
+
+def test_release_decision_conditional_on_uncalibrated_judge():
+    cases = [
+        {"case_id": "c1", "case_set": "release", "success_frequency": 1.0, "consistent": True, "missing_evidence": [], "paired_delta": "both_pass"},
+    ]
+    rubric = [{"case_id": "c1", "verdict": "pass"}]
+    cal = CalibrationRecord()
+    decision = compute_release_decision(cases, rubric, cal)
+    assert decision["outcome"] == "CONDITIONAL"
+    assert any("advisory" in r for r in decision["reasons"])
+
+
+def test_release_decision_conditional_on_rubric_abstain():
+    cases = [
+        {"case_id": "c1", "case_set": "release", "success_frequency": 1.0, "consistent": True, "missing_evidence": [], "paired_delta": "both_pass"},
+    ]
+    rubric = [{"case_id": "c1", "verdict": "abstain"}]
+    cal = CalibrationRecord(human_sample_count=20, judge_agreement_rate=0.9)
+    decision = compute_release_decision(cases, rubric, cal)
+    assert decision["outcome"] == "CONDITIONAL"
+
+
+def test_freeze_snapshot_completeness():
+    freeze = FreezeSnapshot(
+        candidate_tree_hash="abc123",
+        baseline_tree_hash="def456",
+        dataset_hash="ghi789",
+        grader_versions={"default": "1.0"},
+        randomization_seed=42,
+    )
+    assert freeze.complete
+    d = freeze.to_dict()
+    assert d["candidate_tree_hash"] == "abc123"
+    assert d["randomization_seed"] == 42
+
+
+def test_freeze_snapshot_incomplete():
+    freeze = FreezeSnapshot(
+        candidate_tree_hash="",
+        baseline_tree_hash="def456",
+        dataset_hash="ghi789",
+        grader_versions={},
+        randomization_seed=42,
+    )
+    assert not freeze.complete
+
+
+def test_build_release_report_structure():
+    freeze = FreezeSnapshot("a", "b", "c", {"g": "1"}, 42)
+    cal = CalibrationRecord(human_sample_count=10, judge_agreement_rate=0.8)
+    report = build_release_report(
+        skill_name="test-skill",
+        freeze=freeze,
+        case_results=[],
+        rubric_results=[],
+        pairwise_results=[],
+        calibration=cal,
+    )
+    assert report["schema_version"] == 1
+    assert report["skill_name"] == "test-skill"
+    assert "report_id" in report
+    assert "generated_at" in report
+    assert report["release_decision"]["outcome"] in ("PASS", "CONDITIONAL", "HOLD", "BLOCK")
+
+
+def test_build_release_report_validates_against_schema():
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        print("SKIP: jsonschema not installed")
+        return
+
+    schema_path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "schemas"
+        / "release-eval-v1.schema.json"
+    )
+    schema = json.loads(schema_path.read_text())
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+
+    freeze = FreezeSnapshot("abc", "def", "ghi", {"default-pairwise": "1"}, 42)
+    cal = CalibrationRecord(human_sample_count=10, judge_agreement_rate=0.8)
+    case_results = [
+        {
+            "case_id": "c1",
+            "case_set": "release",
+            "trial_count": 3,
+            "success_count": 3,
+            "failure_count": 0,
+            "error_count": 0,
+            "timeout_count": 0,
+            "success_frequency": 1.0,
+            "consistent": True,
+            "missing_evidence": [],
+            "paired_delta": "both_pass",
+        }
+    ]
+    rubric_results = [
+        {
+            "case_id": "c1",
+            "grader_id": "default-pairwise",
+            "grader_version": "1",
+            "blinded": True,
+            "verdict": "pass",
+            "scores": {"relevance": 0.9},
+            "rationale": "good",
+        }
+    ]
+    pairwise_results = [
+        {
+            "case_id": "c1",
+            "position_a": "candidate",
+            "position_b": "baseline",
+            "winner": "a",
+            "order_reversal_tested": True,
+            "order_reversal_consistent": True,
+        }
+    ]
+
+    report = build_release_report(
+        skill_name="test-skill",
+        freeze=freeze,
+        case_results=case_results,
+        rubric_results=rubric_results,
+        pairwise_results=pairwise_results,
+        calibration=cal,
+    )
+
+    errors = list(validator.iter_errors(report))
+    assert not errors, f"Schema validation failed: {[e.message for e in errors]}"
+
+
+def test_write_release_report():
+    import tempfile
+
+    freeze = FreezeSnapshot("a", "b", "c", {"g": "1"}, 42)
+    cal = CalibrationRecord()
+    report = build_release_report(
+        skill_name="my-skill",
+        freeze=freeze,
+        case_results=[],
+        rubric_results=[],
+        pairwise_results=[],
+        calibration=cal,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write_release_report(report, Path(tmp))
+        assert path.is_file()
+        assert "my-skill" in path.name
+        loaded = json.loads(path.read_text())
+        assert loaded["schema_version"] == 1
+
+
+def test_dataset_hash_deterministic():
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write('{"evals": []}')
+        f.flush()
+        h1 = dataset_hash(Path(f.name))
+        h2 = dataset_hash(Path(f.name))
+        assert h1 == h2
+        assert len(h1) == 16
+    Path(f.name).unlink()
+
+
+if __name__ == "__main__":
+    test_aggregate_trials_groups_by_case()
+    test_aggregate_trials_consistency()
+    test_aggregate_trials_counts_errors_and_timeouts()
+    test_aggregate_trials_preserves_all_failures()
+    test_aggregate_trials_missing_evidence()
+    test_aggregate_trials_case_sets()
+    test_case_aggregation_to_dict()
+    test_rubric_grader_pass()
+    test_rubric_grader_abstain_on_empty()
+    test_rubric_grader_insufficient_evidence_on_none()
+    test_rubric_grader_versioned()
+    test_apply_rubric_adds_case_id()
+    test_plan_pairwise_deterministic()
+    test_plan_pairwise_blinded_positions()
+    test_plan_pairwise_reversal()
+    test_evaluate_pairwise_order_reversal()
+    test_evaluate_pairwise_abstain_on_none()
+    test_calibration_not_calibrated()
+    test_calibration_calibrated()
+    test_calibration_low_agreement_not_calibrated()
+    test_release_decision_pass()
+    test_release_decision_block_on_hard_gate()
+    test_release_decision_hold_on_missing_evidence()
+    test_release_decision_block_on_low_frequency()
+    test_release_decision_block_on_regression()
+    test_release_decision_conditional_on_inconsistency()
+    test_release_decision_conditional_on_uncalibrated_judge()
+    test_release_decision_conditional_on_rubric_abstain()
+    test_freeze_snapshot_completeness()
+    test_freeze_snapshot_incomplete()
+    test_build_release_report_structure()
+    test_build_release_report_validates_against_schema()
+    test_write_release_report()
+    test_dataset_hash_deterministic()
+    print("All release evaluation tests passed.")

--- a/schemas/evals-v1.schema.json
+++ b/schemas/evals-v1.schema.json
@@ -43,6 +43,10 @@
           "type": "array",
           "uniqueItems": true,
           "items": {"$ref": "#/$defs/relative_path"}
+        },
+        "case_set": {
+          "type": "string",
+          "enum": ["dev", "regression", "release"]
         }
       }
     }

--- a/schemas/release-eval-v1.schema.json
+++ b/schemas/release-eval-v1.schema.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/magnus919/agent-skills/schemas/release-eval-v1.schema.json",
+  "title": "Release evaluation report v1",
+  "description": "Release-grade evaluation matrix with repeated trials, rubric graders, and explicit gate outcomes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_id",
+    "generated_at",
+    "skill_name",
+    "freeze_snapshot",
+    "case_results",
+    "rubric_results",
+    "pairwise_results",
+    "calibration",
+    "release_decision"
+  ],
+  "properties": {
+    "schema_version": {"type": "integer", "const": 1},
+    "report_id": {"type": "string", "format": "uuid"},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "skill_name": {"type": "string", "minLength": 1},
+    "freeze_snapshot": {"$ref": "#/$defs/freeze_snapshot"},
+    "case_results": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/case_result"}
+    },
+    "rubric_results": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/rubric_result"}
+    },
+    "pairwise_results": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/pairwise_result"}
+    },
+    "calibration": {"$ref": "#/$defs/calibration"},
+    "release_decision": {"$ref": "#/$defs/release_decision"}
+  },
+  "$defs": {
+    "freeze_snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_tree_hash",
+        "baseline_tree_hash",
+        "dataset_hash",
+        "grader_versions",
+        "randomization_seed",
+        "exclusions",
+        "frozen_at"
+      ],
+      "properties": {
+        "candidate_tree_hash": {"type": "string", "minLength": 1},
+        "baseline_tree_hash": {"type": "string", "minLength": 1},
+        "dataset_hash": {"type": "string", "minLength": 1},
+        "grader_versions": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "randomization_seed": {"type": "integer"},
+        "exclusions": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "frozen_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "case_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "case_set",
+        "trial_count",
+        "success_count",
+        "failure_count",
+        "error_count",
+        "timeout_count",
+        "success_frequency",
+        "consistent",
+        "missing_evidence",
+        "paired_delta"
+      ],
+      "properties": {
+        "case_id": {"type": "string", "minLength": 1},
+        "case_set": {
+          "type": "string",
+          "enum": ["dev", "regression", "release"]
+        },
+        "trial_count": {"type": "integer", "minimum": 1},
+        "success_count": {"type": "integer", "minimum": 0},
+        "failure_count": {"type": "integer", "minimum": 0},
+        "error_count": {"type": "integer", "minimum": 0},
+        "timeout_count": {"type": "integer", "minimum": 0},
+        "success_frequency": {"type": "number", "minimum": 0, "maximum": 1},
+        "consistent": {"type": "boolean"},
+        "missing_evidence": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "paired_delta": {
+          "type": "string",
+          "enum": ["candidate_improvement", "candidate_regression", "both_pass", "both_fail", "insufficient_data"]
+        }
+      }
+    },
+    "rubric_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "grader_id",
+        "grader_version",
+        "blinded",
+        "verdict",
+        "scores",
+        "rationale"
+      ],
+      "properties": {
+        "case_id": {"type": "string", "minLength": 1},
+        "grader_id": {"type": "string", "minLength": 1},
+        "grader_version": {"type": "string", "minLength": 1},
+        "blinded": {"type": "boolean"},
+        "verdict": {
+          "type": "string",
+          "enum": ["pass", "fail", "abstain", "insufficient_evidence"]
+        },
+        "scores": {
+          "type": "object",
+          "additionalProperties": {"type": "number"}
+        },
+        "rationale": {"type": "string"}
+      }
+    },
+    "pairwise_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "position_a",
+        "position_b",
+        "winner",
+        "order_reversal_tested",
+        "order_reversal_consistent"
+      ],
+      "properties": {
+        "case_id": {"type": "string", "minLength": 1},
+        "position_a": {"type": "string", "enum": ["candidate", "baseline"]},
+        "position_b": {"type": "string", "enum": ["candidate", "baseline"]},
+        "winner": {
+          "type": "string",
+          "enum": ["a", "b", "tie", "abstain"]
+        },
+        "order_reversal_tested": {"type": "boolean"},
+        "order_reversal_consistent": {"type": ["boolean", "null"]}
+      }
+    },
+    "calibration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "human_sample_count",
+        "judge_agreement_rate",
+        "disagreement_slices",
+        "calibrated"
+      ],
+      "properties": {
+        "human_sample_count": {"type": "integer", "minimum": 0},
+        "judge_agreement_rate": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+        "disagreement_slices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["slice", "disagreement_rate"],
+            "properties": {
+              "slice": {"type": "string"},
+              "disagreement_rate": {"type": "number", "minimum": 0, "maximum": 1}
+            }
+          }
+        },
+        "calibrated": {"type": "boolean"}
+      }
+    },
+    "release_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["outcome", "reasons", "hard_gate_violations"],
+      "properties": {
+        "outcome": {
+          "type": "string",
+          "enum": ["PASS", "CONDITIONAL", "HOLD", "BLOCK"]
+        },
+        "reasons": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "hard_gate_violations": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a release-grade evaluation layer for stochastic reliability and subjective output quality, building on the deterministic paired execution infrastructure from #103-105.

Closes #106

## What's added

| Artifact | Purpose |
|----------|---------|
| `schemas/release-eval-v1.schema.json` | Release report schema: freeze snapshot, trial aggregation, rubric graders, pairwise comparison, calibration, release decision |
| `eval_runner/release.py` | Core module: multi-trial aggregation, versioned rubric graders (abstain/insufficient-evidence), blinded pairwise with order-reversal, calibration tracking, PASS/CONDITIONAL/HOLD/BLOCK decision |
| `eval_runner/tests/test_release.py` | 34 tests covering all acceptance criteria |
| `schemas/evals-v1.schema.json` | Optional `case_set` field (dev/regression/release) — backward compatible |
| `eval_runner/models.py` + `runner.py` | `case_set` on EvalCase, loaded from manifest |
| `.github/workflows/skill-eval.yml` | Release tests added to CI |

## Gate semantics

- Hard privacy, authorization, destructive-action, and cleanup invariants tolerate zero violations and cannot be averaged away → **BLOCK**
- Missing required evidence → **HOLD**, not PASS
- Release cases below 80% success frequency → **BLOCK**
- Regressions in regression set → **BLOCK**
- Inconsistent trials, rubric abstains, or uncalibrated judges → **CONDITIONAL**
- All gates satisfied → **PASS**

## Acceptance criteria coverage

- [x] Run model supports multiple trials per case without collapsing raw outcomes
- [x] Reports show per-case success frequency, consistency, failures, missingness, and paired deltas
- [x] Rubric graders are versioned, blinded, and capable of abstaining
- [x] Pairwise grading randomizes position and includes an order-reversal test
- [x] Human calibration evidence and known judge-validity slices are recorded
- [x] Development, regression, and release sets have separate manifests via `case_set`
- [x] Release decision has explicit PASS, CONDITIONAL, HOLD, and BLOCK outcomes

## Verification

```
python3 eval_runner/tests/test_release.py   # 34 tests pass
python3 eval_runner/tests/test_paired.py    # existing tests pass
python3 scripts/test-eval-validation.py     # 27 tests pass
python3 scripts/validate-evals.py           # 8 manifests valid
```