### PR TITLE
fix: require causal layer maps for cyberpunk image briefs

### DIFF
--- a/cyberpunk/SKILL.md
+++ b/cyberpunk/SKILL.md
@@ -60,14 +60,15 @@ Before delivering, check:
 
 ## Image-direction default
 
-Build an image brief in this order:
+Before drafting prose, make a **layer map**. Do not send a prompt that merely lists cyberpunk ingredients.
 
-1. **Focal human action:** one person or small group doing something concrete.
-2. **Spatial layer:** street, concourse, service deck, mall, tower threshold, transit connection, clinic, market, or orbital work zone.
-3. **Material history:** two or three signs of use, repair, adaptation, or neglect.
-4. **System pressure:** surveillance, a queue, a delivery deadline, access control, a vendor economy, scarcity, or a corporate perimeter.
-5. **Light and weather:** choose only what supports the action. Night, rain, haze, and advertising are options, not requirements.
-6. **Exclusions:** no borrowed named characters, no readable fake-brand overload, no default sexualization, and no frictionless luxury unless the contrast is the point.
+1. **Foreground action:** name the person or small group, the concrete action, and the object or constraint in their hands.
+2. **Middle-ground transaction:** name the witnesses, queue, desk, hatch, stall, or checkpoint where the action changes another person's options.
+3. **Background system and connection:** name the distant system, then specify one visible vertical or causal connection to the foreground: a freight lift, stair, service catwalk, rail line, cable run, pneumatic tube, or access flow.
+4. **Anchored material history:** place two or three repair, reuse, or neglect traces at the layers where they matter; do not leave them as a background noun list.
+5. **Readable pressure:** state the access failure, queue, deadline, scarcity, or surveillance condition that viewers can see shaping the transaction.
+6. **Legibility:** require foreground, middle ground, background, and their connection to remain readable in-frame. Do not use shallow depth of field, smoke, rain, signage, or lighting to hide the causal chain.
+7. **Light, weather, and exclusions:** choose light/weather only to support the action. Exclude borrowed named characters, readable fake-brand overload, default sexualization, and frictionless luxury unless contrast is the point.
 
 Use the template in [visual direction](references/visual-direction.md). For an exact canon request, offer an analytical breakdown or an original adjacent composition instead of a scene recreation.
 

--- a/cyberpunk/references/visual-direction.md
+++ b/cyberpunk/references/visual-direction.md
@@ -13,13 +13,7 @@ A Gibson-informed image usually earns density through relations among people, wo
 ## Prompt template
 
 ```text
-[Medium and framing] of [person or small group] [performing a concrete action]
-in [specific spatial layer]. The setting shows [two material traces of accretion]
-and [one operating pressure]. [Light/weather] supports [the action or mood],
-while [background system] remains legible but secondary. Lived-in, maintained
-and imperfect, culturally specific through [practice or relationship], not
-through generic signage. Original setting and characters; no copyrighted
-characters, logos, or recreated scenes; no readable gibberish text.
+[Medium and framing; keep foreground, middle ground, background, and their connection legible in-frame] of [foreground person or small group] [concrete action] with [object, access point, or failure constraint] in hand. Middle ground: [named transaction, witnesses, queue, desk, hatch, stall, or checkpoint] where that action changes another person's options. Background: [system] connected visibly through [freight lift, stairs, service catwalk, rail line, cable run, pneumatic tube, or access flow]. Place [two material traces of accretion] at [their relevant layers]. The readable pressure is [deadline, queue, access failure, scarcity, or surveillance condition]. [Light/weather] reveals rather than obscures the action and connection; no shallow depth of field that turns systems into atmosphere. Culturally specific through [practice or relationship], not generic signage. Original setting and characters; no copyrighted characters, logos, recreated scenes, or readable gibberish text.
 ```
 
 ### Example: original adjacent image direction
@@ -51,4 +45,4 @@ no copied fictional characters, no unreadable text.
 
 Exclude: recognizable protected characters or locations; direct cover-art composition; model-typical illegible text; default femme-fatale sexualization; unexplained weapon posing; a homogeneous crowd; pristine “future showroom” surfaces; and a generic East Asian visual shorthand for futurity.
 
-Before delivery, inspect whether the image has one readable human action, a clear spatial hierarchy, visible material history, and an operational pressure. If it only says “cyberpunk” through purple-blue light and rain, revise the brief.
+Before generation, reject and rewrite any brief that merely lists people, infrastructure, and neon atmosphere. Require a layer map with a foreground action, named middle-ground transaction, background system, visible connection, anchored material history, and readable pressure. Before delivery, inspect whether every mapped layer and connection remains legible in-frame; if the causal chain is buried by shallow depth of field, smoke, rain, signage, or spectacle, revise the brief.


### PR DESCRIPTION
## Summary

- Require a causal layer map before drafting a cyberpunk image brief.
- Make the visual template assign foreground action, middle-ground transaction, background system, visible connection, anchored material history, and readable pressure.
- Reject prompts that turn those systems into obscured background atmosphere.

## Validation

- `ruby scripts/validate-skills.rb cyberpunk`
- Paired held-out composition brief: the candidate added an explicit authorization-network connection and in-frame legibility requirement that the baseline lacked.
- Installed-artifact regression: passed.

## AI assistance

This change was developed with AI assistance and validated through the repository checker plus paired SkillOpt trajectories.
