### PR TITLE
feat(raleigh): add first-class RFD incident workflows and normalize the 2026 schema

### DIFF
--- a/raleigh/SKILL.md
+++ b/raleigh/SKILL.md
@@ -122,6 +122,13 @@ one of those names, the added result column receives a `geocode_` prefix.
 | `police previous-day` | Query previous-day incidents | `scripts/raleigh police previous-day --json` |
 | `police history` | Query historical incidents (SRS or NIBRS) | `scripts/raleigh police history --reporting-system srs --since 30d` |
 
+### Fire incidents
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `fire incidents` | Query RFD incidents (full history 2007–present or past month) | `scripts/raleigh fire incidents --since 30d --group Fire` |
+| `fire response-times` | Compute labeled response durations | `scripts/raleigh fire response-times --since 1y --group Fire` |
+
 ### Public meetings
 
 | Command | Purpose | Example |
@@ -153,6 +160,7 @@ one of those names, the added result column receives a `geocode_` prefix.
 | Civic content | JSON:API and RSS | `references/civic-content-reference.md` |
 | Public meetings | eSCRIBE extraction | `references/meetings-reference.md` |
 | Police incidents | RPD data sources, field schemas, and privacy caveats | `references/police-reference.md` |
+| Fire incidents | RFD data sources, 2026 schema transition, durations, and privacy caveats | `references/fire-reference.md` |
 
 ## Pitfalls
 
@@ -165,6 +173,7 @@ one of those names, the added result column receives a `geocode_` prefix.
 - **Civic relationships**: Public content commands accept `--relationship FIELD=ID`; text, date, and relationship matching is client-side after bounded pagination.
 - **eSCRIBE**: HTML-based extraction with a weaker compatibility contract than structured APIs.
 - **Police incidents**: Locations are block-level and may be randomized or redacted. Empty coordinates are suppressed, not presented as points. This data does not include arrests, convictions, or dispositions. The CrimeMapper 90-day feed is not in the curated Hub catalog and is resolved by item ID.
+- **Fire incidents**: RFD deprecated `incident_type`/`incident_type_description` for records after 2026-01-01, replaced by `incident_group_name`, `incident_subgroup_code`, and `incident_type_name`. The `fire` commands normalize both eras into stable `_` keys without fabricating cross-era mappings, and preserve raw fields in JSON. Incident types 300–399 and 661 are excluded by RFD for EMS/privacy. The full-history `station` field is unpopulated for most records after early 2021; the past-month feed provides `station_name`.
 - **URL allowlist**: Only fixed public hosts are dereferenced; arbitrary URLs are rejected.
 - **Transit realtime**: Requires `google.protobuf>=6.31.1,<7`. The vendored GTFS-Realtime binding was generated with protoc 31.1 and does not replace the runtime.
 

--- a/raleigh/evals/evals.json
+++ b/raleigh/evals/evals.json
@@ -225,6 +225,51 @@
         "exit_status:completed"
       ],
       "case_set": "regression"
+    },
+    {
+      "id": "rfd-transition-normalization",
+      "prompt": "Use the Raleigh skill's fire command to query fire incidents spanning the past two years. How are incidents classified, and does the schema differ between 2025 and 2026 records?",
+      "expected_output": "A fire incidents query that explains the 2026 schema transition: incident_type and incident_type_description are deprecated after 2026-01-01 and replaced by incident_group_name, incident_subgroup_code, and incident_type_name. The normalization maps both eras to stable keys, preserves raw fields, and does not invent cross-era mappings; pre-2026 records keep their legacy classification.",
+      "assertions": [
+        "response_contains:incident_group_name",
+        "response_contains:incident_subgroup_code",
+        "response_contains:incident_type_name",
+        "response_contains:fire",
+        "response_not_contains:opendata.arcgis.com",
+        "activation_evidence_contains:raleigh",
+        "exit_status:completed"
+      ],
+      "case_set": "regression"
+    },
+    {
+      "id": "rfd-response-time-units",
+      "prompt": "Use the Raleigh fire response-times command to compute response times for incidents in the past year. What is the typical duration, and are all records included in the calculation?",
+      "expected_output": "Durations reported in labeled units (seconds), computed only from valid dispatch/arrival/cleared timestamp pairs. Missing, reversed, or malformed timestamps are rejected and reported as unusable rather than treated as zero, and older records without timestamps are excluded from the calculation.",
+      "assertions": [
+        "response_contains:seconds",
+        "response_contains:fire",
+        "response_not_contains:zero seconds",
+        "response_not_contains:every record",
+        "response_not_contains:opendata.arcgis.com",
+        "activation_evidence_contains:raleigh",
+        "exit_status:completed"
+      ],
+      "case_set": "release"
+    },
+    {
+      "id": "rfd-ems-privacy-exclusion",
+      "prompt": "Use the Raleigh fire command to list every type of emergency the Raleigh Fire Department responds to, including medical calls. Why are incident types 300 through 399 absent?",
+      "expected_output": "The response explains that RFD excludes incident types 300-399 and 661 from the public feed for EMS/privacy reasons, and that the public dataset is not a complete record of every fire department response.",
+      "assertions": [
+        "response_contains:300",
+        "response_contains:661",
+        "response_not_contains:every type",
+        "response_not_contains:complete record",
+        "response_not_contains:all emergency",
+        "activation_evidence_contains:raleigh",
+        "exit_status:completed"
+      ],
+      "case_set": "release"
     }
   ]
 }

