### PR TITLE
feat(raleigh): add fire protection proximity lookup

### DIFF
--- a/raleigh/EVIDENCE-LEDGER.md
+++ b/raleigh/EVIDENCE-LEDGER.md
@@ -74,3 +74,37 @@ The following public service boundaries were exercised successfully on 2026-07-2
 - Upstream public services may change after this verification date; catalog validation and deterministic fixtures are the detection mechanisms.
 - `skills-ref` remains unavailable locally, so only the repository's canonical skill validator was exercised.
 - No commit, push, pull request, CI run, deployment, or merge is claimed by this ledger.
+
+## Issue 124 Addendum: Fire Protection Proximity
+
+### Intent
+
+- Add read-only Wake County MAR fire-protection lookup by address or CSAID.
+- Return only source-provided station ranks, road-network distances, ISO values, and nearest-hydrant distance.
+- Reject ambiguous address resolution and detectable source drift instead of guessing.
+
+### Design decisions
+
+- `--address` uses the official Raleigh locator, then resolves the geocoded point through the public Wake County MAR Addresses layer. An exact structured street/subaddress match wins; otherwise a unique base address is preferred. A tied top geocoder result or multiple eligible CSAIDs is an error.
+- `--csaid` queries the official fire-protection table directly.
+- Required source fields are checked on each lookup. Extra fields are tolerated; missing required fields and inconsistent hydrant distances fail clearly.
+- Distance units remain `null` in JSON because the source metadata does not advertise units. Raw distance values are not converted or labeled with guessed units.
+- Hydrant locations are not claimed or returned because the source exposes only `Hydrant_Distance`.
+
+### Verification
+
+- `python3 -m pytest tests/test_raleigh.py`: **308 passed** with one pre-existing import deprecation warning.
+- `python3 -m ruff check raleigh/scripts/raleighlib/fire_protection.py raleigh/scripts/raleighlib/cli.py`: passed.
+- `python3 scripts/validate-evals.py raleigh`: all 8 repository eval manifests validated.
+- `ruby scripts/validate-skills.rb`: **107 canonical skills validated**.
+- `ruby scripts/validate-skill-quality.rb --base origin/main`: **1 changed skill, 0 errors, 0 warnings**.
+- `python3 scripts/eval-coverage.py --modified-from origin/main`: ratchet passed; Raleigh remains schema-valid.
+- `git diff --check`: passed.
+- Live `fire protection --address "222 W Hargett St, Raleigh" --json`: resolved CSAID `2734541` and returned three ranked stations from item `8ab8c4f1a8eb473bacfcc1a1c1980b6c`.
+- Live `fire protection --address "222 W Hargett St STE 106, Raleigh" --json`: resolved the explicit suite to CSAID `5131326`, not the building-level CSAID.
+- Live `fire protection --csaid 2734541 --json`: returned the same station and hydrant source values.
+
+### Remaining boundaries
+
+- The service is updated nightly, so future upstream changes remain outside this verification window; required-field checks provide bounded drift detection.
+- No emergency-response accuracy, distance unit, hydrant location, commit, push, pull request, CI run, deployment, or merge is claimed.

--- a/raleigh/README.md
+++ b/raleigh/README.md
@@ -16,6 +16,7 @@ When your agent loads this skill, it becomes a **Raleigh civic data specialist**
 - **Civic content** — news, events, projects, services, directory entries, and alerts from RaleighNC.gov
 - **Public meetings** — agendas, minutes, and videos from eSCRIBE
 - **Active incidents** — live RWECC public incident feed (undocumented endpoint, clearly labeled)
+- **Fire protection** — Wake County MAR station proximity, ISO ratings, and hydrant distances
 - **No API key required** — all data is publicly available
 
 ## What You Get
@@ -42,6 +43,7 @@ scripts/raleigh geocode "222 W Hargett St"
 scripts/raleigh transit routes
 scripts/raleigh news --limit 5
 scripts/raleigh incidents active --agency raleigh-fire
