### PR TITLE
fix: allow incidental text in cyberpunk image briefs

### DIFF
--- a/cyberpunk/README.md
+++ b/cyberpunk/README.md
@@ -13,8 +13,8 @@ This skill helps your agent create or analyze a world with that underlying logic
 | `SKILL.md` | A compact workflow for scenes, images, setting design, and analysis |
 | `references/canon-and-boundaries.md` | Corpus, source discipline, and a clear distinction between canon, inference, and original adaptation |
 | `references/world-operations.md` | Practical models for infrastructure, power, culture, technology, and plot pressure |
-| `references/visual-direction.md` | Composition grammar, prompt template, examples, and visual pitfalls |
-| `evals/evals.json` | Six representative behavior checks, including copyright and stereotyping boundaries |
+| `references/visual-direction.md` | Composition grammar, photographic depth hierarchy, prompt template, examples, and visual pitfalls |
+| `evals/evals.json` | Eight representative behavior checks, including copyright, stereotyping, text-policy, and photographic-realism boundaries |
 | `tests/trigger-cases.md` | Positive and near-miss activation checks |
 
 ## Quick Start

--- a/cyberpunk/SKILL.md
+++ b/cyberpunk/SKILL.md
@@ -44,7 +44,7 @@ Use the primary texts as canon. Treat the 1980s publication context and criticis
 3. **Choose two systems that collide.** Pair an official system with an improvised one: corporate logistics and gray-market repair, a security boundary and a courier route, a network protocol and a body clinic, or an orbital supply chain and a street market.
 4. **Show accretion.** Describe the trace of repeated use: patched conduit, a repurposed loading bay, informal wayfinding, incompatible interfaces, a service that became a market. The environment should read as an archaeological record of ownership, technology, and adaptation, not as a single finished design.
 5. **Make technology furniture.** Treat extraordinary devices as habitual surroundings. State what they change in work, intimacy, risk, memory, or status, but keep attention on the person using, repairing, ignoring, or working around them.
-6. **Give culture agency.** Treat language, food, fashion, music, and ritual as practices people choose, adapt, trade, and contest. Avoid using a culture as anonymous future texture or reducing it to signage.
+6. **Give culture agency.** Treat language, food, fashion, music, and ritual as practices people choose, adapt, trade, and contest. Avoid using a culture as anonymous future texture or reducing it to signage; ordinary signage can still support a specific place or practice.
 7. **End with consequence.** Explain what the pressure costs the character, who benefits, and what remains uncertain. Large systems should be felt through a specific decision.
 
 ## The Gibsonian test
@@ -67,8 +67,8 @@ Before drafting prose, make a **layer map**. Do not send a prompt that merely li
 3. **Background system and connection:** name the distant system, then specify one visible vertical or causal connection to the foreground: a freight lift, stair, service catwalk, rail line, cable run, pneumatic tube, or access flow.
 4. **Anchored material history:** place two or three repair, reuse, or neglect traces at the layers where they matter; do not leave them as a background noun list.
 5. **Readable pressure:** state the access failure, queue, deadline, scarcity, or surveillance condition that viewers can see shaping the transaction.
-6. **Legibility:** require foreground, middle ground, background, and their connection to remain readable in-frame. Do not use shallow depth of field, smoke, rain, signage, or lighting to hide the causal chain.
-7. **Light, weather, and exclusions:** choose light/weather only to support the action. Exclude borrowed named characters, readable fake-brand overload, default sexualization, and frictionless luxury unless contrast is the point.
+6. **Legibility:** require foreground, middle ground, background, and their connection to remain readable in-frame. Natural distance falloff can simplify the background, but do not use shallow depth of field, smoke, rain, signage, or lighting to hide the causal chain.
+7. **Light, weather, text, and exclusions:** choose light/weather only to support the action. Do not add a blanket no-text negative: incidental environmental text and user-requested, meaningful lettering are allowed. Avoid unrequested real brands or logos, fabricated readable claims, and decorative text that overwhelms the action. Exclude borrowed named characters, default sexualization, and frictionless luxury unless contrast is the point.
 
 Use the template in [visual direction](references/visual-direction.md). For an exact canon request, offer an analytical breakdown or an original adjacent composition instead of a scene recreation.
 