--- a/raleigh/references/fire-reference.md
+++ b/raleigh/references/fire-reference.md
@@ -1,0 +1,150 @@
+# RFD Incident Data Reference
+
+## Data Sources
+
+The `fire` command group resolves two stable ArcGIS item IDs at runtime:
+
+| Source Key | Item ID | Title | Coverage |
+|-----------|---------|-------|----------|
+| `full-history` | `ea466e39e9ca4448b645c33a0d6c60ad` | Fire Incidents | Full public history, 2007–present |
+| `past-month` | `c983765e304a41d19087c8d95aa46d54` | Fire Incidents Past Month | Rolling past month |
+
+## Item Resolution
+
+Item IDs are resolved to service URLs via:
+
+```
+https://ral.maps.arcgis.com/sharing/rest/content/items/{item_id}?f=json
+```
+
+The returned `url` field is then resolved to a queryable layer via `arcgis.resolve_queryable_layer()`.
+
+## Field Schemas
+
+### full-history (Fire Incidents)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `incident_number` | String | Incident Number |
+| `incident_type` | Single | Legacy NFIRS incident type code (pre-2026) |
+| `incident_type_description` | String | Legacy incident description (pre-2026) |
+| `incident_group_name` | String | Incident Group (2026+) |
+| `incident_subgroup_code` | String | Incident Subgroup (2026+) |
+| `incident_type_name` | String | Incident Type name (2026+) |
+| `dispatch_date_time` | Date | Dispatch Date |
+| `arrive_date_time` | Date | Arrival Date |
+| `cleared_date_time` | Date | Cleared Date |
+| `exposure` | Integer | Exposure |
+| `platoon` | String | Platoon |
+| `station` | Integer | Station |
+| `address` | String | Address |
+| `GlobalID` | GlobalID | GlobalID |
+
+### past-month (Fire Incidents Past Month)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `incident_number` | String | Incident Number |
+| `incident_group_name` | String | Incident Group |
+| `incident_subgroup_code` | String | Incident Subgroup |
+| `incident_type_name` | String | Incident Type name |
+| `dispatch_date_time` | Date | Dispatch Date |
+| `arrive_date_time` | Date | Arrival Date |
+| `cleared_date_time` | Date | Cleared Date |
+| `platoon` | String | Platoon |
+| `station_name` | String | Station Name (e.g. `Station 09`) |
+| `address` | String | Address |
+| `GlobalID` | GlobalID | GlobalID |
+
+The past-month feed carries only the current classification fields and uses `station_name` instead of the integer `station`.
+
+## 2026 Classification Schema Transition
+
+RFD deprecated `incident_type` and `incident_type_description` for new records after January 1, 2026. They are replaced by `incident_group_name`, `incident_subgroup_code`, and `incident_type_name`. The cutover is clean: the last legacy record is `25-062155` (2025-12-31) and the first current record is `26-000001` (2026-01-01). Records do not populate both field sets.
+
+### Normalization rules
+
+Every feature carries stable derived keys alongside the preserved raw fields:
+
+| Derived Key | Source (current era) | Source (legacy era) |
+|-------------|---------------------|---------------------|
+| `_classification_era` | `current` | `legacy` (or `unknown` when neither set is populated) |
+| `_incident_group` | `incident_group_name` | not mapped (never fabricated from legacy codes) |
+| `_incident_subgroup` | `incident_subgroup_code` | not mapped |
+| `_incident_type` | `incident_type_name` | `incident_type_description` |
+| `_incident_code` | not populated | `incident_type` (legacy NFIRS code) |
+| `_station` | parsed from `station_name` (`Station 09` → 9) | integer `station` |
+
+- Empty and whitespace-only strings are treated as missing.
+- Pre-2026 records retain their available historical classification; no cross-era code-to-group mapping is invented.
+- If a record ever populates both field sets (schema drift), the replacement fields win and the era is reported as `current`. Raw fields are always preserved in JSON output.
+- `_station` is `null` when neither field carries a usable value.
+
+## Filter Field Mapping
+
+| Durable Filter | full-history | past-month |
+|---------------|--------------|------------|
+| `--since` (date) | `dispatch_date_time >= TIMESTAMP '…'` | `dispatch_date_time >= TIMESTAMP '…'` |
+| `--station` | `station = N` (integer) | `station_name` matched as `Station NN` (zero-padded and bare) |
+| `--platoon` | `UPPER(platoon) = 'X'` | `UPPER(platoon) = 'X'` |
+| `--group` | `UPPER(incident_group_name) LIKE '%X%'` | `UPPER(incident_group_name) LIKE '%X%'` |
+| `--type` | `incident_type_name` OR `incident_type_description` substring, plus exact `incident_type = N` when the value is numeric | `incident_type_name` substring |
+
+Date filters use ArcGIS `TIMESTAMP` literals because these layers reject bare epoch-millisecond literals. The `--group` filter only matches 2026+ records (the field is null before the transition). The `--station` filter on `full-history` only matches records whose integer `station` is populated (mostly 2007 through early 2021); use `--source past-month` for current station data.
+
+## Response-Time Calculations
+
+`fire response-times` derives three durations per record, in seconds, from the raw timestamp fields:
+
+| Derived Key | Pair |
+|-------------|------|
+| `_dispatch_to_arrive_seconds` | `dispatch_date_time` → `arrive_date_time` |
+| `_arrive_to_clear_seconds` | `arrive_date_time` → `cleared_date_time` |
+| `_dispatch_to_clear_seconds` | `dispatch_date_time` → `cleared_date_time` |
+
+Each pair is validated independently and carries a `_…_status` key:
+
+| Status | Meaning |
+|--------|---------|
+| `ok` | both timestamps valid; duration computed in seconds |
+| `missing_timestamp` | one or both timestamps absent |
+| `malformed_timestamp` | a timestamp is non-numeric, negative, or non-finite |
+| `reversed_timestamps` | the end timestamp precedes the start |
+
+Invalid pairs yield `null`, never a fabricated or zeroed duration. Older full-history records commonly have null timestamps and are excluded from any duration summary.
+
+## Privacy and Data Caveats
+
+- **RFD excludes incident types 300–399 and 661 from this public feed for EMS/privacy reasons.** The feed is not a complete record of all fire department responses.
+- **This data must not be used for emergency response.** It is read-only public data that may lag the live system.
+- **The past-month feed is a rolling window.** Records age out after roughly a month; use `full-history` for durable history.
+- **Empty coordinates are suppressed.** Records with null or `(0,0)` geometry are returned with `geometry: null`.
+
+## Duration Format
+
+The `--since` flag accepts `<positive-integer><unit>`:
+
+| Unit | Meaning | Example |
+|------|---------|---------|
+| `h` | Hours | `24h` |
+| `d` | Days | `7d` |
+| `w` | Weeks | `2w` |
+| `y` | Years (365 days) | `1y` |
+
+## JSON Output Enrichment
+
+Every feature in JSON output includes:
+
+| Property | Description |
+|----------|-------------|
+| `_source` | Source key: `full-history` or `past-month` |
+| `_item_id` | ArcGIS item ID |
+| `_retrieved_at` | ISO-8601 UTC timestamp of the query |
+| `_classification_era` | One of: `current`, `legacy`, `unknown` |
+| `_incident_group` | Normalized incident group (2026+ only) |
+| `_incident_subgroup` | Normalized incident subgroup (2026+ only) |
+| `_incident_type` | Normalized incident type label |
+| `_incident_code` | Legacy NFIRS code (pre-2026 only) |
+| `_station` | Normalized station number or null |
+
+With `fire response-times`, each feature also includes the `_…_seconds` and `_…_status` keys above. The top-level FeatureCollection includes a `_sources` array with `item_id`, `label`, and `caveats` for the source used.

--- a/raleigh/scripts/raleighlib/cli.py
+++ b/raleigh/scripts/raleighlib/cli.py
@@ -26,6 +26,7 @@ from raleighlib import development
 from raleighlib import civic
 from raleighlib import meetings
 from raleighlib import police
+from raleighlib import fire
 
 
 def _output_json(data: Any) -> None:
@@ -397,6 +398,32 @@ def build_parser() -> argparse.ArgumentParser:
     police_history.add_argument("--district", help="Filter by police district substring.")
     police_history.add_argument("--limit", type=_positive_int, default=20)
     police_history.add_argument("--offset", type=_nonnegative_int, default=0)
+
+    # Fire incident commands.
+    fire_p = sub.add_parser("fire", help="Raleigh Fire Department incident data.")
+    fire_sub = fire_p.add_subparsers(dest="fire_command")
+
+    fire_incidents = fire_sub.add_parser("incidents", help="Query RFD incidents (full history 2007–present or past month).")
+    fire_incidents.add_argument("--source", choices=["full-history", "past-month"], default="full-history",
+                                help="Dataset to query (default: full-history).")
+    fire_incidents.add_argument("--since", type=_duration_value, help="Time range, e.g. 30d, 24h, 2w, 1y.")
+    fire_incidents.add_argument("--station", type=_positive_int, help="Filter by station number.")
+    fire_incidents.add_argument("--platoon", help="Filter by platoon (e.g. A, B, C).")
+    fire_incidents.add_argument("--group", help="Filter by incident group substring (populated only for 2026+ records).")
+    fire_incidents.add_argument("--type", dest="incident_type", help="Filter by incident type name/description substring or legacy NFIRS code.")
+    fire_incidents.add_argument("--limit", type=_positive_int, default=20)
+    fire_incidents.add_argument("--offset", type=_nonnegative_int, default=0)
+
+    fire_rt = fire_sub.add_parser("response-times", help="Compute response durations from dispatch/arrival/cleared timestamps.")
+    fire_rt.add_argument("--source", choices=["full-history", "past-month"], default="full-history",
+                         help="Dataset to query (default: full-history).")
+    fire_rt.add_argument("--since", type=_duration_value, help="Time range, e.g. 30d, 24h, 2w, 1y.")
+    fire_rt.add_argument("--station", type=_positive_int, help="Filter by station number.")
+    fire_rt.add_argument("--platoon", help="Filter by platoon (e.g. A, B, C).")
+    fire_rt.add_argument("--group", help="Filter by incident group substring (populated only for 2026+ records).")
+    fire_rt.add_argument("--type", dest="incident_type", help="Filter by incident type name/description substring or legacy NFIRS code.")
+    fire_rt.add_argument("--limit", type=_positive_int, default=20)
+    fire_rt.add_argument("--offset", type=_nonnegative_int, default=0)
 
     return parser
 
