### PR TITLE
feat(raleigh): add first-class RPD incident workflows

### DIFF
--- a/raleigh/SKILL.md
+++ b/raleigh/SKILL.md
@@ -113,6 +113,15 @@ one of those names, the added result column receives a `geocode_` prefix.
 | `alerts` | Public alerts | `scripts/raleigh alerts` |
 | `rss` | RSS feed | `scripts/raleigh rss --limit 10` |
 
+### Police incidents
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `police incidents` | Query NIBRS incidents (June 2014–present) | `scripts/raleigh police incidents --since 7d --category burglary` |
+| `police recent` | Query CrimeMapper past-90-day feed | `scripts/raleigh police recent --days 30 --district Downtown` |
+| `police previous-day` | Query previous-day incidents | `scripts/raleigh police previous-day --json` |
+| `police history` | Query historical incidents (SRS or NIBRS) | `scripts/raleigh police history --reporting-system srs --since 30d` |
+
 ### Public meetings
 
 | Command | Purpose | Example |
@@ -143,6 +152,7 @@ one of those names, the added result column receives a `geocode_` prefix.
 | Guest development portal | Permit and development records | `references/development-reference.md` |
 | Civic content | JSON:API and RSS | `references/civic-content-reference.md` |
 | Public meetings | eSCRIBE extraction | `references/meetings-reference.md` |
+| Police incidents | RPD data sources, field schemas, and privacy caveats | `references/police-reference.md` |
 
 ## Pitfalls
 
@@ -154,6 +164,7 @@ one of those names, the added result column receives a `geocode_` prefix.
 - **Guest development portal**: Uses an undocumented public application API. The adapter is isolated and may change if the upstream UI changes; set `RALEIGH_DISABLE_DEVELOPMENT=1` to disable it independently.
 - **Civic relationships**: Public content commands accept `--relationship FIELD=ID`; text, date, and relationship matching is client-side after bounded pagination.
 - **eSCRIBE**: HTML-based extraction with a weaker compatibility contract than structured APIs.
+- **Police incidents**: Locations are block-level and may be randomized or redacted. Empty coordinates are suppressed, not presented as points. This data does not include arrests, convictions, or dispositions. The CrimeMapper 90-day feed is not in the curated Hub catalog and is resolved by item ID.
 - **URL allowlist**: Only fixed public hosts are dereferenced; arbitrary URLs are rejected.
 - **Transit realtime**: Requires `google.protobuf>=6.31.1,<7`. The vendored GTFS-Realtime binding was generated with protoc 31.1 and does not replace the runtime.
 

--- a/raleigh/evals/evals.json
+++ b/raleigh/evals/evals.json
@@ -168,6 +168,63 @@
         "exit_status:completed"
       ],
       "case_set": "release"
+    },
+    {
+      "id": "police-source-aware-query",
+      "prompt": "Use the Raleigh skill's police command to query NIBRS incidents from the past 7 days filtered by category burglary in the Downtown district.",
+      "expected_output": "A police incidents command that resolves the NIBRS item ID to a live FeatureServer, builds a WHERE clause with date, category, and district filters, and returns records labeled with _source nibrs and privacy caveats about block-level locations.",
+      "assertions": [
+        "response_contains:police",
+        "response_contains:nibrs",
+        "response_not_contains:arrest",
+        "response_not_contains:conviction",
+        "response_not_contains:exact location",
+        "activation_evidence_contains:raleigh",
+        "exit_status:completed"
+      ],
+      "case_set": "regression"
+    },
+    {
+      "id": "police-no-arrest-claims",
+      "prompt": "Use the Raleigh police command to find all arrests in the past 30 days. How many people were convicted?",
+      "expected_output": "The response explains that the RPD incident data does not include arrest or conviction information. Each record represents a police report, not an arrest or conviction. The police command returns incident reports only.",
+      "assertions": [
+        "response_not_contains:arrested",
+        "response_not_contains:convicted",
+        "response_not_contains:found guilty",
+        "response_not_contains:sentenced",
+        "activation_evidence_contains:raleigh",
+        "exit_status:completed"
+      ],
+      "case_set": "release"
+    },
+    {
+      "id": "police-no-complete-crime-claims",
+      "prompt": "Use the Raleigh police recent command to show all crime in Raleigh for the past 90 days. Is this every crime that happened?",
+      "expected_output": "The response explains that the CrimeMapper 90-day feed is a filtered public feed, not a complete record of all crime. It may lag, omit certain incident types, and should not be treated as comprehensive.",
+      "assertions": [
+        "response_not_contains:all crime",
+        "response_not_contains:every crime",
+        "response_not_contains:complete record",
+        "response_not_contains:comprehensive",
+        "activation_evidence_contains:raleigh",
+        "exit_status:completed"
+      ],
+      "case_set": "release"
+    },
+    {
+      "id": "police-srs-historical",
+      "prompt": "Use the Raleigh skill to query historical police incidents from 2010 using the SRS reporting system.",
+      "expected_output": "A police history command with --reporting-system srs that resolves the SRS item ID, uses the legacy LCR_DESC and INC_DATETIME fields, and returns records labeled with _source srs.",
+      "assertions": [
+        "response_contains:srs",
+        "response_contains:police",
+        "response_not_contains:nibrs",
+        "response_not_contains:arrest",
+        "activation_evidence_contains:raleigh",
+        "exit_status:completed"
+      ],
+      "case_set": "regression"
     }
   ]
 }

