### PR TITLE
fix(llama-cpp): harden operational diagnostics

### DIFF
--- a/llama-cpp/SKILL.md
+++ b/llama-cpp/SKILL.md
@@ -81,8 +81,10 @@ Preserve a baseline before changing context size, generation and batch threads, 
 
 - Do not infer accelerator use from the command line alone; require device and load-log evidence.
 - Do not expose an unauthenticated server beyond loopback by accident. Authentication is not a substitute for network and TLS controls.
+- Do not print or `tee` unredacted unit definitions, process environments, environment-file contents, API keys, or other credential-bearing configuration. Prefer redacted metadata; never retain secrets merely as evidence. If exact rollback requires a secret-bearing backup, keep it temporarily outside the repository with mode `0600`, minimum retention, and explicit cleanup. Do not publish raw or low-entropy secret hashes.
 - Do not enable `llama-server` built-in filesystem or shell tools in an untrusted environment.
 - Do not override a chat template until model metadata, the original model card, and rendered behavior have been inspected.
+- For `finish_reason: "length"` with populated `reasoning_content` and empty `content`, inspect the access-controlled raw response but report only sanitized field state, lengths, `finish_reason`, and `usage`. From the same baseline, run separate one-variable probes: a bounded output-budget increase and, when the exact template supports it, `chat_template_kwargs.enable_thinking: false`. In streaming, inspect the documented schema for `choices[].delta.reasoning_content`, `choices[].delta.content`, and terminal `choices[].finish_reason`; record each as absent, null, empty, or populated rather than assuming presence. Treat `reasoning_effort: "none"` and server-side reasoning flags as version-sensitive, source-verified alternatives, not portable defaults.
 - Do not compare benchmark numbers from different models, quants, commits, backends, contexts, batches, thermal states, or workloads as if only one variable changed.
 - Do not treat `llama-bench` tokens per second as TTFT; its measurements exclude tokenization and sampling.
 - Do not claim a larger configured context preserves quality unless the model and scaling behavior support it and the workload was evaluated.


### PR DESCRIPTION
## Summary

<!-- What changed and why? Link the issue with `Closes #123` when applicable. -->

Hardens the `llama-cpp` skill's always-loaded operational safety guidance in two places:

- prevents unredacted service and process configuration from leaking credentials, while bounding exceptional rollback backups by location, permissions, retention, and cleanup;
- diagnoses reasoning-budget exhaustion through sanitized response-shape evidence and separate one-variable probes, with request controls gated by the exact model template and installed server contract.

A three-epoch SkillOpt run evaluated task execution rather than textual coverage. The accepted guidance improved the mapped reasoning-client contract from 0/3 baseline replicas to 3/3, retained all six other held-out task passes, and passed security-corrected systemd, secure-LAN, and scope-boundary regressions. Meaningful AI assistance was used for optimization, task-execution evaluation, security review, and validation.

Authored by Jasper (AI agent on behalf of magnus919).

No linked issue.

## Validation

- [ ] `ruby scripts/validate-skills.rb`
- [x] Passed: 109 canonical skills validated.
- [ ] Skill-specific checks, if applicable: <!-- command and result -->
- [x] `python3 scripts/validate-evals.py` passed all 10 manifests; `ruby scripts/validate-skill-quality.rb --base origin/main` reported 0 errors and 0 warnings; mapped reasoning replicas passed 3/3 after the security correction.
- [x] Full local CI-equivalent suite passed: 27 eval-validator tests, 19 quality-validator tests, 308 package tests, eval ratchet, generated artifacts, marketplace packaging, `llms.txt`, and wheel build.

## Documentation

- [ ] I updated the relevant `SKILL.md`, `README.md`, or reference files.
- [x] Updated `llama-cpp/SKILL.md`.
- [ ] Links are relative and resolve from a fresh clone.
- [x] Repository validation confirmed the skill and its existing relative links.

## Community and security

- [ ] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] Diff and privacy audit passed; only generic operational guidance is included.
- [ ] I have disclosed meaningful AI assistance in the description or commit message.
- [x] Disclosed in the Summary above.

## Review notes

- [ ] Final-head review evidence is tied to commit SHA `<sha>`, and all actionable findings are resolved.
- [x] Final-head independent review passed at `aafba81162ab80f384ba340df06da04f4cec1397`. An earlier review correctly blocked raw-output disclosure and rollback-retention ambiguity; both findings were corrected and the affected regressions rerun before the passing re-review.

<!-- Call out compatibility concerns, intentional simplifications, or follow-up work. -->

The request-level controls remain explicitly version- and template-sensitive. This change does not prescribe a server-wide reasoning setting or select among inference frameworks.