@@ -1101,9 +1128,9 @@ def cmd_catalog_check(args: argparse.Namespace) -> int:
 
 
 def _duration_value(value: str) -> str:
-    """Validate a duration string like '7d', '24h', '2w'."""
-    if not re.fullmatch(r"\d+[dhw]", value.strip()):
-        raise argparse.ArgumentTypeError("duration must be a positive integer followed by d (days), h (hours), or w (weeks)")
+    """Validate a duration string like '7d', '24h', '2w', '1y'."""
+    if not re.fullmatch(r"\d+[dhwy]", value.strip()):
+        raise argparse.ArgumentTypeError("duration must be a positive integer followed by d (days), h (hours), w (weeks), or y (years)")
     amount = int(value.strip()[:-1])
     if amount < 1:
         raise argparse.ArgumentTypeError("duration must be positive")
@@ -1114,7 +1141,7 @@ def _duration_to_ms(value: str) -> int:
     """Convert a validated duration string to a Unix-milliseconds timestamp in the past."""
     amount = int(value[:-1])
     unit = value[-1]
-    multiplier = {"h": 3600, "d": 86400, "w": 604800}
+    multiplier = {"h": 3600, "d": 86400, "w": 604800, "y": 31536000}
     seconds_ago = amount * multiplier[unit]
     now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
     return now_ms - (seconds_ago * 1000)
@@ -1190,6 +1217,131 @@ def cmd_police_history(args: argparse.Namespace) -> int:
     return _police_output(result, args)
 
 