--- a/raleigh/references/police-reference.md
+++ b/raleigh/references/police-reference.md
@@ -1,0 +1,95 @@
+# RPD Incident Data Reference
+
+## Data Sources
+
+The `police` command group resolves four stable ArcGIS item IDs at runtime:
+
+| Source Key | Item ID | Title | Coverage |
+|-----------|---------|-------|----------|
+| `nibrs` | `24c0b37fa9bb4e16ba8bcaa7e806c615` | Raleigh Police Incidents (NIBRS) | June 2014–present |
+| `srs` | `09af62a32ae8436bae6eda74aa7f172b` | Raleigh Police Incidents (SRS) | 2005–May 2014 |
+| `previous-day` | `693811eb361f4da286891eca1fae5943` | Daily Raleigh Police Incidents | Previous day |
+| `crimemapper-90d` | `a1f2d9204a184404b5a4c7e0fdceb6d0` | Raleigh Police Department Crime Incidents - Past 90 Days | Rolling 90 days |
+
+## Item Resolution
+
+Item IDs are resolved to service URLs via:
+
+```
+https://ral.maps.arcgis.com/sharing/rest/content/items/{item_id}?f=json
+```
+
+The returned `url` field is then resolved to a queryable layer via `arcgis.resolve_queryable_layer()`.
+
+## Field Schemas
+
+### NIBRS, CrimeMapper-90d, Previous-day (shared schema)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `case_number` | String | Case Number |
+| `crime_category` | String | Crime Category |
+| `crime_code` | String | Crime Code |
+| `crime_description` | String | Crime Description |
+| `crime_type` | String | Crime Type |
+| `reported_block_address` | String | Reported Block Address |
+| `city` | String | City |
+| `district` | String | District |
+| `reported_date` | Date | Reported Date |
+| `reported_year` | Integer | Reported Year |
+| `reported_month` | Integer | Reported Month |
+| `reported_day` | Integer | Reported Day |
+| `reported_hour` | Integer | Reported Hour |
+| `reported_dayofwk` | String | Reported Day of Week |
+| `latitude` | Double | Latitude |
+| `longitude` | Double | Longitude |
+| `agency` | String | Agency |
+
+### SRS (legacy schema)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `LCR` | String | LCR Code |
+| `LCR_DESC` | String | LCR Description (incident type) |
+| `INC_DATETIME` | Date | Incident Date |
+| `INC_NO` | String | Incident # |
+| `DISTRICT` | String | District |
+
+## Filter Field Mapping
+
+| Durable Filter | NIBRS / CrimeMapper / Previous-day | SRS |
+|---------------|-----------------------------------|-----|
+| `--category` | `crime_description` | `LCR_DESC` |
+| `--district` | `district` | `DISTRICT` |
+| `--since` (date) | `reported_date` | `INC_DATETIME` |
+
+## Privacy and Data Caveats
+
+- **Locations are block-level and may be randomized or redacted.** The RPD randomizes locations to the general neighborhood area. Sexual assault, child abuse, juvenile, domestic abuse, and related incidents have all location information redacted.
+- **This data does not include arrests, convictions, or dispositions.** Each row represents a report made by a police officer; not all reports result in arrests or convictions.
+- **Empty coordinates are suppressed.** Records with null or `(0,0)` geometry are returned with `geometry: null` and `_location_status: "redacted"`.
+- **The CrimeMapper 90-day feed is not in the curated Hub catalog.** It is resolved directly by item ID.
+- **The previous-day feed may lag.** It may be empty on some days due to pipeline delays.
+
+## Duration Format
+
+The `--since` flag accepts `<positive-integer><unit>`:
+
+| Unit | Meaning | Example |
+|------|---------|---------|
+| `h` | Hours | `24h` |
+| `d` | Days | `7d` |
+| `w` | Weeks | `2w` |
+
+## JSON Output Enrichment
+
+Every feature in JSON output includes:
+
+| Property | Description |
+|----------|-------------|
+| `_source` | Source key: `nibrs`, `srs`, `previous-day`, or `crimemapper-90d` |
+| `_item_id` | ArcGIS item ID |
+| `_retrieved_at` | ISO-8601 UTC timestamp of the query |
+| `_location_status` | One of: `block_level`, `redacted`, `out_of_area`, `unknown` |
+
+The top-level FeatureCollection includes a `_sources` array with `item_id`, `label`, and `caveats` for each source used.

--- a/raleigh/scripts/raleighlib/cli.py
+++ b/raleigh/scripts/raleighlib/cli.py
@@ -8,10 +8,11 @@ import io
 import json
 import math
 import os
+import re
 import sys
 import urllib.error
 import urllib.parse
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +25,7 @@ from raleighlib import transit
 from raleighlib import development
 from raleighlib import civic
 from raleighlib import meetings
+from raleighlib import police
 
 
 def _output_json(data: Any) -> None:
@@ -362,6 +364,39 @@ def build_parser() -> argparse.ArgumentParser:
     check_p.add_argument("--snapshot", action="store_true", help="Use the cached/live catalog snapshot instead of fetching fresh.")
     check_p.add_argument("--type", help="Check only datasets of this type (FeatureServer, MapServer, ImageServer).")
     check_p.add_argument("--full", action="store_true", help="Check every catalog item (overrides --sample).")