--- a/cyberpunk/evals/evals.json
+++ b/cyberpunk/evals/evals.json
@@ -75,6 +75,30 @@
         "Does not fabricate quotations, page numbers, or citations."
       ],
       "case_set": "release"
+    },
+    {
+      "id": "environmental-text-without-blanket-ban",
+      "prompt": "Make an image brief for a repair market at night. A few ordinary signs can be in the scene, but the focus should stay on a courier trying to restore access before a delivery deadline.",
+      "expected_output": "An image direction brief with a legible causal composition that permits incidental environmental lettering without relying on signage as the scene's main idea.",
+      "assertions": [
+        "Does not add a blanket no-text, no-signage, or no-lettering exclusion.",
+        "Allows ordinary environmental signage while keeping the foreground action, transaction, system connection, and pressure legible.",
+        "Distinguishes incidental pseudo-text from reader-facing or materially misleading text rather than treating all generated text as a release blocker.",
+        "Avoids unrequested logos, fabricated readable claims, and generic cultural scripts used as decoration."
+      ],
+      "case_set": "regression"
+    },
+    {
+      "id": "photographic-spatial-hierarchy",
+      "prompt": "Make a photorealistic cyberpunk image brief for a service-hatch repair that shows the tower logistics system behind it without turning every surface into tiny sharp detail.",
+      "expected_output": "A photorealistic image direction brief with a focused human action, a readable causal layer map, and natural visual detail falloff by distance.",
+      "assertions": [
+        "Uses detailed focal subjects, a restrained middle ground, and a simplified or atmospherically softened background.",
+        "Preserves realistic scale, occlusion, depth, selective focus, finite lens resolution, and quiet visual areas.",
+        "Avoids uniform sharpness, background micro-detail, object multiplication, overcrowding, crunchy HDR, excessive clarity, etched textures, glowing edges, repeated tiny structures, and high-CFG overbaking.",
+        "Keeps the middle-ground transaction and the connection to the background system readable despite the distance falloff."
+      ],
+      "case_set": "regression"
     }
   ]
 }

--- a/cyberpunk/references/visual-direction.md
+++ b/cyberpunk/references/visual-direction.md
@@ -10,10 +10,16 @@ A Gibson-informed image usually earns density through relations among people, wo
 - **Vertical logic:** show a connection between layers, such as stairs to a service catwalk, a freight lift below offices, or a rail line cutting through housing. Do not assume wealth simply means “up”; demonstrate the access relationship.
 - **Material history:** add a small number of specific traces: mismatched panels, an old mount point, patched cable conduit, drain stains, improvised weather seal, worn handrail, repurposed shipping fixture.
 