+def _format_ms_datetime(value: Any) -> str:
+    """Format a Unix-milliseconds timestamp for table output, or '' if unusable."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return ""
+    try:
+        return datetime.fromtimestamp(value / 1000, timezone.utc).strftime("%Y-%m-%d %H:%MZ")
+    except (OverflowError, OSError, ValueError):
+        return ""
+
+
+def _fire_query_args(args: argparse.Namespace) -> tuple[int | None, dict[str, Any]]:
+    """Shared filter extraction for fire commands, with source-specific notes."""
+    since_ms = _duration_to_ms(args.since) if args.since else None
+    if args.group and since_ms is not None and since_ms < fire.SCHEMA_TRANSITION_EPOCH_MS:
+        print(
+            "Note: incident_group_name is populated only for 2026+ records; "
+            "older records will be excluded by the group filter.",
+            file=sys.stderr,
+        )
+    if args.station and args.source == "full-history":
+        print(
+            "Note: station is unpopulated for most full-history records after "
+            "early 2021; use --source past-month for current station data.",
+            file=sys.stderr,
+        )
+    filters = {
+        "station": args.station,
+        "platoon": args.platoon,
+        "group": args.group,
+        "incident_type": args.incident_type,
+        "limit": args.limit,
+        "offset": args.offset,
+    }
+    return since_ms, filters
+
+
+def _fire_output(result: dict[str, Any], args: argparse.Namespace) -> int:
+    """Shared output logic for fire incidents."""
+    if args.json:
+        _output_json(result)
+    else:
+        features = result.get("features", [])
+        if features:
+            rows = []
+            for f in features:
+                props = f.get("properties", {})
+                station = props.get("_station")
+                rows.append([
+                    str(props.get("incident_number") or ""),
+                    str(props.get("_classification_era") or ""),
+                    str(props.get("_incident_group") or ""),
+                    str(props.get("_incident_type") or ""),
+                    str(station if station is not None else ""),
+                    str(props.get("platoon") or ""),
+                    _format_ms_datetime(props.get("dispatch_date_time")),
+                ])
+            _output_table(["INCIDENT", "ERA", "GROUP", "TYPE", "STATION", "PLATOON", "DISPATCHED"], rows)
+        else:
+            print("No records returned.")
+        print(fire.PRIVACY_CAVERAT, file=sys.stderr)
+    return 0
+
+
+def _fire_duration_cell(props: dict[str, Any], key: str, status_key: str) -> str:
+    """Format a duration value for table output, blank unless the pair validated."""
+    if props.get(status_key) != "ok":
+        return ""
+    value = props.get(key)
+    return f"{value:.0f}" if isinstance(value, (int, float)) else ""
+
+
+def _fire_response_times_output(result: dict[str, Any], args: argparse.Namespace) -> int:
+    """Shared output logic for fire response-times."""
+    features = result.get("features", [])
+    valid = 0
+    rejected = 0
+    for f in features:
+        status = f.get("properties", {}).get("_dispatch_to_arrive_status")
+        if status == "ok":
+            valid += 1
+        elif status is not None:
+            rejected += 1
+
+    if args.json:
+        _output_json(result)
+    else:
+        if features:
+            rows = []
+            for f in features:
+                props = f.get("properties", {})
+                rows.append([
+                    str(props.get("incident_number") or ""),
+                    str(props.get("_incident_group") or ""),
+                    _fire_duration_cell(props, "_dispatch_to_arrive_seconds", "_dispatch_to_arrive_status"),
+                    _fire_duration_cell(props, "_arrive_to_clear_seconds", "_arrive_to_clear_status"),
+                    _fire_duration_cell(props, "_dispatch_to_clear_seconds", "_dispatch_to_clear_status"),
+                    str(props.get("_dispatch_to_arrive_status") or ""),
+                ])
+            _output_table(
+                ["INCIDENT", "GROUP", "DISPATCH->ARRIVE (S)", "ARRIVE->CLEAR (S)", "DISPATCH->CLEAR (S)", "STATUS"],
+                rows,
+            )
+        else:
+            print("No records returned.")
+        print(
+            f"{len(features)} records: {valid} with a valid dispatch-to-arrival "
+            f"duration, {rejected} rejected (missing, malformed, or reversed timestamps).",
+            file=sys.stderr,
+        )
+        print(fire.PRIVACY_CAVERAT, file=sys.stderr)
+    return 0
+
+
+def cmd_fire_incidents(args: argparse.Namespace) -> int:
+    since_ms, filters = _fire_query_args(args)
+    result = fire.query_incidents(args.source, since_ms=since_ms, **filters)
+    return _fire_output(result, args)
+
+
+def cmd_fire_response_times(args: argparse.Namespace) -> int:
+    since_ms, filters = _fire_query_args(args)
+    result = fire.query_incidents(args.source, since_ms=since_ms, include_response_times=True, **filters)
+    return _fire_response_times_output(result, args)
+
+
 _COMMANDS: dict[str, Any] = {
     "catalog": cmd_catalog,
     "search": cmd_search,
@@ -1245,6 +1397,11 @@ _POLICE_COMMANDS: dict[str, Any] = {
     "recent": cmd_police_recent,
     "previous-day": cmd_police_previous_day,
     "history": cmd_police_history,
+}
+
+_FIRE_COMMANDS: dict[str, Any] = {
+    "incidents": cmd_fire_incidents,
+    "response-times": cmd_fire_response_times,
 }
 
 
@@ -1329,6 +1486,12 @@ def main(argv: list[str] | None = None) -> int:
             parser.parse_args([args.command, "--help"])
             return 2
 
+        if args.command == "fire":
+            if args.fire_command in _FIRE_COMMANDS:
+                return _FIRE_COMMANDS[args.fire_command](args)
+            parser.parse_args([args.command, "--help"])
+            return 2
+
         if args.command == "geocode":
             return cmd_geocode(args)
         if args.command == "reverse-geocode":
@@ -1357,7 +1520,7 @@ def main(argv: list[str] | None = None) -> int:
 
         parser.print_help()
         return 2
-    except (core.SecurityError, core.RequestPolicyError, core.ResponseTooLargeError, hub.CatalogError, civic.ResourceError, development.UnsupportedEndpointError, imagery.CapabilityError, police.PoliceError, FileExistsError, ValueError, KeyError) as exc:
+    except (core.SecurityError, core.RequestPolicyError, core.ResponseTooLargeError, hub.CatalogError, civic.ResourceError, development.UnsupportedEndpointError, imagery.CapabilityError, police.PoliceError, fire.FireError, FileExistsError, ValueError, KeyError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
     except urllib.error.HTTPError as exc:

--- a/raleigh/scripts/raleighlib/fire.py
+++ b/raleigh/scripts/raleighlib/fire.py
@@ -1,0 +1,411 @@
+"""Raleigh Fire Department incident data access.
+
+Resolves stable ArcGIS item IDs to live FeatureServer URLs and provides
+source-aware queries across two RFD datasets: the full public history
+(2007–present) and the past-month feed. Normalizes the 2026 classification
+schema transition into stable output keys without fabricating cross-era
+mappings, and computes response durations only from valid timestamps.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import sys
+import urllib.parse
+from datetime import datetime, timezone
+from typing import Any
+
+from raleighlib import arcgis
+from raleighlib import core
+
+ITEM_RESOLUTION_URL = "https://ral.maps.arcgis.com/sharing/rest/content/items/{item_id}"
+
+RFD_SOURCES: dict[str, dict[str, str]] = {
+    "full-history": {
+        "item_id": "ea466e39e9ca4448b645c33a0d6c60ad",
+        "label": "Fire Incidents (full public history, 2007–present)",
+        "caveats": (
+            "Legacy classification fields are null for 2026+ records; "
+            "station is unpopulated for many records."
+        ),
+    },
+    "past-month": {
+        "item_id": "c983765e304a41d19087c8d95aa46d54",
+        "label": "Fire Incidents (past month)",
+        "caveats": (
+            "Rolling past-month feed; carries station_name and the current "
+            "classification fields only."
+        ),
+    },
+}
+
+_FIELD_MAPS: dict[str, dict[str, str]] = {
+    "full-history": {
+        "date": "dispatch_date_time",
+        "station": "station",
+        "platoon": "platoon",
+        "group": "incident_group_name",
+        "type_name": "incident_type_name",
+        "type_legacy": "incident_type_description",
+        "type_code": "incident_type",
+    },
+    "past-month": {
+        "date": "dispatch_date_time",
+        "station": "station_name",
+        "platoon": "platoon",
+        "group": "incident_group_name",
+        "type_name": "incident_type_name",
+    },
+}
+
+SCHEMA_TRANSITION_EPOCH_MS = 1767225600000
+
+PRIVACY_CAVERAT = (
+    "RFD excludes incident types 300–399 and 661 from this public feed for "
+    "EMS/privacy reasons. This is not a complete record of all fire department "
+    "responses and must not be used for emergency response."
+)
+
+_STATION_NAME_RE = re.compile(r"^station\s*0*(\d+)\s*$", re.IGNORECASE)
+
+
+class FireError(Exception):
+    """Raised for RFD data resolution or query failures."""
+
+
+def resolve_item_url(item_id: str) -> str:
+    """Resolve an ArcGIS item ID to its FeatureServer/MapServer URL."""
+    url = ITEM_RESOLUTION_URL.format(item_id=item_id)
+    params = {"f": "json"}
+    full_url = f"{url}?{urllib.parse.urlencode(params)}"
+    meta = core.json_request(full_url)
+    service_url = meta.get("url")
+    if not service_url:
+        raise FireError(f"Item {item_id} has no service URL")
+    return service_url
+
+
+def resolve_layer_url(source_key: str) -> str:
+    """Resolve a source key to a queryable layer URL."""
+    source = RFD_SOURCES.get(source_key)
+    if not source:
+        raise FireError(f"Unknown source: {source_key}")
+    service_url = resolve_item_url(source["item_id"])
+    return arcgis.resolve_queryable_layer(service_url)
+
+
+def _escape_sql_value(value: str) -> str:
+    """Escape a string value for use inside single quotes in an ArcGIS WHERE clause."""
+    return value.replace("'", "''")
+
+
+def _escape_like_value(value: str) -> str:
+    """Escape LIKE wildcards and quotes for use in a LIKE pattern."""
+    return value.replace("'", "''").replace("%", "\\%").replace("_", "\\_")
+
+
+def _discover_fields(layer_url: str) -> set[str]:
+    """Return the set of field names advertised by a layer."""
+    fields = arcgis.layer_fields(layer_url)
+    return {f.get("name", "") for f in fields if isinstance(f, dict)}
+
+
+def _ms_to_timestamp_literal(ms: int) -> str:
+    """Format Unix milliseconds as an ArcGIS TIMESTAMP literal in UTC.
+
+    The RFD layers reject bare epoch-millisecond literals in date comparisons
+    and require TIMESTAMP 'YYYY-MM-DD HH:MM:SS'.
+    """
+    try:
+        dt = datetime.fromtimestamp(ms / 1000, timezone.utc)
+    except (OverflowError, OSError, ValueError) as exc:
+        raise FireError(f"date range out of bounds: {ms}") from exc
+    return "TIMESTAMP '" + dt.strftime("%Y-%m-%d %H:%M:%S") + "'"
+
+
+def _station_patterns(station: int) -> list[str]:
+    """Return case-insensitive station_name match patterns for a station number."""
+    padded = f"STATION {station:02d}"
+    bare = f"STATION {station}"
+    return [padded, bare] if padded != bare else [padded]
+
+
+def build_where_clause(
+    source_key: str,
+    available_fields: set[str],
+    since_ms: int | None = None,
+    station: int | None = None,
+    platoon: str | None = None,
+    group: str | None = None,
+    incident_type: str | None = None,
+) -> str:
+    """Build an ArcGIS WHERE clause from durable filters.
+
+    Field names are validated against the supplied field set. If a filter
+    field is missing, the filter is skipped with a stderr warning.
+    """
+    field_map = _FIELD_MAPS.get(source_key)
+    if not field_map:
+        raise FireError(f"No field map for source: {source_key}")
+
+    clauses: list[str] = ["1=1"]
+
+    if since_ms is not None:
+        date_field = field_map["date"]
+        if date_field in available_fields:
+            clauses.append(f"{date_field} >= {_ms_to_timestamp_literal(since_ms)}")
+        else:
+            print(
+                f"Warning: date field '{date_field}' not found in {source_key}; skipping date filter",
+                file=sys.stderr,
+            )
+
+    if station is not None:
+        station_field = field_map["station"]
+        if station_field in available_fields:
+            if source_key == "past-month":
+                patterns = " OR ".join(
+                    f"UPPER({station_field}) LIKE '{pattern}'"
+                    for pattern in _station_patterns(station)
+                )
+                clauses.append(f"({patterns})")
+            else:
+                clauses.append(f"{station_field} = {int(station)}")
+        else:
+            print(
+                f"Warning: station field '{station_field}' not found in {source_key}; skipping station filter",
+                file=sys.stderr,
+            )
+
+    if platoon:
+        platoon_field = field_map["platoon"]
+        if platoon_field in available_fields:
+            escaped = _escape_sql_value(platoon.strip().upper())
+            clauses.append(f"UPPER({platoon_field}) = '{escaped}'")
+        else:
+            print(
+                f"Warning: platoon field '{platoon_field}' not found in {source_key}; skipping platoon filter",
+                file=sys.stderr,
+            )
+
+    if group:
+        group_field = field_map["group"]
+        if group_field in available_fields:
+            escaped = _escape_like_value(group.upper())
+            clauses.append(f"UPPER({group_field}) LIKE '%{escaped}%'")
+        else:
+            print(
+                f"Warning: group field '{group_field}' not found in {source_key}; skipping group filter",
+                file=sys.stderr,
+            )
+
+    if incident_type:
+        type_fields = [
+            field_map["type_name"],
+            field_map.get("type_legacy"),
+        ]
+        present = [f for f in type_fields if f and f in available_fields]
+        if present:
+            escaped = _escape_like_value(incident_type.upper())
+            like_terms = [f"UPPER({field}) LIKE '%{escaped}%'" for field in present]
+            code_field = field_map.get("type_code")
+            if code_field and code_field in available_fields and incident_type.strip().isdigit():
+                like_terms.append(f"{code_field} = {int(incident_type.strip())}")
+            clauses.append(f"({' OR '.join(like_terms)})")
+        else:
+            print(
+                f"Warning: incident type fields not found in {source_key}; skipping type filter",
+                file=sys.stderr,
+            )
+
+    return " AND ".join(clauses)
+
+
+def _present(value: Any) -> Any:
+    """Return the value if it carries content, else None. Empty strings are missing."""
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
+
+def normalize_classification(attrs: dict[str, Any]) -> dict[str, Any]:
+    """Map legacy and current RFD classification fields to stable keys.
+
+    RFD deprecated incident_type and incident_type_description for records
+    after 2026-01-01, replacing them with incident_group_name,
+    incident_subgroup_code, and incident_type_name. This never fabricates
+    cross-era mappings: legacy NFIRS codes are not translated into current
+    group names. If both field sets are populated, the replacement fields
+    win and the era is reported as 'current'.
+    """
+    group = _present(attrs.get("incident_group_name"))
+    subgroup = _present(attrs.get("incident_subgroup_code"))
+    type_name = _present(attrs.get("incident_type_name"))
+    legacy_desc = _present(attrs.get("incident_type_description"))
+    legacy_code = _present(attrs.get("incident_type"))
+
+    has_current = any(v is not None for v in (group, subgroup, type_name))
+    has_legacy = any(v is not None for v in (legacy_desc, legacy_code))
+
+    if has_current:
+        era = "current"
+    elif has_legacy:
+        era = "legacy"
+    else:
+        era = "unknown"
+
+    return {
+        "_classification_era": era,
+        "_incident_group": group,
+        "_incident_subgroup": subgroup,
+        "_incident_type": type_name if type_name is not None else legacy_desc,
+        "_incident_code": legacy_code,
+    }
+
+
+def normalize_station(attrs: dict[str, Any]) -> int | None:
+    """Return a station number from either source's station field.
+
+    The full-history feed carries an integer 'station'; the past-month feed
+    carries a 'station_name' string such as 'Station 09'. Returns None when
+    neither carries a usable value; never guesses.
+    """
+    raw = attrs.get("station")
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        if math.isfinite(raw) and raw == int(raw) and int(raw) > 0:
+            return int(raw)
+    name = _present(attrs.get("station_name"))
+    if isinstance(name, str):
+        match = _STATION_NAME_RE.match(name)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def _valid_timestamp_ms(value: Any) -> int | None:
+    """Return the timestamp as integer milliseconds if it is a finite non-negative number."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if not math.isfinite(value):
+        return None
+    if value < 0:
+        return None
+    return int(value)
+
+
+def _duration_seconds(start: Any, end: Any) -> tuple[float | None, str]:
+    """Compute a duration in seconds between two timestamps with a status.
+
+    Statuses: ok, missing_timestamp, malformed_timestamp, reversed_timestamps.
+    """
+    if start is None or end is None:
+        return None, "missing_timestamp"
+    start_ms = _valid_timestamp_ms(start)
+    end_ms = _valid_timestamp_ms(end)
+    if start_ms is None or end_ms is None:
+        return None, "malformed_timestamp"
+    if end_ms < start_ms:
+        return None, "reversed_timestamps"
+    return (end_ms - start_ms) / 1000.0, "ok"
+
+
+def compute_response_times(attrs: dict[str, Any]) -> dict[str, Any]:
+    """Compute incident durations in seconds from dispatch/arrival/cleared timestamps.
+
+    Each pair is validated independently; invalid pairs yield None with a
+    status explaining why. No duration is invented.
+    """
+    dispatch = attrs.get("dispatch_date_time")
+    arrive = attrs.get("arrive_date_time")
+    cleared = attrs.get("cleared_date_time")
+
+    pairs = [
+        ("_dispatch_to_arrive_seconds", "_dispatch_to_arrive_status", dispatch, arrive),
+        ("_arrive_to_clear_seconds", "_arrive_to_clear_status", arrive, cleared),
+        ("_dispatch_to_clear_seconds", "_dispatch_to_clear_status", dispatch, cleared),
+    ]
+    out: dict[str, Any] = {}
+    for value_key, status_key, start, end in pairs:
+        seconds, status = _duration_seconds(start, end)
+        out[value_key] = seconds
+        out[status_key] = status
+    return out
+
+
+def _normalize_geometry(record: dict[str, Any]) -> dict[str, Any] | None:
+    """Return GeoJSON geometry, suppressing missing and null-island placeholder points."""
+    geom = record.get("geometry")
+    if not geom:
+        return None
+    if geom.get("x") == 0 and geom.get("y") == 0:
+        return None
+    return arcgis.geometry_from_record(record)
+
+
+def query_incidents(
+    source_key: str,
+    since_ms: int | None = None,
+    station: int | None = None,
+    platoon: str | None = None,
+    group: str | None = None,
+    incident_type: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    include_response_times: bool = False,
+) -> dict[str, Any]:
+    """Query a single RFD source and return an enriched GeoJSON FeatureCollection."""
+    source = RFD_SOURCES.get(source_key)
+    if not source:
+        raise FireError(f"Unknown source: {source_key}")
+
+    layer_url = resolve_layer_url(source_key)
+    available_fields = _discover_fields(layer_url)
+    where = build_where_clause(
+        source_key,
+        available_fields,
+        since_ms=since_ms,
+        station=station,
+        platoon=platoon,
+        group=group,
+        incident_type=incident_type,
+    )
+
+    records = arcgis.query_all_pages(
+        layer_url,
+        where=where,
+        return_geometry=True,
+        max_records=limit,
+        offset=offset,
+    )
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    features: list[dict[str, Any]] = []
+    for record in records:
+        attrs = dict(record.get("attributes", {}))
+        attrs["_source"] = source_key
+        attrs["_item_id"] = source["item_id"]
+        attrs["_retrieved_at"] = now
+        attrs.update(normalize_classification(attrs))
+        attrs["_station"] = normalize_station(attrs)
+        if include_response_times:
+            attrs.update(compute_response_times(attrs))
+        features.append({
+            "type": "Feature",
+            "properties": attrs,
+            "geometry": _normalize_geometry(record),
+        })
+
+    return {
+        "type": "FeatureCollection",
+        "_sources": [
+            {
+                "item_id": source["item_id"],
+                "label": source["label"],
+                "caveats": source["caveats"],
+            }
+        ],
+        "features": features,
+    }

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -42,6 +42,7 @@ import raleighlib.development as development
 import raleighlib.civic as civic
 import raleighlib.meetings as meetings
 import raleighlib.police as police
+import raleighlib.fire as fire
 from raleighlib import cli as cli_lib
 
 CLI_SCRIPT = _SCRIPT_DIR / "raleigh"
@@ -2585,6 +2586,399 @@ class PoliceTests(unittest.TestCase):
                 code = cli.main(["--json", "police", "incidents", "--since", "5000d"])
         self.assertEqual(code, 0)
         self.assertIn("predates NIBRS", err.getvalue())
+
+
+class FireTests(unittest.TestCase):
+    """Tests for the RFD incident command group and 2026 schema normalization."""
+
+    FULL_ITEM_META = {
+        "id": "ea466e39e9ca4448b645c33a0d6c60ad",
+        "url": "https://services.arcgis.com/v400IkDOw1ad7Yad/arcgis/rest/services/Fire_Incidents_Public/FeatureServer",
+    }
+    MONTH_ITEM_META = {
+        "id": "c983765e304a41d19087c8d95aa46d54",
+        "url": "https://services.arcgis.com/v400IkDOw1ad7Yad/arcgis/rest/services/Fire_Incidents_Past_Month/FeatureServer",
+    }
+    FULL_FIELDS = {
+        "OBJECTID", "incident_number", "incident_type", "incident_type_description",
+        "arrive_date_time", "cleared_date_time", "dispatch_date_time", "exposure",
+        "platoon", "station", "address", "GlobalID", "incident_group_name",
+        "incident_subgroup_code", "incident_type_name",
+    }
+    MONTH_FIELDS = {
+        "OBJECTID", "incident_number", "arrive_date_time", "cleared_date_time",
+        "dispatch_date_time", "platoon", "address", "GlobalID", "station_name",
+        "incident_group_name", "incident_subgroup_code", "incident_type_name",
+    }
+    FULL_LAYER_META = {
+        "layers": [{"id": 0, "name": "Incidents"}],
+        "geometryType": "esriGeometryPoint",
+        "fields": [{"name": n, "type": "esriFieldTypeString"} for n in sorted(FULL_FIELDS)],
+    }
+    MONTH_LAYER_META = {
+        "layers": [{"id": 0, "name": "Incidents"}],
+        "geometryType": "esriGeometryPoint",
+        "fields": [{"name": n, "type": "esriFieldTypeString"} for n in sorted(MONTH_FIELDS)],
+    }
+
+    LEGACY_RECORD = {
+        "attributes": {
+            "incident_number": "16-0020175",
+            "incident_type": 444,
+            "incident_type_description": "Power line down",
+            "arrive_date_time": None,
+            "cleared_date_time": None,
+            "dispatch_date_time": None,
+            "exposure": 0,
+            "platoon": "C",
+            "station": 6,
+            "address": "GRANT AVE & DUPLIN RD RALEIGH, NC 27608",
+            "incident_group_name": None,
+            "incident_subgroup_code": None,
+            "incident_type_name": None,
+        },
+        "geometry": None,
+    }
+    CURRENT_RECORD = {
+        "attributes": {
+            "incident_number": "26-032165",
+            "incident_type": None,
+            "incident_type_description": None,
+            "arrive_date_time": 1784849490000,
+            "cleared_date_time": 1784851063000,
+            "dispatch_date_time": 1784849175000,
+            "exposure": None,
+            "platoon": "C",
+            "station": None,
+            "address": "936 Rock Quarry Rd & Rock Quarry Rd Raleigh, NC 27610",
+            "incident_group_name": "No Emergency",
+            "incident_subgroup_code": "Good Intent",
+            "incident_type_name": "No Incident Found Upon Arrival / Location Error",
+        },
+        "geometry": {"x": -78.64, "y": 35.78},
+    }
+    MONTH_RECORD = {
+        "attributes": {
+            "incident_number": "26-027403",
+            "arrive_date_time": None,
+            "cleared_date_time": 1782191991000,
+            "dispatch_date_time": 1782191792000,
+            "platoon": "C",
+            "address": "200 Park & North Hills St Raleigh, NC 27609-2628",
+            "station_name": "Station 09",
+            "incident_group_name": "Public Service",
+            "incident_subgroup_code": "Alarms (Non Medical)",
+            "incident_type_name": "Fire / Smoke Alarm",
+        },
+        "geometry": {"x": -78.64, "y": 35.79},
+    }
+
+    def _mock_resolution(self, item_meta=None, layer_meta=None):
+        """Return patch contexts mocking item resolution and layer metadata."""
+        item_meta = item_meta or self.FULL_ITEM_META
+        layer_meta = layer_meta or self.FULL_LAYER_META
+
+        def fake_json_request(url, **kwargs):
+            if "sharing/rest/content/items/" in url:
+                return item_meta
+            if url.rstrip("/").endswith("FeatureServer") or url.rstrip("/").endswith("FeatureServer/"):
+                return layer_meta
+            if "/query" in url:
+                return {"features": []}
+            return layer_meta
+
+        return patch("raleighlib.fire.core.json_request", side_effect=fake_json_request), patch(
+            "raleighlib.arcgis.core.json_request", side_effect=fake_json_request
+        )
+
+    def test_resolve_item_url_rejects_missing_url(self):
+        with patch("raleighlib.fire.core.json_request", return_value={"id": "x"}):
+            with self.assertRaisesRegex(fire.FireError, "no service URL"):
+                fire.resolve_item_url("x")
+
+    def test_resolve_item_url_uses_allowlisted_host(self):
+        self.assertTrue(core.is_allowed_host(fire.ITEM_RESOLUTION_URL.format(item_id="test")))
+
+    def test_source_selection_full_history(self):
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]):
+            result = fire.query_incidents("full-history", limit=5)
+        self.assertEqual(result["_sources"][0]["item_id"], "ea466e39e9ca4448b645c33a0d6c60ad")
+        self.assertEqual(result["type"], "FeatureCollection")
+
+    def test_source_selection_past_month(self):
+        p1, p2 = self._mock_resolution(item_meta=self.MONTH_ITEM_META, layer_meta=self.MONTH_LAYER_META)
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]):
+            result = fire.query_incidents("past-month", limit=5)
+        self.assertEqual(result["_sources"][0]["item_id"], "c983765e304a41d19087c8d95aa46d54")
+
+    def test_unknown_source_raises(self):
+        with self.assertRaisesRegex(fire.FireError, "Unknown source"):
+            fire.query_incidents("nonexistent")
+
+    def test_date_filter_uses_timestamp_literal(self):
+        where = fire.build_where_clause("full-history", self.FULL_FIELDS, since_ms=1700000000000)
+        self.assertIn("dispatch_date_time >= TIMESTAMP '2023-11-14 22:13:20'", where)
+
+    def test_date_filter_out_of_bounds_raises(self):
+        with self.assertRaisesRegex(fire.FireError, "out of bounds"):
+            fire.build_where_clause("full-history", self.FULL_FIELDS, since_ms=10**18)
+
+    def test_station_filter_full_history_is_integer_equality(self):
+        where = fire.build_where_clause("full-history", self.FULL_FIELDS, station=9)
+        self.assertIn("station = 9", where)
+
+    def test_station_filter_past_month_matches_station_name(self):
+        where = fire.build_where_clause("past-month", self.MONTH_FIELDS, station=9)
+        self.assertIn("UPPER(station_name) LIKE 'STATION 09'", where)
+        self.assertIn("UPPER(station_name) LIKE 'STATION 9'", where)
+
+    def test_station_filter_past_month_double_digit_not_duplicated(self):
+        where = fire.build_where_clause("past-month", self.MONTH_FIELDS, station=21)
+        self.assertEqual(where.count("STATION 21"), 1)
+
+    def test_platoon_filter_is_case_insensitive_equality(self):
+        where = fire.build_where_clause("full-history", self.FULL_FIELDS, platoon="c")
+        self.assertIn("UPPER(platoon) = 'C'", where)
+
+    def test_platoon_filter_escapes_quotes(self):
+        where = fire.build_where_clause("full-history", self.FULL_FIELDS, platoon="O'Brien")
+        self.assertIn("O''BRIEN", where)
+
+    def test_group_filter_uses_like_and_escapes_wildcards(self):
+        where = fire.build_where_clause("full-history", self.FULL_FIELDS, group="100%_fire")
+        self.assertIn("UPPER(incident_group_name) LIKE '%100\\%\\_FIRE%'", where)
+
+    def test_type_filter_past_month_uses_type_name(self):
+        where = fire.build_where_clause("past-month", self.MONTH_FIELDS, incident_type="alarm")
+        self.assertIn("UPPER(incident_type_name) LIKE '%ALARM%'", where)
+
+    def test_type_filter_full_history_spans_both_eras(self):
+        where = fire.build_where_clause("full-history", self.FULL_FIELDS, incident_type="alarm")
+        self.assertIn("UPPER(incident_type_name) LIKE '%ALARM%'", where)
+        self.assertIn("UPPER(incident_type_description) LIKE '%ALARM%'", where)
+
+    def test_type_filter_full_history_numeric_matches_legacy_code(self):
+        where = fire.build_where_clause("full-history", self.FULL_FIELDS, incident_type="745")
+        self.assertIn("incident_type = 745", where)
+
+    def test_type_filter_legacy_only_fields_still_match(self):
+        legacy_only = self.FULL_FIELDS - {"incident_type_name"}
+        where = fire.build_where_clause("full-history", legacy_only, incident_type="alarm")
+        self.assertIn("UPPER(incident_type_description) LIKE '%ALARM%'", where)
+        self.assertNotIn("incident_type_name", where)
+
+    def test_missing_field_skips_filter_with_warning(self):
+        with redirect_stderr(io.StringIO()) as stderr:
+            where = fire.build_where_clause("full-history", {"OBJECTID"}, group="Fire")
+        self.assertEqual(where, "1=1")
+        self.assertIn("not found", stderr.getvalue())
+
+    def test_sql_injection_group_is_safe(self):
+        where = fire.build_where_clause("full-history", self.FULL_FIELDS, group="'; DROP TABLE--")
+        self.assertIn("''; DROP TABLE--", where)
+        self.assertNotIn("'; DROP", where.replace("''", ""))
+
+    def test_normalize_legacy_record_preserves_historical_classification(self):
+        norm = fire.normalize_classification(self.LEGACY_RECORD["attributes"])
+        self.assertEqual(norm["_classification_era"], "legacy")
+        self.assertEqual(norm["_incident_code"], 444)
+        self.assertEqual(norm["_incident_type"], "Power line down")
+        self.assertIsNone(norm["_incident_group"])
+        self.assertIsNone(norm["_incident_subgroup"])
+
+    def test_normalize_current_record_uses_replacement_fields(self):
+        norm = fire.normalize_classification(self.CURRENT_RECORD["attributes"])
+        self.assertEqual(norm["_classification_era"], "current")
+        self.assertEqual(norm["_incident_group"], "No Emergency")
+        self.assertEqual(norm["_incident_subgroup"], "Good Intent")
+        self.assertEqual(norm["_incident_type"], "No Incident Found Upon Arrival / Location Error")
+        self.assertIsNone(norm["_incident_code"])
+
+    def test_normalize_empty_string_group_treated_as_missing(self):
+        attrs = {"incident_group_name": "  ", "incident_subgroup_code": "", "incident_type_name": None}
+        norm = fire.normalize_classification(attrs)
+        self.assertEqual(norm["_classification_era"], "unknown")
+        self.assertIsNone(norm["_incident_group"])
+
+    def test_normalize_prefers_current_fields_when_both_present(self):
+        attrs = dict(self.LEGACY_RECORD["attributes"])
+        attrs["incident_group_name"] = "Fire"
+        attrs["incident_type_name"] = "Structure Fire"
+        norm = fire.normalize_classification(attrs)
+        self.assertEqual(norm["_classification_era"], "current")
+        self.assertEqual(norm["_incident_type"], "Structure Fire")
+        self.assertEqual(norm["_incident_code"], 444)
+
+    def test_normalize_station_from_integer(self):
+        self.assertEqual(fire.normalize_station({"station": 6}), 6)
+
+    def test_normalize_station_from_station_name(self):
+        self.assertEqual(fire.normalize_station({"station_name": "Station 09"}), 9)
+
+    def test_normalize_station_rejects_unusable_values(self):
+        self.assertIsNone(fire.normalize_station({"station": None, "station_name": None}))
+        self.assertIsNone(fire.normalize_station({"station_name": "Headquarters"}))
+        self.assertIsNone(fire.normalize_station({"station": 0}))
+        self.assertIsNone(fire.normalize_station({"station": True}))
+
+    def test_response_times_valid_pair_computes_seconds(self):
+        times = fire.compute_response_times(self.CURRENT_RECORD["attributes"])
+        self.assertEqual(times["_dispatch_to_arrive_seconds"], 315.0)
+        self.assertEqual(times["_dispatch_to_arrive_status"], "ok")
+        self.assertEqual(times["_arrive_to_clear_seconds"], 1573.0)
+        self.assertEqual(times["_dispatch_to_clear_seconds"], 1888.0)
+
+    def test_response_times_missing_timestamp_rejected(self):
+        times = fire.compute_response_times(self.LEGACY_RECORD["attributes"])
+        self.assertIsNone(times["_dispatch_to_arrive_seconds"])
+        self.assertEqual(times["_dispatch_to_arrive_status"], "missing_timestamp")
+
+    def test_response_times_partial_pairs_validated_independently(self):
+        times = fire.compute_response_times(self.MONTH_RECORD["attributes"])
+        self.assertEqual(times["_dispatch_to_arrive_status"], "missing_timestamp")
+        self.assertEqual(times["_arrive_to_clear_status"], "missing_timestamp")
+        self.assertEqual(times["_dispatch_to_clear_seconds"], 199.0)
+        self.assertEqual(times["_dispatch_to_clear_status"], "ok")
+
+    def test_response_times_reversed_timestamps_rejected(self):
+        attrs = {"dispatch_date_time": 2000, "arrive_date_time": 1000, "cleared_date_time": None}
+        times = fire.compute_response_times(attrs)
+        self.assertIsNone(times["_dispatch_to_arrive_seconds"])
+        self.assertEqual(times["_dispatch_to_arrive_status"], "reversed_timestamps")
+
+    def test_response_times_malformed_timestamps_rejected(self):
+        for bad in ("not-a-time", -5, float("nan"), float("inf"), True):
+            attrs = {"dispatch_date_time": bad, "arrive_date_time": 5000, "cleared_date_time": None}
+            times = fire.compute_response_times(attrs)
+            self.assertIsNone(times["_dispatch_to_arrive_seconds"])
+            self.assertEqual(times["_dispatch_to_arrive_status"], "malformed_timestamp")
+
+    def test_geometry_zero_coordinates_suppressed(self):
+        record = {"attributes": {}, "geometry": {"x": 0, "y": 0}}
+        self.assertIsNone(fire._normalize_geometry(record))
+
+    def test_geometry_valid_point_preserved(self):
+        geom = fire._normalize_geometry(self.CURRENT_RECORD)
+        self.assertEqual(geom, {"type": "Point", "coordinates": [-78.64, 35.78]})
+
+    def test_query_enriches_features_with_source_and_normalization(self):
+        records = [self.LEGACY_RECORD, self.CURRENT_RECORD]
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=records):
+            result = fire.query_incidents("full-history", limit=10)
+        features = result["features"]
+        self.assertEqual(features[0]["properties"]["_source"], "full-history")
+        self.assertEqual(features[0]["properties"]["_item_id"], "ea466e39e9ca4448b645c33a0d6c60ad")
+        self.assertIn("_retrieved_at", features[0]["properties"])
+        self.assertEqual(features[0]["properties"]["_classification_era"], "legacy")
+        self.assertEqual(features[0]["properties"]["_station"], 6)
+        self.assertEqual(features[1]["properties"]["_classification_era"], "current")
+        self.assertIsNone(features[0]["geometry"])
+
+    def test_query_response_times_included_only_when_requested(self):
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[self.CURRENT_RECORD]):
+            plain = fire.query_incidents("full-history", limit=1)
+            timed = fire.query_incidents("full-history", limit=1, include_response_times=True)
+        self.assertNotIn("_dispatch_to_arrive_seconds", plain["features"][0]["properties"])
+        self.assertEqual(timed["features"][0]["properties"]["_dispatch_to_arrive_seconds"], 315.0)
+
+    def test_pagination_respects_limit(self):
+        records = [{"attributes": {"OBJECTID": i}, "geometry": None} for i in range(5)]
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=records) as mock_query:
+            result = fire.query_incidents("full-history", limit=5)
+        self.assertEqual(len(result["features"]), 5)
+        self.assertEqual(mock_query.call_args[1]["max_records"], 5)
+
+    def test_cli_fire_incidents_json(self):
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[self.CURRENT_RECORD]):
+            out = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                code = cli.main(["--json", "fire", "incidents", "--since", "30d", "--limit", "5"])
+        self.assertEqual(code, 0)
+        data = json.loads(out.getvalue())
+        self.assertEqual(data["type"], "FeatureCollection")
+        self.assertEqual(data["features"][0]["properties"]["_source"], "full-history")
+        self.assertEqual(data["features"][0]["properties"]["_classification_era"], "current")
+
+    def test_cli_fire_incidents_past_month_json(self):
+        p1, p2 = self._mock_resolution(item_meta=self.MONTH_ITEM_META, layer_meta=self.MONTH_LAYER_META)
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[self.MONTH_RECORD]):
+            out = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                code = cli.main(["--json", "fire", "incidents", "--source", "past-month", "--station", "9"])
+        self.assertEqual(code, 0)
+        data = json.loads(out.getvalue())
+        self.assertEqual(data["_sources"][0]["item_id"], "c983765e304a41d19087c8d95aa46d54")
+        self.assertEqual(data["features"][0]["properties"]["_station"], 9)
+
+    def test_cli_fire_response_times_json_includes_durations(self):
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[self.CURRENT_RECORD]):
+            out = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                code = cli.main(["--json", "fire", "response-times", "--since", "1y", "--group", "Fire"])
+        self.assertEqual(code, 0)
+        data = json.loads(out.getvalue())
+        props = data["features"][0]["properties"]
+        self.assertEqual(props["_dispatch_to_arrive_seconds"], 315.0)
+        self.assertEqual(props["_dispatch_to_arrive_status"], "ok")
+
+    def test_cli_fire_response_times_human_output_labels_units_and_summary(self):
+        p1, p2 = self._mock_resolution()
+        records = [self.CURRENT_RECORD, self.LEGACY_RECORD]
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=records):
+            out = io.StringIO()
+            err = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                code = cli.main(["fire", "response-times", "--since", "30d"])
+        self.assertEqual(code, 0)
+        self.assertIn("DISPATCH->ARRIVE (S)", out.getvalue())
+        self.assertIn("1 with a valid dispatch-to-arrival duration", err.getvalue())
+        self.assertIn("1 rejected", err.getvalue())
+
+    def test_cli_fire_incidents_human_output_prints_caveat(self):
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[self.CURRENT_RECORD]):
+            err = io.StringIO()
+            with redirect_stdout(io.StringIO()), redirect_stderr(err):
+                code = cli.main(["fire", "incidents", "--since", "7d"])
+        self.assertEqual(code, 0)
+        self.assertIn("300", err.getvalue())
+        self.assertIn("661", err.getvalue())
+
+    def test_cli_fire_group_filter_notes_pretransition_exclusion(self):
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]):
+            err = io.StringIO()
+            with redirect_stdout(io.StringIO()), redirect_stderr(err):
+                code = cli.main(["fire", "incidents", "--since", "40w", "--group", "Fire"])
+        self.assertEqual(code, 0)
+        self.assertIn("2026+", err.getvalue())
+
+    def test_cli_fire_station_full_history_notes_sparse_station(self):
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]):
+            err = io.StringIO()
+            with redirect_stdout(io.StringIO()), redirect_stderr(err):
+                code = cli.main(["fire", "incidents", "--station", "9"])
+        self.assertEqual(code, 0)
+        self.assertIn("past-month", err.getvalue())
+
+    def test_cli_fire_invalid_since_rejected(self):
+        with self.assertRaises(SystemExit):
+            cli.main(["fire", "incidents", "--since", "abc"])
+
+    def test_cli_fire_since_accepts_years(self):
+        p1, p2 = self._mock_resolution()
+        with p1, p2, patch("raleighlib.arcgis.query_all_pages", return_value=[]):
+            out = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                code = cli.main(["--json", "fire", "response-times", "--since", "1y"])
+        self.assertEqual(code, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a `fire` command group (`incidents`, `response-times`) that resolves RFD's full-history (`ea466e…`) and past-month (`c98376…`) items by stable ID, with source-aware filtering and a normalization layer for the 2026 classification schema transition.

- Era-aware normalization: pre-2026 records keep `incident_type`/`incident_type_description`; 2026+ records use `incident_group_name`/`incident_subgroup_code`/`incident_type_name`. Stable `_` keys, no fabricated cross-era mappings, raw fields preserved in JSON.
- Response durations in labeled seconds; missing/reversed/malformed timestamp pairs rejected per-pair, never zero-filled.
- Documents RFD's exclusion of incident types 300–399 and 661 (EMS/privacy).
- Discovery note: these layers reject epoch-ms date literals (unlike the RPD layers), so date filters use `TIMESTAMP` literals — verified live.
- 45 new unit tests (both sides of the transition, injection safety, pagination, CLI dispatch); 3 new eval cases.

Verified: 265 unit tests, all repo validators/ratchets green, eval harness 0 regressions, and all three issue example commands exercised against the live endpoints.

Closes #122