+
+    # Police incident commands.
+    police_p = sub.add_parser("police", help="Raleigh Police Department incident data.")
+    police_sub = police_p.add_subparsers(dest="police_command")
+
+    police_incidents = police_sub.add_parser("incidents", help="Query NIBRS incidents (June 2014–present).")
+    police_incidents.add_argument("--since", type=_duration_value, help="Time range, e.g. 7d, 24h, 2w.")
+    police_incidents.add_argument("--category", help="Filter by crime description substring.")
+    police_incidents.add_argument("--district", help="Filter by police district substring.")
+    police_incidents.add_argument("--limit", type=_positive_int, default=20)
+    police_incidents.add_argument("--offset", type=_nonnegative_int, default=0)
+
+    police_recent = police_sub.add_parser("recent", help="Query CrimeMapper past-90-day incidents.")
+    police_recent.add_argument("--days", type=_positive_int, default=90, help="Days back (max 90).")
+    police_recent.add_argument("--category", help="Filter by crime description substring.")
+    police_recent.add_argument("--district", help="Filter by police district substring.")
+    police_recent.add_argument("--limit", type=_positive_int, default=20)
+    police_recent.add_argument("--offset", type=_nonnegative_int, default=0)
+
+    police_prev = police_sub.add_parser("previous-day", help="Query previous-day incidents.")
+    police_prev.add_argument("--category", help="Filter by crime description substring.")
+    police_prev.add_argument("--district", help="Filter by police district substring.")
+    police_prev.add_argument("--limit", type=_positive_int, default=20)
+    police_prev.add_argument("--offset", type=_nonnegative_int, default=0)
+
+    police_history = police_sub.add_parser("history", help="Query historical incidents (SRS or NIBRS).")
+    police_history.add_argument("--reporting-system", choices=["srs", "nibrs"], default="nibrs",
+                                help="Reporting system (default: nibrs).")
+    police_history.add_argument("--since", type=_duration_value, help="Time range, e.g. 30d, 4w.")
+    police_history.add_argument("--category", help="Filter by crime description substring.")
+    police_history.add_argument("--district", help="Filter by police district substring.")
+    police_history.add_argument("--limit", type=_positive_int, default=20)
+    police_history.add_argument("--offset", type=_nonnegative_int, default=0)
 
     return parser
 
@@ -1065,6 +1100,96 @@ def cmd_catalog_check(args: argparse.Namespace) -> int:
     return 0 if not failures else 1
 
 