+### Optical hierarchy for photographic realism
+
+For photographic or cinematic-realistic work, use natural spatial-frequency falloff: detailed focal subjects, a restrained middle ground, and a simplified, atmospherically softened background. Preserve believable scale, occlusion, depth, selective focus, finite lens resolution, and quiet visual areas. Avoid uniform sharpness, background micro-detail, object multiplication, overcrowding, crunchy HDR, excessive clarity, etched textures, glowing edges, repeated tiny structures, and high-CFG overbaking. Do not invent detail to fill distant areas.
+
+This hierarchy must not erase the layer map. Keep the middle-ground transaction and the visible connection to the background system readable even when they are less detailed than the foreground.
+
 ## Prompt template
 
 ```text
-[Medium and framing; keep foreground, middle ground, background, and their connection legible in-frame] of [foreground person or small group] [concrete action] with [object, access point, or failure constraint] in hand. Middle ground: [named transaction, witnesses, queue, desk, hatch, stall, or checkpoint] where that action changes another person's options. Background: [system] connected visibly through [freight lift, stairs, service catwalk, rail line, cable run, pneumatic tube, or access flow]. Place [two material traces of accretion] at [their relevant layers]. The readable pressure is [deadline, queue, access failure, scarcity, or surveillance condition]. [Light/weather] reveals rather than obscures the action and connection; no shallow depth of field that turns systems into atmosphere. Culturally specific through [practice or relationship], not generic signage. Original setting and characters; no copyrighted characters, logos, recreated scenes, or readable gibberish text.
+[Medium and framing; keep foreground, middle ground, background, and their connection legible in-frame] of [foreground person or small group] [concrete action] with [object, access point, or failure constraint] in hand. Middle ground: [named transaction, witnesses, queue, desk, hatch, stall, or checkpoint] where that action changes another person's options. Background: [system] connected visibly through [freight lift, stairs, service catwalk, rail line, cable run, pneumatic tube, or access flow]. Place [two material traces of accretion] at [their relevant layers]. The readable pressure is [deadline, queue, access failure, scarcity, or surveillance condition]. [Light/weather] reveals rather than obscures the action and connection. For photographic realism: detailed focal subjects, restrained middle ground, and a simplified, atmospherically softened background with realistic scale, occlusion, selective focus, finite lens resolution, and quiet visual areas; do not let that falloff hide the transaction or connection. Culturally specific through [practice or relationship], not generic signage. Text policy: do not add a blanket no-text exclusion; allow incidental environmental signage, and describe exact meaningful lettering only when the user requests it. Original setting and characters; no copyrighted characters, unrequested logos, or fabricated readable claims.
 ```
 
 ### Example: original adjacent image direction
@@ -26,8 +32,9 @@ with patched conduit, old bolt holes from a removed sign, and a water-stained
 service door. The pressure is a closing delivery window and a biometric access
 reader that works only intermittently. Damp daylight and hard fluorescent spill
 make the repair task visible; distant elevated transit is secondary. Original
-setting and characters, ordinary work inside an enormous network, no logos,
-no copied fictional characters, no unreadable text.
+setting and characters, ordinary work inside an enormous network. Incidental
+environmental signage may appear, but no unrequested logos or fabricated
+readable claims; no copied fictional characters.
 ```
 
 ## Deliberate controls
@@ -43,6 +50,6 @@ no copied fictional characters, no unreadable text.
 
 ## Negative prompt and review checklist
 
-Exclude: recognizable protected characters or locations; direct cover-art composition; model-typical illegible text; default femme-fatale sexualization; unexplained weapon posing; a homogeneous crowd; pristine “future showroom” surfaces; and a generic East Asian visual shorthand for futurity.
+Exclude: recognizable protected characters or locations; direct cover-art composition; unrequested real-world logos or fabricated readable claims; default femme-fatale sexualization; unexplained weapon posing; a homogeneous crowd; pristine “future showroom” surfaces; and a generic East Asian visual shorthand for futurity. Do not use a blanket no-text negative. Incidental pseudo-text is a quality concern only when it is reader-facing, materially misleading, or materially distracting. When the user requests exact readable text, include it deliberately and verify the rendered result.
 
 Before generation, reject and rewrite any brief that merely lists people, infrastructure, and neon atmosphere. Require a layer map with a foreground action, named middle-ground transaction, background system, visible connection, anchored material history, and readable pressure. Before delivery, inspect whether every mapped layer and connection remains legible in-frame; if the causal chain is buried by shallow depth of field, smoke, rain, signage, or spectacle, revise the brief.


### PR DESCRIPTION
## Summary
- remove blanket no-text and no-unreadable-text prompt constraints while retaining protections against unrequested logos and fabricated reader-facing claims
- allow natural photographic detail falloff without obscuring the causal layer map
- add regression evals for environmental text policy and photographic spatial hierarchy

## Validation
- `ruby scripts/validate-skills.rb`
- `python3 scripts/validate-evals.py`
- `python3 scripts/test-eval-validation.py`
- `ruby scripts/gen-claude-marketplace.rb`
- `ruby scripts/gen-codex-plugin.rb`
- `ruby scripts/gen-llms-txt.rb`
- focused policy regression checks