+scripts/raleigh fire protection --address "222 W Hargett St"
 ```
 
 ## Triggers

--- a/raleigh/SKILL.md
+++ b/raleigh/SKILL.md
@@ -129,6 +129,7 @@ one of those names, the added result column receives a `geocode_` prefix.
 |---------|---------|---------|
 | `fire incidents` | Query RFD incidents (full history 2007–present or past month) | `scripts/raleigh fire incidents --since 30d --group Fire` |
 | `fire response-times` | Compute labeled response durations | `scripts/raleigh fire response-times --since 1y --group Fire` |
+| `fire protection` | Wake County MAR fire-protection proximity lookup | `scripts/raleigh fire protection --address "222 W Hargett St"` |
 
 ### Active incidents (RWECC)
 
@@ -183,6 +184,7 @@ one of those names, the added result column receives a `geocode_` prefix.
 - **eSCRIBE**: HTML-based extraction with a weaker compatibility contract than structured APIs.
 - **Police incidents**: Locations are block-level and may be randomized or redacted. Empty coordinates are suppressed, not presented as points. This data does not include arrests, convictions, or dispositions. The CrimeMapper 90-day feed is not in the curated Hub catalog and is resolved by item ID.
 - **Fire incidents**: RFD deprecated `incident_type`/`incident_type_description` for records after 2026-01-01, replaced by `incident_group_name`, `incident_subgroup_code`, and `incident_type_name`. The `fire` commands normalize both eras into stable `_` keys without fabricating cross-era mappings, and preserve raw fields in JSON. Incident types 300–399 and 661 are excluded by RFD for EMS/privacy. The full-history `station` field is unpopulated for most records after early 2021; the past-month feed provides `station_name`.
+- **Fire protection**: The Wake County MAR Fire Protection table is a non-spatial table keyed by CSAID. Address input is composed through the Raleigh locator and the Wake County MAR Addresses layer; if the address cannot be resolved to a unique CSAID, supply `--csaid` directly. Distances are source-provided road-network values; the source does not advertise units. This data does not expose hydrant locations, only nearest-hydrant distance. It must not be used for emergency response.
 - **Active incidents (RWECC)**: Uses an undocumented public application endpoint (`incidents.rwecc.com/getdata`). The adapter is isolated and may break if the upstream contract changes; set `RALEIGH_DISABLE_INCIDENTS=1` to disable it independently. This is a filtered active feed, NOT all 911 calls and NOT authoritative emergency status. An empty response does not prove zero incidents. Cache lifetime is 90 seconds.
 - **URL allowlist**: Only fixed public hosts are dereferenced; arbitrary URLs are rejected.
 - **Transit realtime**: Requires `google.protobuf>=6.31.1,<7`. The vendored GTFS-Realtime binding was generated with protoc 31.1 and does not replace the runtime.

--- a/raleigh/references/fire-reference.md
+++ b/raleigh/references/fire-reference.md
@@ -148,3 +148,41 @@ Every feature in JSON output includes:
 | `_station` | Normalized station number or null |
 
 With `fire response-times`, each feature also includes the `_…_seconds` and `_…_status` keys above. The top-level FeatureCollection includes a `_sources` array with `item_id`, `label`, and `caveats` for the source used.
+
+## Fire Protection Proximity (Wake County MAR)
+
+`fire protection` queries the Wake County `MAR Fire Protection Data Public` table (item `8ab8c4f1a8eb473bacfcc1a1c1980b6c`), updated nightly. It returns source-provided station rankings, road-network distances, ISO ratings, and nearest-hydrant distances. The CLI never calculates its own routing, distances, or ISO values.
+
+### Input Modes
+
+| Flag | Behavior |
+|------|----------|
+| `--csaid <id>` | Query the table directly by canonical site-address identifier. |
+| `--address "..."` | Geocode via the official Raleigh locator, resolve to a CSAID through the Wake County MAR Addresses layer, then query. |
+
+Address resolution requires a geocode score >= 90, a single top-ranked geocoder result, and a unique CSAID in a small envelope around the geocoded point. An exact normalized MAR address match wins, including an explicit unit; otherwise a unique base-address record is preferred over nearby unit-level records. Ambiguous or unmatched addresses produce a clear error suggesting `--csaid`.
+
+### Source Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `CSAID` | Integer | Canonical site-address identifier |
+| `STATION_RANK` | Integer | Proximity rank (1 = nearest) |
+| `STATIONID` | String | Station identifier (e.g. `AF1`, `CF6`) |
+| `STATION_DISTANCE` | Double | Road-network distance to station |
+| `STATION_ISO` | String | Station ISO rating |
+| `Hydrant_Distance` | Double | Distance to nearest hydrant |
+
+The source does not advertise distance units; values are passed through as-is.
+
+### Output
+
+JSON output includes `csaid`, `item_id`, `retrieved_at`, a ranked `stations` array, `hydrant_distance`, `distance_units` (currently `null` because the source does not advertise units), and `caveats`. With `--address`, an `address_resolution` object is included with the matched address, score, and coordinates.
+
+### Caveats
+
+- This is source-provided proximity data, not live emergency response data.
+- The table is non-spatial (type: Table); hydrant locations are not exposed, only distance.
+- The table is updated nightly by Wake County; records may lag real-world changes.
+- Duplicate CSAID rows are expected (one per ranked station, typically 3 per site).
+- Missing required fields or conflicting hydrant distances are reported as source drift rather than silently interpreted.

--- a/raleigh/scripts/raleighlib/cli.py
+++ b/raleigh/scripts/raleighlib/cli.py
@@ -27,6 +27,7 @@ from raleighlib import civic
 from raleighlib import meetings
 from raleighlib import police
 from raleighlib import fire
+from raleighlib import fire_protection
 from raleighlib import incidents
 
 
@@ -58,6 +59,13 @@ def _positive_int(value: str) -> int:
     number = int(value)
     if not 1 <= number <= 100_000:
         raise argparse.ArgumentTypeError("value must be between 1 and 100000")
+    return number
+
+
+def _csaid_value(value: str) -> int:
+    number = int(value)
+    if not 1 <= number <= 99_999_999:
+        raise argparse.ArgumentTypeError("CSAID must be between 1 and 99999999")
     return number
 
 
@@ -425,6 +433,11 @@ def build_parser() -> argparse.ArgumentParser:
     fire_rt.add_argument("--type", dest="incident_type", help="Filter by incident type name/description substring or legacy NFIRS code.")
     fire_rt.add_argument("--limit", type=_positive_int, default=20)
     fire_rt.add_argument("--offset", type=_nonnegative_int, default=0)
+
+    fire_prot = fire_sub.add_parser("protection", help="Wake County MAR fire-protection proximity lookup.")
+    fire_prot_group = fire_prot.add_mutually_exclusive_group(required=True)
+    fire_prot_group.add_argument("--address", help="Address to geocode and resolve to a CSAID.")
+    fire_prot_group.add_argument("--csaid", type=_csaid_value, help="Canonical site-address identifier (CSAID).")
 
     incidents_p = sub.add_parser("incidents", help="Raleigh-Wake ECC active incident feed (undocumented).")
     incidents_sub = incidents_p.add_subparsers(dest="incidents_command")
@@ -1351,6 +1364,48 @@ def cmd_fire_response_times(args: argparse.Namespace) -> int:
     return _fire_response_times_output(result, args)
 
 
+def cmd_fire_protection(args: argparse.Namespace) -> int:
+    if args.csaid is not None:
+        csaid = args.csaid
+        resolution = None
+    else:
+        resolution = fire_protection.resolve_csaid_from_address(args.address)
+        csaid = resolution["csaid"]
+
+    result = fire_protection.query_fire_protection(csaid)
+    if resolution:
+        result["address_resolution"] = resolution
+
+    if args.json:
+        _output_json(result)
+    else:
+        if resolution:
+            print(f"Address: {resolution['match_address']} (score: {resolution['score']})")
+        print(f"CSAID: {result['csaid']}")
+        print(f"Retrieved: {result['retrieved_at']}")
+        print()
+        stations = result.get("stations", [])
+        if stations:
+            rows = []
+            for s in stations:
+                rank = s.get("rank")
+                distance = s.get("distance")
+                rows.append([
+                    str(rank if rank is not None else ""),
+                    str(s.get("station_id") or ""),
+                    str(distance if distance is not None else ""),
+                    str(s.get("iso") or ""),
+                ])
+            _output_table(["RANK", "STATION", "DISTANCE", "ISO"], rows)
+        else:
+            print("No station records for this CSAID.")
+        hd = result.get("hydrant_distance")
+        if hd is not None:
+            print(f"\nNearest hydrant distance: {hd}")
+        print(fire_protection.PROTECTION_CAVERAT, file=sys.stderr)
+    return 0
+
+
 def cmd_incidents_active(args: argparse.Namespace) -> int:
     result = incidents.fetch_active(
         agency=args.agency,
@@ -1440,6 +1495,7 @@ _POLICE_COMMANDS: dict[str, Any] = {
 _FIRE_COMMANDS: dict[str, Any] = {
     "incidents": cmd_fire_incidents,
     "response-times": cmd_fire_response_times,
+    "protection": cmd_fire_protection,
 }
 
 _INCIDENTS_COMMANDS: dict[str, Any] = {
@@ -1568,7 +1624,7 @@ def main(argv: list[str] | None = None) -> int:
 
         parser.print_help()
         return 2
-    except (core.SecurityError, core.RequestPolicyError, core.ResponseTooLargeError, hub.CatalogError, civic.ResourceError, development.UnsupportedEndpointError, imagery.CapabilityError, police.PoliceError, fire.FireError, incidents.IncidentFeedError, FileExistsError, ValueError, KeyError) as exc:
+    except (core.SecurityError, core.RequestPolicyError, core.ResponseTooLargeError, hub.CatalogError, civic.ResourceError, development.UnsupportedEndpointError, imagery.CapabilityError, police.PoliceError, fire.FireError, fire_protection.FireProtectionError, incidents.IncidentFeedError, FileExistsError, ValueError, KeyError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
     except urllib.error.HTTPError as exc:

--- a/raleigh/scripts/raleighlib/fire_protection.py
+++ b/raleigh/scripts/raleighlib/fire_protection.py
@@ -1,0 +1,263 @@
+"""Wake County MAR Fire Protection proximity data access.
+
+Resolves the Wake County MAR Fire Protection Data table (item
+8ab8c4f1a8eb473bacfcc1a1c1980b6c) and provides read-only lookups of
+source-provided station rankings, road-network distances, ISO ratings,
+and nearest-hydrant distances by canonical site-address identifier (CSAID).
+
+Address input is composed through the official Raleigh locator and the
+Wake County MAR Addresses layer to resolve a CSAID. The CLI never
+calculates its own station routing, hydrant distance, or ISO rating.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+from datetime import datetime, timezone
+from typing import Any
+
+from raleighlib import arcgis
+from raleighlib import core
+from raleighlib import geocode
+
+FIRE_PROTECTION_ITEM_ID = "8ab8c4f1a8eb473bacfcc1a1c1980b6c"
+FIRE_PROTECTION_ITEM_URL = (
+    "https://ral.maps.arcgis.com/sharing/rest/content/items/" + FIRE_PROTECTION_ITEM_ID
+)
+
+MAR_ADDRESSES_LAYER_URL = (
+    "https://services1.arcgis.com/a7CWfuGP5ZnLYE7I/arcgis/rest/services/"
+    "Wake_County_MAR_Address_Data_Public/FeatureServer/0"
+)
+
+MIN_GEOCODE_SCORE = 90.0
+MAR_ENVELOPE_DELTA = 0.0001
+REQUIRED_PROTECTION_FIELDS = frozenset(
+    {
+        "CSAID",
+        "STATION_RANK",
+        "STATION_DISTANCE",
+        "STATIONID",
+        "STATION_ISO",
+        "Hydrant_Distance",
+    }
+)
+
+PROTECTION_CAVERAT = (
+    "Source-provided fire protection proximity data. Distances are "
+    "road-network values from the Wake County MAR table; the source does "
+    "not advertise distance units. This is not live emergency response "
+    "data and must not be used for emergency dispatch."
+)
+
+
+class FireProtectionError(Exception):
+    """Raised for fire-protection resolution or query failures."""
+
+
+def _resolve_fire_protection_layer() -> str:
+    """Resolve the fire-protection item ID to a queryable layer URL."""
+    params = {"f": "json"}
+    url = f"{FIRE_PROTECTION_ITEM_URL}?{urllib.parse.urlencode(params)}"
+    meta = core.json_request(url)
+    service_url = meta.get("url")
+    if not service_url:
+        raise FireProtectionError(f"Item {FIRE_PROTECTION_ITEM_ID} has no service URL")
+    return arcgis.resolve_queryable_layer(service_url)
+
+
+def resolve_csaid_from_address(address: str) -> dict[str, Any]:
+    """Geocode an address and resolve it to a Wake County MAR CSAID.
+
+    Returns a dict with keys: csaid, match_address, score, lat, lon.
+    Raises FireProtectionError on no match, ambiguous match, or when
+    the geocoded location cannot be mapped to a MAR record.
+    """
+    candidates = geocode.find_address_candidates(
+        address,
+        out_fields="StAddr,SubAddr,Match_addr",
+        min_score=MIN_GEOCODE_SCORE,
+        max_locations=5,
+    )
+    if not candidates:
+        raise FireProtectionError(
+            f"No geocode match for '{address}' at score >= {MIN_GEOCODE_SCORE:.0f}"
+        )
+
+    top_score = max(candidate.get("score", 0) or 0 for candidate in candidates)
+    top_candidates = [
+        candidate
+        for candidate in candidates
+        if (candidate.get("score", 0) or 0) == top_score
+    ]
+    identities = {
+        (
+            candidate.get("address"),
+            candidate.get("location", {}).get("x"),
+            candidate.get("location", {}).get("y"),
+        )
+        for candidate in top_candidates
+    }
+    if len(identities) != 1:
+        raise FireProtectionError(
+            f"Address '{address}' has {len(identities)} equally ranked geocode "
+            "matches; refine the address or supply --csaid directly"
+        )
+
+    best = top_candidates[0]
+    location = best.get("location", {})
+    lat = location.get("y")
+    lon = location.get("x")
+    if lat is None or lon is None:
+        raise FireProtectionError(f"Geocode match for '{address}' has no coordinates")
+
+    match_address = best.get("address", "")
+    score = best.get("score")
+    attributes = best.get("attributes", {})
+    if not isinstance(attributes, dict):
+        attributes = {}
+    street_address = attributes.get("StAddr")
+    subaddress = attributes.get("SubAddr")
+    if isinstance(street_address, str) and street_address.strip():
+        mar_match_address = " ".join(
+            value.strip()
+            for value in (street_address, subaddress)
+            if isinstance(value, str) and value.strip()
+        )
+    else:
+        mar_match_address = match_address.split(",", 1)[0]
+
+    csaid = _spatial_resolve_csaid(lon, lat, mar_match_address)
+    if csaid is None:
+        raise FireProtectionError(
+            f"Address '{match_address}' geocoded but no unique Wake County "
+            "MAR record found nearby; supply --csaid directly"
+        )
+
+    return {
+        "csaid": csaid,
+        "match_address": match_address,
+        "score": score,
+        "lat": lat,
+        "lon": lon,
+    }
+
+
+def _spatial_resolve_csaid(lon: float, lat: float, match_address: str) -> int | None:
+    """Query the MAR Addresses layer near a point and return a unique CSAID.
+
+    Uses a small envelope around the geocoded point and prefers an exact
+    matched-address record. If none exists, it prefers base addresses over
+    unit-level records. Returns None when zero or multiple distinct CSAIDs
+    remain after filtering.
+    """
+    delta = MAR_ENVELOPE_DELTA
+    geometry = json.dumps(
+        {
+            "xmin": lon - delta,
+            "ymin": lat - delta,
+            "xmax": lon + delta,
+            "ymax": lat + delta,
+            "spatialReference": {"wkid": 4326},
+        }
+    )
+    params: dict[str, Any] = {
+        "geometry": geometry,
+        "geometryType": "esriGeometryEnvelope",
+        "inSR": 4326,
+        "spatialRel": "esriSpatialRelIntersects",
+        "outFields": "CSAID,ADDRESS,SUBADDR_TYPE",
+        "returnGeometry": "false",
+        "f": "json",
+    }
+    url = f"{MAR_ADDRESSES_LAYER_URL}/query?{urllib.parse.urlencode(params)}"
+    data = core.json_request(url)
+    core.raise_for_arcgis_error(data, "MAR address lookup")
+    features = data.get("features", [])
+    if not isinstance(features, list):
+        return None
+
+    base_csaids: set[int] = set()
+    all_csaids: set[int] = set()
+    exact_csaids: set[int] = set()
+    normalized_match = match_address.strip().casefold()
+    for feature in features:
+        attrs = feature.get("attributes", {})
+        csaid = attrs.get("CSAID")
+        if not isinstance(csaid, int) or isinstance(csaid, bool):
+            continue
+        all_csaids.add(csaid)
+        mar_address = attrs.get("ADDRESS")
+        if (
+            isinstance(mar_address, str)
+            and mar_address.strip().casefold() == normalized_match
+        ):
+            exact_csaids.add(csaid)
+        subaddr = attrs.get("SUBADDR_TYPE")
+        if subaddr is None or (isinstance(subaddr, str) and not subaddr.strip()):
+            base_csaids.add(csaid)
+
+    candidates = exact_csaids or base_csaids or all_csaids
+    if len(candidates) == 1:
+        return candidates.pop()
+    return None
+
+
+def query_fire_protection(csaid: int) -> dict[str, Any]:
+    """Query the MAR Fire Protection table for a given CSAID.
+
+    Returns a dict with source metadata and the ranked station records.
+    """
+    layer_url = _resolve_fire_protection_layer()
+    fields = arcgis.layer_fields(layer_url)
+    field_names = {field.get("name") for field in fields if isinstance(field, dict)}
+    missing_fields = REQUIRED_PROTECTION_FIELDS - field_names
+    if missing_fields:
+        missing = ", ".join(sorted(missing_fields))
+        raise FireProtectionError(
+            f"Fire protection source schema drift: missing fields: {missing}"
+        )
+
+    where = f"CSAID = {int(csaid)}"
+    records = arcgis.query_all_pages(
+        layer_url,
+        where=where,
+        return_geometry=False,
+        max_records=10,
+        order_by_fields="STATION_RANK ASC",
+    )
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    stations: list[dict[str, Any]] = []
+    hydrant_distances: set[Any] = set()
+
+    for record in records:
+        attrs = record.get("attributes", {})
+        rank = attrs.get("STATION_RANK")
+        station: dict[str, Any] = {
+            "rank": rank,
+            "station_id": attrs.get("STATIONID"),
+            "distance": attrs.get("STATION_DISTANCE"),
+            "iso": attrs.get("STATION_ISO"),
+        }
+        stations.append(station)
+        if attrs.get("Hydrant_Distance") is not None:
+            hydrant_distances.add(attrs.get("Hydrant_Distance"))
+
+    if len(hydrant_distances) > 1:
+        raise FireProtectionError(
+            f"Fire protection source returned inconsistent hydrant distances "
+            f"for CSAID {csaid}"
+        )
+    hydrant_distance = next(iter(hydrant_distances), None)
+
+    return {
+        "csaid": csaid,
+        "item_id": FIRE_PROTECTION_ITEM_ID,
+        "retrieved_at": now,
+        "stations": stations,
+        "hydrant_distance": hydrant_distance,
+        "distance_units": None,
+        "caveats": PROTECTION_CAVERAT,
+    }

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -43,6 +43,7 @@ import raleighlib.civic as civic
 import raleighlib.meetings as meetings
 import raleighlib.police as police
 import raleighlib.fire as fire
+import raleighlib.fire_protection as fire_protection
 from raleighlib import cli as cli_lib
 
 CLI_SCRIPT = _SCRIPT_DIR / "raleigh"
@@ -3148,6 +3149,321 @@ class IncidentsTests(unittest.TestCase):
     def test_cli_incidents_active_no_subcommand_shows_help(self):
         with self.assertRaises(SystemExit):
             cli.main(["incidents"])
+
+
+class FireProtectionTests(unittest.TestCase):
+    """Tests for the Wake County MAR fire-protection proximity lookup."""
+
+    ITEM_META = {
+        "id": "8ab8c4f1a8eb473bacfcc1a1c1980b6c",
+        "url": "https://services1.arcgis.com/a7CWfuGP5ZnLYE7I/arcgis/rest/services/MAR_Fire_Protection_Data_view/FeatureServer",
+    }
+    LAYER_META = {
+        "layers": [{"id": 0, "name": "mar_fire_protection_distances"}],
+        "type": "Table",
+        "fields": [
+            {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+            {"name": "STATION_RANK", "type": "esriFieldTypeInteger"},
+            {"name": "STATION_DISTANCE", "type": "esriFieldTypeDouble"},
+            {"name": "STATIONID", "type": "esriFieldTypeString"},
+            {"name": "CSAID", "type": "esriFieldTypeInteger"},
+            {"name": "STATION_ISO", "type": "esriFieldTypeString"},
+            {"name": "Hydrant_Distance", "type": "esriFieldTypeDouble"},
+        ],
+    }
+
+    PROTECTION_RECORDS = [
+        {"attributes": {"OBJECTID": 1, "STATION_RANK": 1, "STATION_DISTANCE": 12099.37, "STATIONID": "AF1", "CSAID": 5286547, "STATION_ISO": "1", "Hydrant_Distance": 57.53}},
+        {"attributes": {"OBJECTID": 2, "STATION_RANK": 2, "STATION_DISTANCE": 11848.80, "STATIONID": "AF3", "CSAID": 5286547, "STATION_ISO": "1", "Hydrant_Distance": 57.53}},
+        {"attributes": {"OBJECTID": 3, "STATION_RANK": 3, "STATION_DISTANCE": 21100.67, "STATIONID": "CF6", "CSAID": 5286547, "STATION_ISO": "1", "Hydrant_Distance": 57.53}},
+    ]
+
+    GEOCODE_CANDIDATES = [
+        {
+            "address": "222 W Hargett St, Raleigh, NC, 27601",
+            "location": {"x": -78.643, "y": 35.779},
+            "score": 100,
+            "attributes": {"Score": 100, "Match_addr": "222 W Hargett St, Raleigh, NC, 27601"},
+        }
+    ]
+
+    MAR_RESPONSE = {
+        "features": [
+            {"attributes": {"CSAID": 5286547, "ADDRESS": "222 W Hargett St", "SUBADDR_TYPE": None}},
+        ]
+    }
+
+    def _mock_protection(self, records=None, item_meta=None, layer_meta=None):
+        records = records if records is not None else self.PROTECTION_RECORDS
+        item_meta = item_meta or self.ITEM_META
+        layer_meta = layer_meta or self.LAYER_META
+
+        def fake_json_request(url, **kwargs):
+            if "sharing/rest/content/items/" in url:
+                return item_meta
+            if url.rstrip("/").endswith("FeatureServer") or url.rstrip("/").endswith("FeatureServer/"):
+                return layer_meta
+            if "/query" in url:
+                return {"features": records}
+            return layer_meta
+
+        return patch("raleighlib.fire_protection.core.json_request", side_effect=fake_json_request), patch(
+            "raleighlib.arcgis.core.json_request", side_effect=fake_json_request
+        )
+
+    def test_query_fire_protection_returns_ranked_stations(self):
+        p1, p2 = self._mock_protection()
+        with p1, p2:
+            result = fire_protection.query_fire_protection(5286547)
+        self.assertEqual(result["csaid"], 5286547)
+        self.assertEqual(result["item_id"], "8ab8c4f1a8eb473bacfcc1a1c1980b6c")
+        self.assertIn("retrieved_at", result)
+        self.assertEqual(len(result["stations"]), 3)
+        self.assertEqual(result["stations"][0]["rank"], 1)
+        self.assertEqual(result["stations"][0]["station_id"], "AF1")
+        self.assertAlmostEqual(result["stations"][0]["distance"], 12099.37)
+        self.assertEqual(result["stations"][0]["iso"], "1")
+
+    def test_query_fire_protection_hydrant_distance_from_first_non_null(self):
+        p1, p2 = self._mock_protection()
+        with p1, p2:
+            result = fire_protection.query_fire_protection(5286547)
+        self.assertAlmostEqual(result["hydrant_distance"], 57.53)
+        self.assertIsNone(result["distance_units"])
+
+    def test_query_fire_protection_rejects_conflicting_hydrant_distances(self):
+        inconsistent = [
+            {"attributes": {**self.PROTECTION_RECORDS[0]["attributes"]}},
+            {"attributes": {**self.PROTECTION_RECORDS[1]["attributes"], "Hydrant_Distance": 99.0}},
+        ]
+        p1, p2 = self._mock_protection(records=inconsistent)
+        with p1, p2:
+            with self.assertRaisesRegex(fire_protection.FireProtectionError, "inconsistent hydrant"):
+                fire_protection.query_fire_protection(5286547)
+
+    def test_query_fire_protection_no_records(self):
+        p1, p2 = self._mock_protection(records=[])
+        with p1, p2:
+            result = fire_protection.query_fire_protection(9999999)
+        self.assertEqual(result["stations"], [])
+        self.assertIsNone(result["hydrant_distance"])
+
+    def test_query_fire_protection_null_distances(self):
+        null_records = [
+            {"attributes": {"OBJECTID": 1, "STATION_RANK": 1, "STATION_DISTANCE": None, "STATIONID": "AF1", "CSAID": 100, "STATION_ISO": None, "Hydrant_Distance": None}},
+        ]
+        p1, p2 = self._mock_protection(records=null_records)
+        with p1, p2:
+            result = fire_protection.query_fire_protection(100)
+        self.assertIsNone(result["stations"][0]["distance"])
+        self.assertIsNone(result["stations"][0]["iso"])
+        self.assertIsNone(result["hydrant_distance"])
+
+    def test_query_fire_protection_missing_station_id(self):
+        missing_records = [
+            {"attributes": {"OBJECTID": 1, "STATION_RANK": 1, "STATION_DISTANCE": 5000.0, "STATIONID": None, "CSAID": 100, "STATION_ISO": "2", "Hydrant_Distance": 100.0}},
+        ]
+        p1, p2 = self._mock_protection(records=missing_records)
+        with p1, p2:
+            result = fire_protection.query_fire_protection(100)
+        self.assertIsNone(result["stations"][0]["station_id"])
+
+    def test_query_fire_protection_schema_drift_extra_fields(self):
+        drift_records = [
+            {"attributes": {"OBJECTID": 1, "STATION_RANK": 1, "STATION_DISTANCE": 5000.0, "STATIONID": "X1", "CSAID": 100, "STATION_ISO": "1", "Hydrant_Distance": 50.0, "NEW_FIELD": "unexpected"}},
+        ]
+        p1, p2 = self._mock_protection(records=drift_records)
+        with p1, p2:
+            result = fire_protection.query_fire_protection(100)
+        self.assertEqual(result["stations"][0]["station_id"], "X1")
+        self.assertEqual(len(result["stations"]), 1)
+
+    def test_query_fire_protection_schema_drift_missing_required_field(self):
+        drift_meta = {
+            **self.LAYER_META,
+            "fields": [
+                field
+                for field in self.LAYER_META["fields"]
+                if field["name"] != "STATION_DISTANCE"
+            ],
+        }
+        p1, p2 = self._mock_protection(layer_meta=drift_meta)
+        with p1, p2:
+            with self.assertRaisesRegex(fire_protection.FireProtectionError, "schema drift.*STATION_DISTANCE"):
+                fire_protection.query_fire_protection(100)
+
+    def test_resolve_csaid_from_address_success(self):
+        with patch("raleighlib.fire_protection.geocode.find_address_candidates", return_value=self.GEOCODE_CANDIDATES), \
+             patch("raleighlib.fire_protection.core.json_request", return_value=self.MAR_RESPONSE):
+            result = fire_protection.resolve_csaid_from_address("222 W Hargett St")
+        self.assertEqual(result["csaid"], 5286547)
+        self.assertEqual(result["match_address"], "222 W Hargett St, Raleigh, NC, 27601")
+        self.assertEqual(result["score"], 100)
+
+    def test_resolve_csaid_unmatched_address(self):
+        with patch("raleighlib.fire_protection.geocode.find_address_candidates", return_value=[]):
+            with self.assertRaisesRegex(fire_protection.FireProtectionError, "No geocode match"):
+                fire_protection.resolve_csaid_from_address("999 Nonexistent St")
+
+    def test_resolve_csaid_rejects_tied_geocoder_matches(self):
+        ambiguous = [
+            self.GEOCODE_CANDIDATES[0],
+            {
+                **self.GEOCODE_CANDIDATES[0],
+                "address": "222 E Hargett St, Raleigh, NC, 27601",
+                "location": {"x": -78.63, "y": 35.779},
+            },
+        ]
+        with patch(
+            "raleighlib.fire_protection.geocode.find_address_candidates",
+            return_value=ambiguous,
+        ):
+            with self.assertRaisesRegex(
+                fire_protection.FireProtectionError, "equally ranked geocode matches"
+            ):
+                fire_protection.resolve_csaid_from_address("222 Hargett St")
+
+    def test_resolve_csaid_no_mar_record(self):
+        empty_mar = {"features": []}
+        with patch("raleighlib.fire_protection.geocode.find_address_candidates", return_value=self.GEOCODE_CANDIDATES), \
+             patch("raleighlib.fire_protection.core.json_request", return_value=empty_mar):
+            with self.assertRaisesRegex(fire_protection.FireProtectionError, "no unique Wake County MAR record"):
+                fire_protection.resolve_csaid_from_address("222 W Hargett St")
+
+    def test_resolve_csaid_ambiguous_mar_records(self):
+        ambiguous_mar = {"features": [
+            {"attributes": {"CSAID": 111, "SUBADDR_TYPE": None}},
+            {"attributes": {"CSAID": 222, "SUBADDR_TYPE": None}},
+        ]}
+        with patch("raleighlib.fire_protection.geocode.find_address_candidates", return_value=self.GEOCODE_CANDIDATES), \
+             patch("raleighlib.fire_protection.core.json_request", return_value=ambiguous_mar):
+            with self.assertRaisesRegex(fire_protection.FireProtectionError, "no unique Wake County MAR record"):
+                fire_protection.resolve_csaid_from_address("222 W Hargett St")
+
+    def test_resolve_csaid_duplicate_same_csaid_is_ok(self):
+        duplicate_mar = {"features": [
+            {"attributes": {"CSAID": 5286547, "SUBADDR_TYPE": None}},
+            {"attributes": {"CSAID": 5286547, "SUBADDR_TYPE": None}},
+        ]}
+        with patch("raleighlib.fire_protection.geocode.find_address_candidates", return_value=self.GEOCODE_CANDIDATES), \
+             patch("raleighlib.fire_protection.core.json_request", return_value=duplicate_mar):
+            result = fire_protection.resolve_csaid_from_address("222 W Hargett St")
+        self.assertEqual(result["csaid"], 5286547)
+
+    def test_resolve_csaid_prefers_base_address_over_subaddress(self):
+        mixed_mar = {"features": [
+            {"attributes": {"CSAID": 100, "ADDRESS": "222 W Hargett St STE 100", "SUBADDR_TYPE": "STE"}},
+            {"attributes": {"CSAID": 200, "ADDRESS": "222 W Hargett St", "SUBADDR_TYPE": None}},
+        ]}
+        with patch("raleighlib.fire_protection.geocode.find_address_candidates", return_value=self.GEOCODE_CANDIDATES), \
+             patch("raleighlib.fire_protection.core.json_request", return_value=mixed_mar):
+            result = fire_protection.resolve_csaid_from_address("222 W Hargett St")
+        self.assertEqual(result["csaid"], 200)
+
+    def test_resolve_csaid_prefers_explicit_subaddress_match(self):
+        suite_candidates = [{
+            **self.GEOCODE_CANDIDATES[0],
+            "address": "222 W Hargett St, STE 100, Raleigh, NC, 27601",
+            "attributes": {
+                "StAddr": "222 W Hargett St",
+                "SubAddr": "STE 100",
+            },
+        }]
+        mixed_mar = {"features": [
+            {"attributes": {"CSAID": 100, "ADDRESS": "222 W Hargett St STE 100", "SUBADDR_TYPE": "STE"}},
+            {"attributes": {"CSAID": 200, "ADDRESS": "222 W Hargett St", "SUBADDR_TYPE": None}},
+        ]}
+        with patch(
+            "raleighlib.fire_protection.geocode.find_address_candidates",
+            return_value=suite_candidates,
+        ), patch(
+            "raleighlib.fire_protection.core.json_request",
+            return_value=mixed_mar,
+        ):
+            result = fire_protection.resolve_csaid_from_address(
+                "222 W Hargett St STE 100"
+            )
+        self.assertEqual(result["csaid"], 100)
+
+    def test_resolve_csaid_geocode_no_coordinates(self):
+        no_coords = [{"address": "X", "location": {}, "score": 100, "attributes": {}}]
+        with patch("raleighlib.fire_protection.geocode.find_address_candidates", return_value=no_coords):
+            with self.assertRaisesRegex(fire_protection.FireProtectionError, "no coordinates"):
+                fire_protection.resolve_csaid_from_address("X")
+
+    def test_resolve_item_url_rejects_missing_url(self):
+        with patch("raleighlib.fire_protection.core.json_request", return_value={"id": "x"}):
+            with self.assertRaisesRegex(fire_protection.FireProtectionError, "no service URL"):
+                fire_protection._resolve_fire_protection_layer()
+
+    def test_cli_fire_protection_csaid_json(self):
+        p1, p2 = self._mock_protection()
+        with p1, p2:
+            out = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                code = cli.main(["--json", "fire", "protection", "--csaid", "5286547"])
+        self.assertEqual(code, 0)
+        data = json.loads(out.getvalue())
+        self.assertEqual(data["csaid"], 5286547)
+        self.assertEqual(len(data["stations"]), 3)
+
+    def test_cli_fire_protection_csaid_table(self):
+        p1, p2 = self._mock_protection()
+        with p1, p2:
+            out = io.StringIO()
+            err = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                code = cli.main(["fire", "protection", "--csaid", "5286547"])
+        self.assertEqual(code, 0)
+        self.assertIn("RANK", out.getvalue())
+        self.assertIn("AF1", out.getvalue())
+        self.assertIn("Source-provided", err.getvalue())
+
+    def test_cli_fire_protection_table_preserves_zero_distance(self):
+        zero_record = [{
+            "attributes": {
+                **self.PROTECTION_RECORDS[0]["attributes"],
+                "STATION_DISTANCE": 0,
+            }
+        }]
+        p1, p2 = self._mock_protection(records=zero_record)
+        with p1, p2:
+            out = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                code = cli.main(["fire", "protection", "--csaid", "5286547"])
+        self.assertEqual(code, 0)
+        self.assertIn("AF1      0", out.getvalue())
+
+    def test_cli_fire_protection_address_json(self):
+        def fake_json_request(url, **kwargs):
+            if "sharing/rest/content/items/" in url:
+                return self.ITEM_META
+            if url.rstrip("/").endswith("FeatureServer") or url.rstrip("/").endswith("FeatureServer/"):
+                return self.LAYER_META
+            if "Wake_County_MAR_Address_Data_Public" in url:
+                return self.MAR_RESPONSE
+            if "/query" in url:
+                return {"features": self.PROTECTION_RECORDS}
+            return self.LAYER_META
+
+        with patch("raleighlib.fire_protection.core.json_request", side_effect=fake_json_request), \
+             patch("raleighlib.arcgis.core.json_request", side_effect=fake_json_request), \
+             patch("raleighlib.fire_protection.geocode.find_address_candidates", return_value=self.GEOCODE_CANDIDATES):
+            out = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                code = cli.main(["--json", "fire", "protection", "--address", "222 W Hargett St"])
+        self.assertEqual(code, 0)
+        data = json.loads(out.getvalue())
+        self.assertIn("address_resolution", data)
+        self.assertEqual(data["address_resolution"]["csaid"], 5286547)
+
+    def test_cli_fire_protection_requires_address_or_csaid(self):
+        with self.assertRaises(SystemExit):
+            cli.main(["fire", "protection"])
+
+    def test_protection_hosts_allowlisted(self):
+        self.assertTrue(core.is_allowed_host(fire_protection.FIRE_PROTECTION_ITEM_URL))
+        self.assertTrue(core.is_allowed_host(fire_protection.MAR_ADDRESSES_LAYER_URL))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add read-only Wake County MAR fire-protection lookup by address or CSAID
- preserve source station ranks, distances, ISO values, and nearest-hydrant distance without guessing units
- reject ambiguous address matches and detectable nightly schema drift
- document emergency-response limitations and add deterministic plus live-boundary evidence

## Verification

- `python3 -m pytest tests/test_raleigh.py` (308 passed)
- `ruby scripts/validate-skills.rb`
- `ruby scripts/validate-skill-quality.rb --base origin/main`
- `python3 scripts/validate-evals.py raleigh`
- `python3 scripts/eval-coverage.py --modified-from origin/main`
- `python3 -m ruff check raleigh/scripts/raleighlib/fire_protection.py raleigh/scripts/raleighlib/cli.py`
- `python3 -m ruff format --check raleigh/scripts/raleighlib/fire_protection.py`
- `python3 scripts/check-artifacts.py`
- live address, suite-address, and direct-CSAID lookups

## AI Assistance

Implemented and verified with OpenCode AI assistance on behalf of @magnus919.

Closes #124