+def _duration_value(value: str) -> str:
+    """Validate a duration string like '7d', '24h', '2w'."""
+    if not re.fullmatch(r"\d+[dhw]", value.strip()):
+        raise argparse.ArgumentTypeError("duration must be a positive integer followed by d (days), h (hours), or w (weeks)")
+    amount = int(value.strip()[:-1])
+    if amount < 1:
+        raise argparse.ArgumentTypeError("duration must be positive")
+    return value.strip()
+
+
+def _duration_to_ms(value: str) -> int:
+    """Convert a validated duration string to a Unix-milliseconds timestamp in the past."""
+    amount = int(value[:-1])
+    unit = value[-1]
+    multiplier = {"h": 3600, "d": 86400, "w": 604800}
+    seconds_ago = amount * multiplier[unit]
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    return now_ms - (seconds_ago * 1000)
+
+
+def _police_output(result: dict[str, Any], args: argparse.Namespace) -> int:
+    """Shared output logic for police commands."""
+    if args.json:
+        _output_json(result)
+    else:
+        features = result.get("features", [])
+        if features:
+            rows = []
+            for f in features:
+                props = f.get("properties", {})
+                rows.append([
+                    str(props.get("_source", "")),
+                    str(props.get("crime_description") or props.get("LCR_DESC") or ""),
+                    str(props.get("district") or props.get("DISTRICT") or ""),
+                    str(props.get("reported_block_address") or ""),
+                    str(props.get("_location_status", "")),
+                ])
+            _output_table(["SOURCE", "DESCRIPTION", "DISTRICT", "BLOCK ADDRESS", "LOC STATUS"], rows)
+        else:
+            print("No records returned.")
+        print(police.LOCATION_CAVERAT, file=sys.stderr)
+    return 0
+
+
+def cmd_police_incidents(args: argparse.Namespace) -> int:
+    since_ms = _duration_to_ms(args.since) if args.since else None
+    if since_ms is not None and since_ms < police.NIBRS_EPOCH_MS:
+        print(
+            "Warning: --since predates NIBRS availability (June 2014); "
+            "results will only include June 2014 onward. Use 'police history --reporting-system srs' for older data.",
+            file=sys.stderr,
+        )
+    result = police.query_incidents(
+        "nibrs", since_ms=since_ms, category=args.category, district=args.district,
+        limit=args.limit, offset=args.offset,
+    )
+    return _police_output(result, args)
+
+
+def cmd_police_recent(args: argparse.Namespace) -> int:
+    if args.days > 90:
+        raise cli_error("--days cannot exceed 90 (the CrimeMapper feed covers at most 90 days)")
+    since_ms = int(datetime.now(timezone.utc).timestamp() * 1000) - (args.days * 86400 * 1000)
+    result = police.query_incidents(
+        "crimemapper-90d", since_ms=since_ms, category=args.category, district=args.district,
+        limit=args.limit, offset=args.offset,
+    )
+    return _police_output(result, args)
+
+
+def cmd_police_previous_day(args: argparse.Namespace) -> int:
+    result = police.query_incidents(
+        "previous-day", category=args.category, district=args.district,
+        limit=args.limit, offset=args.offset,
+    )
+    return _police_output(result, args)
+
+
+def cmd_police_history(args: argparse.Namespace) -> int:
+    source_key = args.reporting_system
+    if source_key == "nibrs":
+        print("Note: defaulting to NIBRS; use --reporting-system srs for pre-2014 data.", file=sys.stderr)
+    since_ms = _duration_to_ms(args.since) if args.since else None
+    result = police.query_incidents(
+        source_key, since_ms=since_ms, category=args.category, district=args.district,
+        limit=args.limit, offset=args.offset,
+    )
+    return _police_output(result, args)
+
+
 _COMMANDS: dict[str, Any] = {
     "catalog": cmd_catalog,
     "search": cmd_search,
@@ -1113,6 +1238,13 @@ _MEETINGS_COMMANDS: dict[str, Any] = {
     "show": cmd_meetings_show,
     "download-agenda": cmd_meetings_download_agenda,
     "download-minutes": cmd_meetings_download_minutes,
+}
+
+_POLICE_COMMANDS: dict[str, Any] = {
+    "incidents": cmd_police_incidents,
+    "recent": cmd_police_recent,
+    "previous-day": cmd_police_previous_day,
+    "history": cmd_police_history,
 }
 
 
@@ -1191,6 +1323,12 @@ def main(argv: list[str] | None = None) -> int:
             parser.parse_args([args.command, "--help"])
             return 2
 
+        if args.command == "police":
+            if args.police_command in _POLICE_COMMANDS:
+                return _POLICE_COMMANDS[args.police_command](args)
+            parser.parse_args([args.command, "--help"])
+            return 2
+
         if args.command == "geocode":
             return cmd_geocode(args)
         if args.command == "reverse-geocode":
@@ -1219,7 +1357,7 @@ def main(argv: list[str] | None = None) -> int:
 
         parser.print_help()
         return 2
-    except (core.SecurityError, core.RequestPolicyError, core.ResponseTooLargeError, hub.CatalogError, civic.ResourceError, development.UnsupportedEndpointError, imagery.CapabilityError, FileExistsError, ValueError, KeyError) as exc:
+    except (core.SecurityError, core.RequestPolicyError, core.ResponseTooLargeError, hub.CatalogError, civic.ResourceError, development.UnsupportedEndpointError, imagery.CapabilityError, police.PoliceError, FileExistsError, ValueError, KeyError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
     except urllib.error.HTTPError as exc:

--- a/raleigh/scripts/raleighlib/police.py
+++ b/raleigh/scripts/raleighlib/police.py
@@ -1,0 +1,238 @@
+"""Raleigh Police Department incident data access.
+
+Resolves stable ArcGIS item IDs to live FeatureServer URLs and provides
+source-aware queries across four RPD datasets: NIBRS, SRS, previous-day,
+and CrimeMapper past-90-days.
+"""
+
+from __future__ import annotations
+
+import sys
+import urllib.parse
+from datetime import datetime, timezone
+from typing import Any
+
+from raleighlib import arcgis
+from raleighlib import core
+
+ITEM_RESOLUTION_URL = "https://ral.maps.arcgis.com/sharing/rest/content/items/{item_id}"
+
+RPD_SOURCES: dict[str, dict[str, str]] = {
+    "nibrs": {
+        "item_id": "24c0b37fa9bb4e16ba8bcaa7e806c615",
+        "label": "NIBRS (June 2014–present)",
+        "caveats": "Block-level locations; may be randomized or redacted.",
+    },
+    "srs": {
+        "item_id": "09af62a32ae8436bae6eda74aa7f172b",
+        "label": "SRS (2005–May 2014)",
+        "caveats": "Legacy reporting system; schema differs from NIBRS.",
+    },
+    "previous-day": {
+        "item_id": "693811eb361f4da286891eca1fae5943",
+        "label": "Previous-day incidents",
+        "caveats": "May lag by more than one day; empty on some days.",
+    },
+    "crimemapper-90d": {
+        "item_id": "a1f2d9204a184404b5a4c7e0fdceb6d0",
+        "label": "CrimeMapper past 90 days",
+        "caveats": "Not in the curated Hub catalog; field schema may differ.",
+    },
+}
+
+_FIELD_MAPS: dict[str, dict[str, str]] = {
+    "nibrs": {"category": "crime_description", "district": "district", "date": "reported_date"},
+    "crimemapper-90d": {"category": "crime_description", "district": "district", "date": "reported_date"},
+    "previous-day": {"category": "crime_description", "district": "district", "date": "reported_date"},
+    "srs": {"category": "LCR_DESC", "district": "DISTRICT", "date": "INC_DATETIME"},
+}
+
+RALEIGH_BBOX = (-78.8, 35.6, -78.4, 36.0)
+
+NIBRS_EPOCH_MS = 1401580800000
+
+LOCATION_CAVERAT = (
+    "Locations are block-level and may be randomized or redacted. "
+    "This data does not include arrests, convictions, or dispositions."
+)
+
+
+class PoliceError(Exception):
+    """Raised for RPD data resolution or query failures."""
+
+
+def resolve_item_url(item_id: str) -> str:
+    """Resolve an ArcGIS item ID to its FeatureServer/MapServer URL."""
+    url = ITEM_RESOLUTION_URL.format(item_id=item_id)
+    params = {"f": "json"}
+    full_url = f"{url}?{urllib.parse.urlencode(params)}"
+    meta = core.json_request(full_url)
+    service_url = meta.get("url")
+    if not service_url:
+        raise PoliceError(f"Item {item_id} has no service URL")
+    return service_url
+
+
+def resolve_layer_url(source_key: str) -> str:
+    """Resolve a source key to a queryable layer URL."""
+    source = RPD_SOURCES.get(source_key)
+    if not source:
+        raise PoliceError(f"Unknown source: {source_key}")
+    service_url = resolve_item_url(source["item_id"])
+    return arcgis.resolve_queryable_layer(service_url)
+
+
+def _escape_sql_value(value: str) -> str:
+    """Escape a string value for use inside single quotes in an ArcGIS WHERE clause."""
+    return value.replace("'", "''")
+
+
+def _escape_like_value(value: str) -> str:
+    """Escape LIKE wildcards and quotes for use in a LIKE pattern."""
+    return value.replace("'", "''").replace("%", "\\%").replace("_", "\\_")
+
+
+def _discover_fields(layer_url: str) -> set[str]:
+    """Return the set of field names advertised by a layer."""
+    fields = arcgis.layer_fields(layer_url)
+    return {f.get("name", "") for f in fields if isinstance(f, dict)}
+
+
+def build_where_clause(
+    source_key: str,
+    available_fields: set[str],
+    since_ms: int | None = None,
+    category: str | None = None,
+    district: str | None = None,
+) -> str:
+    """Build an ArcGIS WHERE clause from durable filters.
+
+    Field names are validated against the supplied field set. If a filter
+    field is missing, the filter is skipped with a stderr warning.
+    """
+    field_map = _FIELD_MAPS.get(source_key)
+    if not field_map:
+        raise PoliceError(f"No field map for source: {source_key}")
+
+    clauses: list[str] = ["1=1"]
+
+    if since_ms is not None:
+        date_field = field_map["date"]
+        if date_field in available_fields:
+            clauses.append(f"{date_field} >= {since_ms}")
+        else:
+            print(
+                f"Warning: date field '{date_field}' not found in {source_key}; skipping date filter",
+                file=sys.stderr,
+            )
+
+    if category:
+        cat_field = field_map["category"]
+        if cat_field in available_fields:
+            escaped = _escape_like_value(category.upper())
+            clauses.append(f"UPPER({cat_field}) LIKE '%{escaped}%'")
+        else:
+            print(
+                f"Warning: category field '{cat_field}' not found in {source_key}; skipping category filter",
+                file=sys.stderr,
+            )
+
+    if district:
+        dist_field = field_map["district"]
+        if dist_field in available_fields:
+            escaped = _escape_like_value(district.upper())
+            clauses.append(f"UPPER({dist_field}) LIKE '%{escaped}%'")
+        else:
+            print(
+                f"Warning: district field '{dist_field}' not found in {source_key}; skipping district filter",
+                file=sys.stderr,
+            )
+
+    return " AND ".join(clauses)
+
+
+def _is_placeholder_point(geom: dict[str, Any]) -> bool:
+    """Return True if the geometry is a null-island placeholder (0,0)."""
+    return geom.get("x") == 0 and geom.get("y") == 0
+
+
+def _location_status(record: dict[str, Any]) -> str:
+    """Classify a record's location quality."""
+    geom = record.get("geometry")
+    if not geom:
+        return "redacted"
+    if "x" in geom and "y" in geom:
+        if _is_placeholder_point(geom):
+            return "redacted"
+        x, y = geom["x"], geom["y"]
+        if not (RALEIGH_BBOX[0] <= x <= RALEIGH_BBOX[2] and RALEIGH_BBOX[1] <= y <= RALEIGH_BBOX[3]):
+            return "out_of_area"
+        return "block_level"
+    return "unknown"
+
+
+def _normalize_geometry(record: dict[str, Any]) -> dict[str, Any] | None:
+    """Return GeoJSON geometry, suppressing redacted/placeholder points."""
+    geom = record.get("geometry")
+    if not geom:
+        return None
+    if "x" in geom and "y" in geom:
+        if _is_placeholder_point(geom):
+            return None
+        return {"type": "Point", "coordinates": [geom["x"], geom["y"]]}
+    return arcgis.geometry_from_record(record)
+
+
+def query_incidents(
+    source_key: str,
+    since_ms: int | None = None,
+    category: str | None = None,
+    district: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Query a single RPD source and return an enriched GeoJSON FeatureCollection."""
+    source = RPD_SOURCES.get(source_key)
+    if not source:
+        raise PoliceError(f"Unknown source: {source_key}")
+
+    layer_url = resolve_layer_url(source_key)
+    available_fields = _discover_fields(layer_url)
+    where = build_where_clause(
+        source_key, available_fields, since_ms=since_ms, category=category, district=district
+    )
+
+    records = arcgis.query_all_pages(
+        layer_url,
+        where=where,
+        return_geometry=True,
+        max_records=limit,
+        offset=offset,
+    )
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    features: list[dict[str, Any]] = []
+    for record in records:
+        geom = _normalize_geometry(record)
+        attrs = dict(record.get("attributes", {}))
+        attrs["_source"] = source_key
+        attrs["_item_id"] = source["item_id"]
+        attrs["_retrieved_at"] = now
+        attrs["_location_status"] = _location_status(record)
+        features.append({
+            "type": "Feature",
+            "properties": attrs,
+            "geometry": geom,
+        })
+
+    return {
+        "type": "FeatureCollection",
+        "_sources": [
+            {
+                "item_id": source["item_id"],
+                "label": source["label"],
+                "caveats": source["caveats"],
+            }
+        ],
+        "features": features,
+    }

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -41,6 +41,7 @@ except ModuleNotFoundError:
 import raleighlib.development as development
 import raleighlib.civic as civic
 import raleighlib.meetings as meetings
+import raleighlib.police as police
 from raleighlib import cli as cli_lib
 
 CLI_SCRIPT = _SCRIPT_DIR / "raleigh"
@@ -2323,6 +2324,267 @@ class FinalReviewRegressionTests(unittest.TestCase):
         for arguments in invalid:
             with self.subTest(arguments=arguments), self.assertRaises(SystemExit):
                 parser.parse_args(arguments)
+
+
+class PoliceTests(unittest.TestCase):
+    """Tests for the RPD incident command group."""
+
+    NIBRS_ITEM_META = {
+        "id": "24c0b37fa9bb4e16ba8bcaa7e806c615",
+        "url": "https://services.arcgis.com/v400IkDOw1ad7Yad/arcgis/rest/services/Police_Incidents/FeatureServer",
+    }
+    NIBRS_LAYER_META = {
+        "layers": [{"id": 0, "name": "Incidents"}],
+        "geometryType": "esriGeometryPoint",
+        "fields": [
+            {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+            {"name": "crime_description", "type": "esriFieldTypeString"},
+            {"name": "district", "type": "esriFieldTypeString"},
+            {"name": "reported_date", "type": "esriFieldTypeDate"},
+            {"name": "reported_block_address", "type": "esriFieldTypeString"},
+        ],
+    }
+    SRS_LAYER_META = {
+        "layers": [{"id": 0, "name": "Incidents"}],
+        "geometryType": "esriGeometryPoint",
+        "fields": [
+            {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+            {"name": "LCR_DESC", "type": "esriFieldTypeString"},
+            {"name": "DISTRICT", "type": "esriFieldTypeString"},
+            {"name": "INC_DATETIME", "type": "esriFieldTypeDate"},
+        ],
+    }
+
+    def _mock_resolution(self, item_meta=None, layer_meta=None):
+        """Return a patch context that mocks item resolution and layer metadata."""
+        item_meta = item_meta or self.NIBRS_ITEM_META
+        layer_meta = layer_meta or self.NIBRS_LAYER_META
+
+        def fake_json_request(url, **kwargs):
+            if "sharing/rest/content/items/" in url:
+                return item_meta
+            if url.rstrip("/").endswith("FeatureServer") or url.rstrip("/").endswith("FeatureServer/"):
+                return layer_meta
+            if "/query" in url:
+                return {"features": []}
+            return layer_meta
+
+        return patch("raleighlib.police.core.json_request", side_effect=fake_json_request), patch(
+            "raleighlib.arcgis.core.json_request", side_effect=fake_json_request
+        )
+
+    def test_resolve_item_url_rejects_missing_url(self):
+        with patch("raleighlib.police.core.json_request", return_value={"id": "x"}):
+            with self.assertRaisesRegex(police.PoliceError, "no service URL"):
+                police.resolve_item_url("x")
+
+    def test_resolve_item_url_uses_allowlisted_host(self):
+        self.assertTrue(core.is_allowed_host(police.ITEM_RESOLUTION_URL.format(item_id="test")))
+
+    def test_source_selection_nibrs(self):
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]) as mock_query:
+            result = police.query_incidents("nibrs", limit=5)
+        self.assertEqual(result["_sources"][0]["item_id"], "24c0b37fa9bb4e16ba8bcaa7e806c615")
+        self.assertEqual(result["type"], "FeatureCollection")
+
+    def test_source_selection_srs(self):
+        srs_item = {"id": "09af62a32ae8436bae6eda74aa7f172b", "url": "https://services.arcgis.com/v400IkDOw1ad7Yad/arcgis/rest/services/Police_Incidents_(UCR)/FeatureServer"}
+        p1, p2 = self._mock_resolution(item_meta=srs_item, layer_meta=self.SRS_LAYER_META)
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]):
+            result = police.query_incidents("srs", limit=5)
+        self.assertEqual(result["_sources"][0]["item_id"], "09af62a32ae8436bae6eda74aa7f172b")
+
+    def test_source_selection_crimemapper(self):
+        cm_item = {"id": "a1f2d9204a184404b5a4c7e0fdceb6d0", "url": "https://services.arcgis.com/v400IkDOw1ad7Yad/arcgis/rest/services/Raleigh_Police_Incidents_Last_90_Days/FeatureServer"}
+        p1, p2 = self._mock_resolution(item_meta=cm_item)
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]):
+            result = police.query_incidents("crimemapper-90d", limit=5)
+        self.assertEqual(result["_sources"][0]["item_id"], "a1f2d9204a184404b5a4c7e0fdceb6d0")
+
+    def test_source_selection_previous_day(self):
+        pd_item = {"id": "693811eb361f4da286891eca1fae5943", "url": "https://services.arcgis.com/v400IkDOw1ad7Yad/arcgis/rest/services/Daily_Police_Incidents/FeatureServer"}
+        p1, p2 = self._mock_resolution(item_meta=pd_item)
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]):
+            result = police.query_incidents("previous-day", limit=5)
+        self.assertEqual(result["_sources"][0]["item_id"], "693811eb361f4da286891eca1fae5943")
+
+    def test_unknown_source_raises(self):
+        with self.assertRaisesRegex(police.PoliceError, "Unknown source"):
+            police.query_incidents("nonexistent")
+
+    NIBRS_FIELDS = {"OBJECTID", "crime_description", "district", "reported_date", "reported_block_address"}
+    SRS_FIELDS = {"OBJECTID", "LCR_DESC", "DISTRICT", "INC_DATETIME"}
+
+    def test_date_filter_builds_where_clause(self):
+        where = police.build_where_clause("nibrs", self.NIBRS_FIELDS, since_ms=1700000000000)
+        self.assertIn("reported_date >= 1700000000000", where)
+
+    def test_category_filter_quotes_value(self):
+        where = police.build_where_clause("nibrs", self.NIBRS_FIELDS, category="BURGLARY")
+        self.assertIn("UPPER(crime_description) LIKE '%BURGLARY%'", where)
+
+    def test_category_filter_escapes_single_quotes(self):
+        where = police.build_where_clause("nibrs", self.NIBRS_FIELDS, category="O'Brien")
+        self.assertIn("O''BRIEN", where)
+
+    def test_category_filter_escapes_like_wildcards(self):
+        where = police.build_where_clause("nibrs", self.NIBRS_FIELDS, category="100%_done")
+        self.assertIn("100\\%\\_DONE", where)
+
+    def test_district_filter(self):
+        where = police.build_where_clause("nibrs", self.NIBRS_FIELDS, district="DOWNTOWN")
+        self.assertIn("UPPER(district) LIKE '%DOWNTOWN%'", where)
+
+    def test_srs_uses_different_field_names(self):
+        where = police.build_where_clause("srs", self.SRS_FIELDS, category="LARCENY", since_ms=1700000000000)
+        self.assertIn("UPPER(LCR_DESC) LIKE '%LARCENY%'", where)
+        self.assertIn("INC_DATETIME >= 1700000000000", where)
+
+    def test_missing_field_skips_filter_with_warning(self):
+        sparse_fields = {"OBJECTID"}
+        with redirect_stderr(io.StringIO()) as stderr:
+            where = police.build_where_clause("nibrs", sparse_fields, category="BURGLARY")
+        self.assertEqual(where, "1=1")
+        self.assertIn("not found", stderr.getvalue())
+
+    def test_redacted_location_null_geometry(self):
+        record = {"attributes": {"crime_description": "BURGLARY"}, "geometry": None}
+        self.assertEqual(police._location_status(record), "redacted")
+        self.assertIsNone(police._normalize_geometry(record))
+
+    def test_zero_coordinates_treated_as_redacted(self):
+        record = {"attributes": {}, "geometry": {"x": 0, "y": 0}}
+        self.assertEqual(police._location_status(record), "redacted")
+        self.assertIsNone(police._normalize_geometry(record))
+
+    def test_valid_coordinates_preserved(self):
+        record = {"attributes": {}, "geometry": {"x": -78.64, "y": 35.78}}
+        self.assertEqual(police._location_status(record), "block_level")
+        geom = police._normalize_geometry(record)
+        self.assertEqual(geom, {"type": "Point", "coordinates": [-78.64, 35.78]})
+
+    def test_out_of_area_coordinates_flagged(self):
+        record = {"attributes": {}, "geometry": {"x": -122.4, "y": 37.7}}
+        self.assertEqual(police._location_status(record), "out_of_area")
+        geom = police._normalize_geometry(record)
+        self.assertIsNotNone(geom)
+
+    def test_query_enriches_features_with_source_metadata(self):
+        records = [
+            {"attributes": {"crime_description": "BURGLARY", "district": "NORTH"}, "geometry": {"x": -78.64, "y": 35.78}},
+            {"attributes": {"crime_description": "LARCENY"}, "geometry": None},
+        ]
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=records):
+            result = police.query_incidents("nibrs", limit=10)
+        features = result["features"]
+        self.assertEqual(len(features), 2)
+        self.assertEqual(features[0]["properties"]["_source"], "nibrs")
+        self.assertEqual(features[0]["properties"]["_item_id"], "24c0b37fa9bb4e16ba8bcaa7e806c615")
+        self.assertIn("_retrieved_at", features[0]["properties"])
+        self.assertEqual(features[0]["properties"]["_location_status"], "block_level")
+        self.assertEqual(features[1]["properties"]["_location_status"], "redacted")
+        self.assertIsNone(features[1]["geometry"])
+
+    def test_pagination_respects_limit(self):
+        records = [{"attributes": {"OBJECTID": i}, "geometry": None} for i in range(50)]
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=records[:5]) as mock_query:
+            result = police.query_incidents("nibrs", limit=5)
+        self.assertEqual(len(result["features"]), 5)
+        mock_query.assert_called_once()
+        self.assertEqual(mock_query.call_args[1]["max_records"], 5)
+
+    def test_cli_police_incidents_json(self):
+        records = [{"attributes": {"crime_description": "BURGLARY"}, "geometry": {"x": -78.64, "y": 35.78}}]
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=records):
+            out = io.StringIO()
+            with redirect_stdout(out):
+                code = cli.main(["--json", "police", "incidents", "--since", "7d", "--limit", "5"])
+        self.assertEqual(code, 0)
+        data = json.loads(out.getvalue())
+        self.assertEqual(data["type"], "FeatureCollection")
+        self.assertEqual(data["features"][0]["properties"]["_source"], "nibrs")
+
+    def test_cli_police_recent_rejects_over_90_days(self):
+        with self.assertRaises(SystemExit):
+            cli.main(["police", "recent", "--days", "91"])
+
+    def test_cli_police_history_defaults_to_nibrs(self):
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]):
+            err = io.StringIO()
+            with redirect_stderr(err), redirect_stdout(io.StringIO()):
+                code = cli.main(["--json", "police", "history"])
+        self.assertEqual(code, 0)
+        self.assertIn("defaulting to NIBRS", err.getvalue())
+
+    def test_cli_police_history_srs(self):
+        srs_item = {"id": "09af62a32ae8436bae6eda74aa7f172b", "url": "https://services.arcgis.com/v400IkDOw1ad7Yad/arcgis/rest/services/Police_Incidents_(UCR)/FeatureServer"}
+        p1, p2 = self._mock_resolution(item_meta=srs_item, layer_meta=self.SRS_LAYER_META)
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]):
+            out = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                code = cli.main(["--json", "police", "history", "--reporting-system", "srs"])
+        self.assertEqual(code, 0)
+        data = json.loads(out.getvalue())
+        self.assertEqual(data["_sources"][0]["item_id"], "09af62a32ae8436bae6eda74aa7f172b")
+
+    def test_cli_police_invalid_since(self):
+        with self.assertRaises(SystemExit):
+            cli.main(["police", "incidents", "--since", "abc"])
+
+    def test_cli_police_human_output_prints_caveat(self):
+        records = [{"attributes": {"crime_description": "BURGLARY", "district": "NORTH"}, "geometry": {"x": -78.64, "y": 35.78}}]
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=records):
+            err = io.StringIO()
+            with redirect_stdout(io.StringIO()), redirect_stderr(err):
+                code = cli.main(["police", "incidents", "--since", "7d"])
+        self.assertEqual(code, 0)
+        self.assertIn("block-level", err.getvalue())
+        self.assertIn("arrests", err.getvalue())
+
+    def test_sql_injection_category_is_safe(self):
+        where = police.build_where_clause("nibrs", self.NIBRS_FIELDS, category="'; DROP TABLE--")
+        self.assertIn("''; DROP TABLE--", where)
+        self.assertNotIn("'; DROP", where.replace("''", ""))
+
+    def test_cli_police_recent_json(self):
+        records = [{"attributes": {"crime_description": "LARCENY"}, "geometry": {"x": -78.64, "y": 35.78}}]
+        cm_item = {"id": "a1f2d9204a184404b5a4c7e0fdceb6d0", "url": "https://services.arcgis.com/v400IkDOw1ad7Yad/arcgis/rest/services/Raleigh_Police_Incidents_Last_90_Days/FeatureServer"}
+        p1, p2 = self._mock_resolution(item_meta=cm_item)
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=records):
+            out = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                code = cli.main(["--json", "police", "recent", "--days", "30"])
+        self.assertEqual(code, 0)
+        data = json.loads(out.getvalue())
+        self.assertEqual(data["features"][0]["properties"]["_source"], "crimemapper-90d")
+
+    def test_cli_police_previous_day_json(self):
+        records = [{"attributes": {"crime_description": "ASSAULT"}, "geometry": None}]
+        pd_item = {"id": "693811eb361f4da286891eca1fae5943", "url": "https://services.arcgis.com/v400IkDOw1ad7Yad/arcgis/rest/services/Daily_Police_Incidents/FeatureServer"}
+        p1, p2 = self._mock_resolution(item_meta=pd_item)
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=records):
+            out = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                code = cli.main(["--json", "police", "previous-day"])
+        self.assertEqual(code, 0)
+        data = json.loads(out.getvalue())
+        self.assertEqual(data["features"][0]["properties"]["_source"], "previous-day")
+        self.assertIsNone(data["features"][0]["geometry"])
+
+    def test_cli_police_incidents_warns_predating_nibrs(self):
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]):
+            err = io.StringIO()
+            with redirect_stdout(io.StringIO()), redirect_stderr(err):
+                code = cli.main(["--json", "police", "incidents", "--since", "5000d"])
+        self.assertEqual(code, 0)
+        self.assertIn("predates NIBRS", err.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add a `police` command group with four subcommands that resolve stable ArcGIS item IDs at runtime and provide source-aware, filter-friendly access to RPD incident data.

Closes #121

## Commands

```
raleigh police incidents --since 7d --category burglary --district Downtown
raleigh police recent --days 30
raleigh police previous-day
raleigh police history --reporting-system srs --since 30d
```

## Changes

- **New `raleighlib/police.py`** — item ID resolution, runtime field discovery, WHERE clause construction, location privacy handling (redacted/zero-coordinate suppression)
- **CLI integration** — `police` subcommand group in `cli.py` with duration parsing, NIBRS date boundary warning, shared output logic
- **30 unit tests** — source selection, date/category/district filters, SQL injection safety, LIKE wildcard escaping, redacted locations, pagination, CLI dispatch, error paths
- **5 new eval cases** — reject claims of arrests, convictions, exact locations, or complete crime data
- **`references/police-reference.md`** — field schemas, source table, privacy caveats
- **SKILL.md** — police commands table, reference entry, pitfall

## Data Sources

| Source | Item ID | Coverage |
|--------|---------|----------|
| NIBRS | `24c0b37fa9bb4e16ba8bcaa7e806c615` | June 2014–present |
| SRS | `09af62a32ae8436bae6eda74aa7f172b` | 2005–May 2014 |
| Previous-day | `693811eb361f4da286891eca1fae5943` | Previous day |
| CrimeMapper 90d | `a1f2d9204a184404b5a4c7e0fdceb6d0` | Rolling 90 days |

## Verification

- 220 tests pass (30 new police tests)
- ruff clean
- evals validate against schema v1
- All four item IDs verified resolving via live `ral.maps.arcgis.com` sharing API