### PR TITLE
feat(raleigh): expose official public safety statistics

### DIFF
--- a/raleigh/EVIDENCE-LEDGER.md
+++ b/raleigh/EVIDENCE-LEDGER.md
@@ -170,7 +170,7 @@ The following public service boundaries were exercised successfully on 2026-07-2
 
 ### Verification
 
-- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **355 tests passed**.
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **356 tests passed**.
 - `python3 -m ruff check raleigh/scripts/raleighlib/core.py raleigh/scripts/raleighlib/public_safety_stats.py raleigh/scripts/raleighlib/cli.py`: passed.
 - `python3 scripts/validate-evals.py raleigh`: **11 eval manifests validated**.
 - `ruby scripts/validate-skills.rb`: **110 canonical skills validated**.
@@ -181,7 +181,7 @@ The following public service boundaries were exercised successfully on 2026-07-2
 - Live `fire stats --year 2026 --json`: returned seven official published categories, including medical `7,882`, source revision/retrieval metadata, the annual document URL, and the aggregate-only privacy warning.
 - Live `fire reports --year 2025 --quarter 1 --json`: returned the canonical official quarterly page.
 - Live `fire reports --date 2026-07-24 --json`: exercised the unchanged ArcGIS incident-report path successfully.
-- Review passes found and then verified fixes for terminal-control handling, path traversal and URL components, empty tables, document availability, redirect targets, malformed or ambiguous JSON:API relationships, and eval coverage.
+- Review passes found and then verified fixes for terminal-control handling, path traversal and URL components, empty or missing sections and tables, document availability, redirect targets, malformed or ambiguous JSON:API relationships, and eval coverage.
 
 ### Remaining boundaries and follow-up triggers
 

--- a/raleigh/EVIDENCE-LEDGER.md
+++ b/raleigh/EVIDENCE-LEDGER.md
@@ -170,7 +170,7 @@ The following public service boundaries were exercised successfully on 2026-07-2
 
 ### Verification
 
-- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **359 tests passed**.
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **360 tests passed**.
 - `python3 -m ruff check raleigh/scripts/raleighlib/core.py raleigh/scripts/raleighlib/public_safety_stats.py raleigh/scripts/raleighlib/cli.py`: passed.
 - `python3 scripts/validate-evals.py raleigh`: **11 eval manifests validated**.
 - `ruby scripts/validate-skills.rb`: **110 canonical skills validated**.

--- a/raleigh/EVIDENCE-LEDGER.md
+++ b/raleigh/EVIDENCE-LEDGER.md
@@ -170,7 +170,7 @@ The following public service boundaries were exercised successfully on 2026-07-2
 
 ### Verification
 
-- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **358 tests passed**.
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **359 tests passed**.
 - `python3 -m ruff check raleigh/scripts/raleighlib/core.py raleigh/scripts/raleighlib/public_safety_stats.py raleigh/scripts/raleighlib/cli.py`: passed.
 - `python3 scripts/validate-evals.py raleigh`: **11 eval manifests validated**.
 - `ruby scripts/validate-skills.rb`: **110 canonical skills validated**.

--- a/raleigh/EVIDENCE-LEDGER.md
+++ b/raleigh/EVIDENCE-LEDGER.md
@@ -170,7 +170,7 @@ The following public service boundaries were exercised successfully on 2026-07-2
 
 ### Verification
 
-- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **354 tests passed**.
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **355 tests passed**.
 - `python3 -m ruff check raleigh/scripts/raleighlib/core.py raleigh/scripts/raleighlib/public_safety_stats.py raleigh/scripts/raleighlib/cli.py`: passed.
 - `python3 scripts/validate-evals.py raleigh`: **11 eval manifests validated**.
 - `ruby scripts/validate-skills.rb`: **110 canonical skills validated**.
@@ -181,7 +181,7 @@ The following public service boundaries were exercised successfully on 2026-07-2
 - Live `fire stats --year 2026 --json`: returned seven official published categories, including medical `7,882`, source revision/retrieval metadata, the annual document URL, and the aggregate-only privacy warning.
 - Live `fire reports --year 2025 --quarter 1 --json`: returned the canonical official quarterly page.
 - Live `fire reports --date 2026-07-24 --json`: exercised the unchanged ArcGIS incident-report path successfully.
-- Three review passes found and then verified fixes for terminal-control handling, path traversal and URL components, empty tables, document availability, redirect targets, JSON:API relationship ambiguity, and eval coverage; the final pass reported no actionable findings.
+- Review passes found and then verified fixes for terminal-control handling, path traversal and URL components, empty tables, document availability, redirect targets, malformed or ambiguous JSON:API relationships, and eval coverage.
 
 ### Remaining boundaries and follow-up triggers
 

--- a/raleigh/EVIDENCE-LEDGER.md
+++ b/raleigh/EVIDENCE-LEDGER.md
@@ -170,12 +170,12 @@ The following public service boundaries were exercised successfully on 2026-07-2
 
 ### Verification
 
-- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **364 tests passed**.
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **368 tests passed**.
 - `python3 -m ruff check raleigh/scripts/raleighlib/core.py raleigh/scripts/raleighlib/public_safety_stats.py raleigh/scripts/raleighlib/cli.py`: passed.
 - `python3 scripts/validate-evals.py raleigh`: **11 eval manifests validated**.
 - `ruby scripts/validate-skills.rb`: **110 canonical skills validated**.
-- `ruby scripts/validate-skill-quality.rb --base HEAD`: **1 changed skill, 0 errors, 0 warnings**.
-- `python3 scripts/eval-coverage.py --modified-from HEAD`: ratchet passed; Raleigh remains schema-valid.
+- `ruby scripts/validate-skill-quality.rb --base origin/main`: **1 changed skill, 0 errors, 0 warnings**.
+- `python3 scripts/eval-coverage.py --modified-from origin/main`: ratchet passed; Raleigh remains schema-valid.
 - Live `police reports --year 2025 --quarter 4 --json`: returned the official `Q4 stats` label and canonical government-cloud PDF URL after an availability probe.
 - Live `police stats --year 2025 --json`: returned the annual and quarterly publication index with an explicit document-only warning and no fabricated totals.
 - Live `fire stats --year 2026 --json`: returned seven official published categories, including medical `7,882`, source revision/retrieval metadata, the annual document URL, and the aggregate-only privacy warning.

--- a/raleigh/EVIDENCE-LEDGER.md
+++ b/raleigh/EVIDENCE-LEDGER.md
@@ -170,7 +170,7 @@ The following public service boundaries were exercised successfully on 2026-07-2
 
 ### Verification
 
-- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **356 tests passed**.
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **357 tests passed**.
 - `python3 -m ruff check raleigh/scripts/raleighlib/core.py raleigh/scripts/raleighlib/public_safety_stats.py raleigh/scripts/raleighlib/cli.py`: passed.
 - `python3 scripts/validate-evals.py raleigh`: **11 eval manifests validated**.
 - `ruby scripts/validate-skills.rb`: **110 canonical skills validated**.

--- a/raleigh/EVIDENCE-LEDGER.md
+++ b/raleigh/EVIDENCE-LEDGER.md
@@ -146,3 +146,47 @@ The following public service boundaries were exercised successfully on 2026-07-2
 - Upstream schemas, selectors, forms, and availability can change after the verification date. Required-field and parser-contract checks fail visibly when detectable.
 - Deterministic fixtures exercise results, no-results, schema/markup changes, service/error pages, malformed fragments, and recent-record fallback. They do not prove future upstream stability.
 - No bulk enumeration, authenticated action, invoice retrieval or payment, private contact access, inspection-detail retrieval, write operation, commit, push, pull request, CI run, deployment, or merge is claimed.
+
+## Issue 126 Addendum: Official Police and Fire Aggregate Statistics
+
+### Intent and authority
+
+- Expose official RPD and RFD published statistics and report indexes without presenting incident-row calculations as official totals.
+- Preserve RFD medical totals as aggregate-only data that cannot be joined to or used to infer excluded incident records.
+- Modify the local Raleigh skill only. No publish, deploy, merge, document download, or PDF-extraction authority was used.
+
+### Inspected artifacts and decisions
+
+- Reviewed issue `#126`, the official RPD crime-data page, the official RFD statistics page, their Drupal JSON:API service nodes and included paragraph resources, existing police/fire adapters, CLI routing, tests, references, and recent fire-report commit `4eaf5aa`.
+- The official pages expose one stable structured boundary: service-node JSON:API responses with included HTML fragments. RFD publishes current incident totals and sprinkler-save tables inline; RPD currently publishes document links only.
+- Chose one shared JSON:API adapter over separate page scrapers. Rejected incident-row aggregation because source coverage differs, and rejected PDF parsing because no stable tested extraction contract exists.
+- Returned documents are restricted by agency to the official Raleigh page or City government-cloud PDF path, sanitized, checked for traversal and malformed URL components, and availability-probed with `HEAD`. Redirect targets must satisfy the same agency-specific contract.
+- Fire `reports --date/--incident-number` remains the existing incident-report mode. `fire reports --year/--quarter` and no-selector mode use the aggregate publication index.
+
+### Files changed
+
+- Added `scripts/raleighlib/public_safety_stats.py`, representative police/fire JSON:API fixtures, and `references/public-safety-statistics-reference.md`.
+- Updated `scripts/raleighlib/core.py`, `scripts/raleighlib/cli.py`, `tests/test_raleigh.py`, `SKILL.md`, `README.md`, police/fire references, and `evals/evals.json`.
+
+### Verification
+
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **354 tests passed**.
+- `python3 -m ruff check raleigh/scripts/raleighlib/core.py raleigh/scripts/raleighlib/public_safety_stats.py raleigh/scripts/raleighlib/cli.py`: passed.
+- `python3 scripts/validate-evals.py raleigh`: **11 eval manifests validated**.
+- `ruby scripts/validate-skills.rb`: **110 canonical skills validated**.
+- `ruby scripts/validate-skill-quality.rb --base HEAD`: **1 changed skill, 0 errors, 0 warnings**.
+- `python3 scripts/eval-coverage.py --modified-from HEAD`: ratchet passed; Raleigh remains schema-valid.
+- Live `police reports --year 2025 --quarter 4 --json`: returned the official `Q4 stats` label and canonical government-cloud PDF URL after an availability probe.
+- Live `police stats --year 2025 --json`: returned the annual and quarterly publication index with an explicit document-only warning and no fabricated totals.
+- Live `fire stats --year 2026 --json`: returned seven official published categories, including medical `7,882`, source revision/retrieval metadata, the annual document URL, and the aggregate-only privacy warning.
+- Live `fire reports --year 2025 --quarter 1 --json`: returned the canonical official quarterly page.
+- Live `fire reports --date 2026-07-24 --json`: exercised the unchanged ArcGIS incident-report path successfully.
+- Three review passes found and then verified fixes for terminal-control handling, path traversal and URL components, empty tables, document availability, redirect targets, JSON:API relationship ambiguity, and eval coverage; the final pass reported no actionable findings.
+
+### Remaining boundaries and follow-up triggers
+
+- PDF contents were not parsed or semantically verified. Add extraction only after a stable format and representative regression fixtures exist.
+- `HEAD` availability confirms reachability at request time, not document correctness or future availability.
+- Upstream node IDs, headings, table headers, publication labels, or origins may change. Detectable changes fail visibly; revise the adapter and fixtures only after re-verifying the official source contract.
+- No model-backed eval run, CI run, commit, push, pull request, deployment, release, or merge is claimed.
+- Roll back the aggregate adapter and CLI wiring if the official site removes JSON:API access or publication links cannot be validated without broadening the trust boundary.

--- a/raleigh/EVIDENCE-LEDGER.md
+++ b/raleigh/EVIDENCE-LEDGER.md
@@ -170,7 +170,7 @@ The following public service boundaries were exercised successfully on 2026-07-2
 
 ### Verification
 
-- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **360 tests passed**.
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **364 tests passed**.
 - `python3 -m ruff check raleigh/scripts/raleighlib/core.py raleigh/scripts/raleighlib/public_safety_stats.py raleigh/scripts/raleighlib/cli.py`: passed.
 - `python3 scripts/validate-evals.py raleigh`: **11 eval manifests validated**.
 - `ruby scripts/validate-skills.rb`: **110 canonical skills validated**.

--- a/raleigh/EVIDENCE-LEDGER.md
+++ b/raleigh/EVIDENCE-LEDGER.md
@@ -170,7 +170,7 @@ The following public service boundaries were exercised successfully on 2026-07-2
 
 ### Verification
 
-- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **357 tests passed**.
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py`: **358 tests passed**.
 - `python3 -m ruff check raleigh/scripts/raleighlib/core.py raleigh/scripts/raleighlib/public_safety_stats.py raleigh/scripts/raleighlib/cli.py`: passed.
 - `python3 scripts/validate-evals.py raleigh`: **11 eval manifests validated**.
 - `ruby scripts/validate-skills.rb`: **110 canonical skills validated**.

--- a/raleigh/README.md
+++ b/raleigh/README.md
@@ -18,6 +18,7 @@ When your agent loads this skill, it becomes a **Raleigh civic data specialist**
 - **Active incidents** — live RWECC public incident feed (undocumented endpoint, clearly labeled)
 - **Fire protection** — Wake County MAR station proximity, ISO ratings, and hydrant distances
 - **Fire records** — authoritative ArcGIS report summaries plus guarded RFD narratives and inspection searches
+- **Published public-safety statistics** — official RPD/RFD totals and annual or quarterly report links, kept distinct from incident rows
 - **No API key required** — all data is publicly available
 
 ## What You Get
@@ -45,6 +46,8 @@ scripts/raleigh transit routes
 scripts/raleigh news --limit 5
 scripts/raleigh incidents active --agency raleigh-fire
 scripts/raleigh fire protection --address "222 W Hargett St"
+scripts/raleigh police reports --year 2025 --quarter 4
+scripts/raleigh fire stats --year 2026
 scripts/raleigh fire reports --date 2026-07-24
 # RFD has no usable TLS endpoint; this sends the search term over plain HTTP.
 scripts/raleigh fire inspections --business "Example" --acknowledge-insecure-rfd

--- a/raleigh/SKILL.md
+++ b/raleigh/SKILL.md
@@ -123,6 +123,8 @@ one of those names, the added result column receives a `geocode_` prefix.
 | `police recent` | Query CrimeMapper past-90-day feed | `scripts/raleigh police recent --days 30 --district Downtown` |
 | `police previous-day` | Query previous-day incidents | `scripts/raleigh police previous-day --json` |
 | `police history` | Query historical incidents (SRS or NIBRS) | `scripts/raleigh police history --reporting-system srs --since 30d` |
+| `police stats` | Official published statistics availability and document links | `scripts/raleigh police stats --year 2025` |
+| `police reports` | Official annual and quarterly report links | `scripts/raleigh police reports --year 2025 --quarter 4` |
 
 ### Fire incidents
 
@@ -131,7 +133,9 @@ one of those names, the added result column receives a `geocode_` prefix.
 | `fire incidents` | Query RFD incidents (full history 2007–present or past month) | `scripts/raleigh fire incidents --since 30d --group Fire` |
 | `fire response-times` | Compute labeled response durations | `scripts/raleigh fire response-times --since 1y --group Fire` |
 | `fire protection` | Wake County MAR fire-protection proximity lookup | `scripts/raleigh fire protection --address "222 W Hargett St"` |
-| `fire reports` | Exact ArcGIS report summary, with optional guarded RFD fallback | `scripts/raleigh fire reports --date 2026-07-24` |
+| `fire stats` | Official published incident totals and sprinkler-save statistics | `scripts/raleigh fire stats --year 2026` |
+| `fire reports` | Published aggregate-report links or exact incident-report lookup | `scripts/raleigh fire reports --year 2025 --quarter 1` |
+| `fire reports --date` | Exact ArcGIS incident-report summary, with optional guarded RFD fallback | `scripts/raleigh fire reports --date 2026-07-24` |
 | `fire inspections` | Business/address inspection lookup through fragile RFD HTML | `scripts/raleigh fire inspections --business "Example" --acknowledge-insecure-rfd` |
 
 ### Active incidents (RWECC)
@@ -174,6 +178,7 @@ one of those names, the added result column receives a `geocode_` prefix.
 | Police incidents | RPD data sources, field schemas, and privacy caveats | `references/police-reference.md` |
 | Fire incidents | RFD data sources, 2026 schema transition, durations, and privacy caveats | `references/fire-reference.md` |
 | Fire reports and inspections | ArcGIS-first contract, RFD forms, insecure transport, and exclusions | `references/fire-reports-reference.md` |
+| Published police and fire statistics | Official page contract, report indexes, structured totals, and privacy boundary | `references/public-safety-statistics-reference.md` |
 | Active incidents (RWECC) | Undocumented feed contract, schema guard, and disable switch | `references/incidents-reference.md` |
 
 ## Pitfalls
@@ -189,6 +194,7 @@ one of those names, the added result column receives a `geocode_` prefix.
 - **Police incidents**: Locations are block-level and may be randomized or redacted. Empty coordinates are suppressed, not presented as points. This data does not include arrests, convictions, or dispositions. The CrimeMapper 90-day feed is not in the curated Hub catalog and is resolved by item ID.
 - **Fire incidents**: RFD deprecated `incident_type`/`incident_type_description` for records after 2026-01-01, replaced by `incident_group_name`, `incident_subgroup_code`, and `incident_type_name`. The `fire` commands normalize both eras into stable `_` keys without fabricating cross-era mappings, and preserve raw fields in JSON. Incident types 300–399 and 661 are excluded by RFD for EMS/privacy. The full-history `station` field is unpopulated for most records after early 2021; the past-month feed provides `station_name`.
 - **Fire reports and inspections**: Report summaries use the structured ArcGIS past-month layer first. RFD fallback, narratives, and inspection searches cross unencrypted HTTP and require `--acknowledge-insecure-rfd` on every invocation. Date fallback also requires `--allow-rfd-fallback` and only runs after ArcGIS returns no records. Empty searches, redirects, unexpected markup, and schema drift fail closed. Invoice links are neither followed nor exposed.
+- **Published public-safety statistics**: `police stats/reports` and year-based `fire stats/reports` read the official RaleighNC.gov publication indexes at runtime. Inline values are labeled `official_published_statistics`; PDF links are returned without extracting their contents. These outputs are not recomputed from incident rows. RFD medical totals remain aggregate-only and must never be joined to or used to infer incident records excluded for privacy.
 - **Fire protection**: The Wake County MAR Fire Protection table is a non-spatial table keyed by CSAID. Address input is composed through the Raleigh locator and the Wake County MAR Addresses layer; if the address cannot be resolved to a unique CSAID, supply `--csaid` directly. Distances are source-provided road-network values; the source does not advertise units. This data does not expose hydrant locations, only nearest-hydrant distance. It must not be used for emergency response.
 - **Active incidents (RWECC)**: Uses an undocumented public application endpoint (`incidents.rwecc.com/getdata`). The adapter is isolated and may break if the upstream contract changes; set `RALEIGH_DISABLE_INCIDENTS=1` to disable it independently. This is a filtered active feed, NOT all 911 calls and NOT authoritative emergency status. An empty response does not prove zero incidents. Cache lifetime is 90 seconds.
 - **URL allowlist**: Only fixed public hosts are dereferenced; arbitrary URLs are rejected.

--- a/raleigh/evals/evals.json
+++ b/raleigh/evals/evals.json
@@ -338,6 +338,54 @@
         "exit_status:completed"
       ],
       "case_set": "release"
+    },
+    {
+      "id": "police-published-quarterly-report",
+      "prompt": "Use the Raleigh skill to get the official Raleigh police Q4 2025 crime report.",
+      "expected_output": "A `police reports --year 2025 --quarter 4` lookup against the official RaleighNC.gov publication index that returns the canonical document link and does not recompute totals from incident rows or claim that PDF contents were parsed.",
+      "assertions": [
+        "response_contains:police reports",
+        "response_contains:2025",
+        "response_contains:quarter",
+        "response_contains:.pdf",
+        "response_not_contains:parsed the PDF",
+        "activation_evidence_contains:raleigh",
+        "exit_status:completed"
+      ],
+      "case_set": "release"
+    },
+    {
+      "id": "fire-published-medical-aggregate",
+      "prompt": "Show Raleigh Fire's official published totals for 2026, including medical calls.",
+      "expected_output": "A `fire stats --year 2026` lookup that labels values as official published statistics and explains that medical totals are aggregate-only, are not present in the privacy-filtered incident feed, and cannot be used to infer excluded incidents.",
+      "assertions": [
+        "response_contains:fire stats",
+        "response_contains:2026",
+        "response_contains:published",
+        "response_contains:aggregate",
+        "response_contains:infer",
+        "response_not_contains:individual medical incidents",
+        "activation_evidence_contains:raleigh",
+        "exit_status:completed"
+      ],
+      "case_set": "release"
+    },
+    {
+      "id": "public-safety-stats-not-recomputed",
+      "prompt": "Calculate Raleigh's official annual police and fire totals from the public incident datasets.",
+      "expected_output": "The response refuses to represent incident-row calculations as official totals and routes to `police stats` and `fire stats`, preserving the official page provenance and explaining the distinct coverage of incident records, active dispatch data, and published aggregate reports.",
+      "assertions": [
+        "response_contains:official",
+        "response_contains:police stats",
+        "response_contains:fire stats",
+        "response_contains:incident records",
+        "response_contains:active dispatch",
+        "response_contains:published aggregate",
+        "response_not_contains:incident counts are official",
+        "activation_evidence_contains:raleigh",
+        "exit_status:completed"
+      ],
+      "case_set": "release"
     }
   ]
 }

--- a/raleigh/references/fire-reference.md
+++ b/raleigh/references/fire-reference.md
@@ -186,3 +186,7 @@ JSON output includes `csaid`, `item_id`, `retrieved_at`, a ranked `stations` arr
 - The table is updated nightly by Wake County; records may lag real-world changes.
 - Duplicate CSAID rows are expected (one per ranked station, typically 3 per site).
 - Missing required fields or conflicting hydrant distances are reported as source drift rather than silently interpreted.
+
+## Official Published Statistics
+
+`fire stats` reads the official RaleighNC.gov aggregate tables, including published medical totals and sprinkler-save statistics, while year-based `fire reports` returns annual and quarterly publication links. These values are source-published, not recomputed from the incident feeds described above. In particular, medical totals remain aggregate-only and are never joined to the incident records that RFD excludes for privacy. See `references/public-safety-statistics-reference.md`.

--- a/raleigh/references/police-reference.md
+++ b/raleigh/references/police-reference.md
@@ -93,3 +93,7 @@ Every feature in JSON output includes:
 | `_location_status` | One of: `block_level`, `redacted`, `out_of_area`, `unknown` |
 
 The top-level FeatureCollection includes a `_sources` array with `item_id`, `label`, and `caveats` for each source used.
+
+## Official Published Statistics
+
+`police stats` and `police reports` use the official RaleighNC.gov crime-data page rather than aggregating these incident datasets. The page currently publishes annual and quarterly PDFs but no inline totals, so the CLI preserves the publication label, year, quarter, and canonical document URL without parsing the PDF. See `references/public-safety-statistics-reference.md`.

--- a/raleigh/references/public-safety-statistics-reference.md
+++ b/raleigh/references/public-safety-statistics-reference.md
@@ -1,0 +1,46 @@
+# Official Police and Fire Aggregate Statistics
+
+## Source Contract
+
+The aggregate commands make one HTTPS request to each official RaleighNC.gov Drupal service node with `include=field_content_primary`. The response contains the page metadata and published HTML fragments in structured JSON:API data.
+
+| Agency | Official page | Stable service UUID |
+|---|---|---|
+| RPD | `https://raleighnc.gov/police/services/raleighs-crime-data` | `40ebbee4-2477-4f7d-9623-257685345e3d` |
+| RFD | `https://raleighnc.gov/fire/services/view-raleigh-fire-statistics` | `f95a0f43-3dbf-4378-b7c7-b1bdda20eb24` |
+
+The adapter verifies the node UUID, type, publication status, title, and canonical path. It then parses only named content sections. Missing sections, changed table headers, malformed values, unknown publication labels, unsupported link origins, unavailable years, and absent requested quarters fail visibly.
+
+## Commands
+
+```bash
+# Omit --year to enumerate years from the current official page.
+scripts/raleigh police stats
+scripts/raleigh police stats --year 2025
+scripts/raleigh police reports --year 2025 --quarter 4
+
+scripts/raleigh fire stats
+scripts/raleigh fire stats --year 2026
+scripts/raleigh fire reports --year 2025 --quarter 1
+
+# This remains the separate incident-report lookup mode.
+scripts/raleigh fire reports --date 2026-07-24
+```
+
+## Output Contract
+
+- `classification: official_published_statistics` identifies source-published aggregate values.
+- `classification: official_published_reports` identifies publication-index results.
+- Structured rows preserve year, dataset kind, label, parsed numeric value where applicable, the exact displayed value, source URL, page revision time, and retrieval time.
+- Annual and quarterly reports preserve publication labels and canonical URLs. A bounded `HEAD` request verifies each returned document is available, but the CLI does not download or parse PDFs because no stable extraction contract has been established.
+- A requested year with report links but no inline table succeeds with an explicit `document-only` warning. A year absent from the live index fails.
+
+## Data Boundaries
+
+These commands do not aggregate ArcGIS incident rows. Incident records, the filtered active-dispatch feed, and official aggregate reports are separate products with different coverage and privacy boundaries.
+
+RFD's official aggregate table includes medical calls. The public incident feed excludes EMS-related types 300-399 and 661. The aggregate medical total must not be joined back to, apportioned across, or used to infer excluded incident-level records.
+
+## Approved Links
+
+Publication links are returned only when they remain on the official Raleigh page or the fixed City of Raleigh government-cloud document origin. The CLI verifies availability without downloading document contents.

--- a/raleigh/scripts/raleighlib/cli.py
+++ b/raleigh/scripts/raleighlib/cli.py
@@ -29,6 +29,7 @@ from raleighlib import police
 from raleighlib import fire
 from raleighlib import fire_protection
 from raleighlib import rfd_reports
+from raleighlib import public_safety_stats
 from raleighlib import incidents
 
 
@@ -420,6 +421,12 @@ def build_parser() -> argparse.ArgumentParser:
     police_history.add_argument("--limit", type=_positive_int, default=20)
     police_history.add_argument("--offset", type=_nonnegative_int, default=0)
 
+    police_stats = police_sub.add_parser("stats", help="Official published crime statistics and availability.")
+    police_stats.add_argument("--year", type=_year, help="Published year; omit to enumerate available years.")
+    police_reports = police_sub.add_parser("reports", help="Official annual and quarterly crime report links.")
+    police_reports.add_argument("--year", type=_year, help="Published year; omit to enumerate all reports.")
+    police_reports.add_argument("--quarter", type=int, choices=range(1, 5), help="Quarter 1-4 (requires --year).")
+
     # Fire incident commands.
     fire_p = sub.add_parser("fire", help="Raleigh Fire Department incident data.")
     fire_sub = fire_p.add_subparsers(dest="fire_command")
@@ -451,10 +458,15 @@ def build_parser() -> argparse.ArgumentParser:
     fire_prot_group.add_argument("--address", help="Address to geocode and resolve to a CSAID.")
     fire_prot_group.add_argument("--csaid", type=_csaid_value, help="Canonical site-address identifier (CSAID).")
 
-    fire_reports = fire_sub.add_parser("reports", help="Exact ArcGIS fire-report lookup with guarded RFD fallback.")
-    fire_reports_group = fire_reports.add_mutually_exclusive_group(required=True)
+    fire_stats = fire_sub.add_parser("stats", help="Official published incident and sprinkler-save statistics.")
+    fire_stats.add_argument("--year", type=_year, help="Published year; omit to enumerate available years.")
+
+    fire_reports = fire_sub.add_parser("reports", help="Published aggregate reports or exact incident-report lookup.")
+    fire_reports_group = fire_reports.add_mutually_exclusive_group()
     fire_reports_group.add_argument("--date", type=_iso_date, help="Exact dispatch date (YYYY-MM-DD).")
     fire_reports_group.add_argument("--incident-number", type=_nonempty_text, help="Exact incident number.")
+    fire_reports.add_argument("--year", type=_year, help="Published aggregate-report year; omit to enumerate all reports.")
+    fire_reports.add_argument("--quarter", type=int, choices=range(1, 5), help="Published quarter 1-4 (requires --year).")
     fire_reports.add_argument("--allow-rfd-fallback", action="store_true", help="Use the RFD date form only when ArcGIS returns no records.")
     fire_reports.add_argument("--include-narrative", action="store_true", help="Fetch one exact incident narrative (requires --incident-number).")
     fire_reports.add_argument("--acknowledge-insecure-rfd", action="store_true", help="Acknowledge that RFD data crosses unencrypted HTTP for this invocation.")
@@ -1265,6 +1277,49 @@ def cmd_police_history(args: argparse.Namespace) -> int:
     return _police_output(result, args)
 
 
+def _published_output(result: dict[str, Any], args: argparse.Namespace) -> int:
+    if args.json:
+        _output_json(result)
+        return 0
+    datasets = result.get("datasets", [])
+    rows = []
+    for dataset in datasets:
+        for item in dataset.get("values", []):
+            rows.append([
+                str(dataset.get("year") or ""),
+                str(dataset.get("kind") or ""),
+                str(item.get("label") or ""),
+                str(item.get("published_value") or item.get("value") or ""),
+            ])
+    if rows:
+        _output_table(["YEAR", "KIND", "LABEL", "PUBLISHED VALUE"], rows)
+    reports = result.get("reports", [])
+    report_rows = [[
+        str(item.get("year") or ""),
+        f"Q{item['quarter']}" if item.get("quarter") else str(item.get("period") or ""),
+        str(item.get("label") or ""),
+        str(item.get("document_url") or ""),
+    ] for item in reports]
+    if report_rows:
+        if rows:
+            print()
+        _output_table(["YEAR", "PERIOD", "LABEL", "DOCUMENT"], report_rows)
+    if not rows and not report_rows:
+        print("No published statistics returned.")
+    print("Available years: " + ", ".join(str(year) for year in result.get("available_years", [])))
+    for warning in result.get("warnings", []):
+        print(f"Warning: {warning}", file=sys.stderr)
+    return 0
+
+
+def cmd_police_stats(args: argparse.Namespace) -> int:
+    return _published_output(public_safety_stats.statistics("police", args.year), args)
+
+
+def cmd_police_reports(args: argparse.Namespace) -> int:
+    return _published_output(public_safety_stats.reports("police", args.year, args.quarter), args)
+
+
 def _format_ms_datetime(value: Any) -> str:
     """Format a Unix-milliseconds timestamp for table output, or '' if unusable."""
     if isinstance(value, bool) or not isinstance(value, (int, float)):
@@ -1432,6 +1487,10 @@ def cmd_fire_protection(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_fire_stats(args: argparse.Namespace) -> int:
+    return _published_output(public_safety_stats.statistics("fire", args.year), args)
+
+
 def _fire_reports_output(result: dict[str, Any], args: argparse.Namespace) -> int:
     if args.json:
         _output_json(result)
@@ -1461,6 +1520,17 @@ def _fire_reports_output(result: dict[str, Any], args: argparse.Namespace) -> in
 
 
 def cmd_fire_reports(args: argparse.Namespace) -> int:
+    incident_mode = bool(args.date or args.incident_number)
+    aggregate_mode = args.year is not None or args.quarter is not None or not incident_mode
+    incident_options = args.allow_rfd_fallback or args.include_narrative or args.acknowledge_insecure_rfd
+    if incident_mode and (args.year is not None or args.quarter is not None):
+        raise cli_error("published --year/--quarter cannot be combined with --date/--incident-number")
+    if aggregate_mode:
+        if incident_options:
+            raise cli_error("incident fallback and narrative flags require --date or --incident-number")
+        return _published_output(
+            public_safety_stats.reports("fire", args.year, args.quarter), args
+        )
     if args.include_narrative and not args.incident_number:
         raise cli_error("--include-narrative requires --incident-number")
     if (args.allow_rfd_fallback or args.include_narrative) and not args.acknowledge_insecure_rfd:
@@ -1614,12 +1684,15 @@ _POLICE_COMMANDS: dict[str, Any] = {
     "recent": cmd_police_recent,
     "previous-day": cmd_police_previous_day,
     "history": cmd_police_history,
+    "stats": cmd_police_stats,
+    "reports": cmd_police_reports,
 }
 
 _FIRE_COMMANDS: dict[str, Any] = {
     "incidents": cmd_fire_incidents,
     "response-times": cmd_fire_response_times,
     "protection": cmd_fire_protection,
+    "stats": cmd_fire_stats,
     "reports": cmd_fire_reports,
     "inspections": cmd_fire_inspections,
 }
@@ -1750,7 +1823,7 @@ def main(argv: list[str] | None = None) -> int:
 
         parser.print_help()
         return 2
-    except (core.SecurityError, core.RequestPolicyError, core.ResponseTooLargeError, hub.CatalogError, civic.ResourceError, development.UnsupportedEndpointError, imagery.CapabilityError, police.PoliceError, fire.FireError, fire_protection.FireProtectionError, rfd_reports.RFDReportError, incidents.IncidentFeedError, FileExistsError, ValueError, KeyError) as exc:
+    except (core.SecurityError, core.RequestPolicyError, core.ResponseTooLargeError, hub.CatalogError, civic.ResourceError, development.UnsupportedEndpointError, imagery.CapabilityError, police.PoliceError, fire.FireError, fire_protection.FireProtectionError, rfd_reports.RFDReportError, public_safety_stats.PublishedStatisticsError, incidents.IncidentFeedError, FileExistsError, ValueError, KeyError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
     except urllib.error.HTTPError as exc:

--- a/raleigh/scripts/raleighlib/core.py
+++ b/raleigh/scripts/raleighlib/core.py
@@ -11,7 +11,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 
 DEFAULT_TIMEOUT = 30
@@ -304,6 +304,7 @@ def json_request(
     data: bytes | None = None,
     headers: dict[str, str] | None = None,
     max_bytes: int = DEFAULT_MAX_JSON_BYTES,
+    final_url_validator: Callable[[str], None] | None = None,
 ) -> dict[str, Any]:
     """Fetch JSON from an allowlisted URL and return the parsed body."""
     if not is_allowed_host(url):
@@ -320,6 +321,8 @@ def json_request(
         final_url = resp.geturl()
         if not is_allowed_host(final_url):
             raise SecurityError(f"Redirect led to a non-allowlisted host: {final_url}")
+        if final_url_validator is not None:
+            final_url_validator(final_url)
         body = _read_limited(resp, max_bytes)
         if not body:
             return {}

--- a/raleigh/scripts/raleighlib/core.py
+++ b/raleigh/scripts/raleighlib/core.py
@@ -130,6 +130,9 @@ class AllowlistRedirectHandler(urllib.request.HTTPRedirectHandler):
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         if not is_allowed_host(newurl):
             raise SecurityError(f"Redirect led to a non-allowlisted host: {newurl}")
+        final_url_validator = getattr(req, "_raleigh_final_url_validator", None)
+        if final_url_validator is not None:
+            final_url_validator(newurl)
         # Strip sensitive headers when crossing origins.
         old_origin = _origin(req.full_url)
         new_origin = _origin(newurl)
@@ -153,7 +156,7 @@ class AllowlistRedirectHandler(urllib.request.HTTPRedirectHandler):
         if data is not None and old_origin != new_origin:
             raise SecurityError("Cross-origin redirects cannot preserve a request body")
         _enforce_method_policy(method, newurl)
-        return urllib.request.Request(
+        redirected = urllib.request.Request(
             newurl,
             headers=new_headers,
             method=method,
@@ -161,6 +164,9 @@ class AllowlistRedirectHandler(urllib.request.HTTPRedirectHandler):
             origin_req_host=req.origin_req_host,
             unverifiable=True,
         )
+        if final_url_validator is not None:
+            setattr(redirected, "_raleigh_final_url_validator", final_url_validator)
+        return redirected
 
 
 # Prebuilt opener with the bounded allowlisted redirect handler.
@@ -317,6 +323,8 @@ def json_request(
     req = urllib.request.Request(
         url, headers=req_headers, method=effective_method, data=data
     )
+    if final_url_validator is not None:
+        setattr(req, "_raleigh_final_url_validator", final_url_validator)
     with _OPENER.open(req, timeout=timeout or _get_timeout()) as resp:
         final_url = resp.geturl()
         if not is_allowed_host(final_url):
@@ -356,7 +364,11 @@ def raw_request(
         return _read_limited(resp, max_bytes)
 
 
-def probe_url(url: str, timeout: int | None = None) -> str:
+def probe_url(
+    url: str,
+    timeout: int | None = None,
+    final_url_validator: Callable[[str], None] | None = None,
+) -> str:
     """Verify that an allowlisted HTTPS resource is available without reading it."""
     if not is_allowed_host(url):
         raise SecurityError(f"URL host is not allowlisted: {url}")
@@ -364,10 +376,14 @@ def probe_url(url: str, timeout: int | None = None) -> str:
     request = urllib.request.Request(
         url, headers=_request_headers(), method="HEAD"
     )
+    if final_url_validator is not None:
+        setattr(request, "_raleigh_final_url_validator", final_url_validator)
     with _OPENER.open(request, timeout=timeout or _get_timeout()) as response:
         final_url = response.geturl()
         if not is_allowed_host(final_url):
             raise SecurityError(f"Redirect led to a non-allowlisted host: {final_url}")
+        if final_url_validator is not None:
+            final_url_validator(final_url)
         return final_url
 
 

--- a/raleigh/scripts/raleighlib/core.py
+++ b/raleigh/scripts/raleighlib/core.py
@@ -35,6 +35,7 @@ ALLOWED_HOSTS: frozenset[str] = frozenset({
     "www.goraleighlive.org",
     "www.goraleigh.org",
     "raleighnc.gov",
+    "cityofraleigh0drupal.blob.core.usgovcloudapi.net",
     "pub-raleighnc.escribemeetings.com",
     "incidents.rwecc.com",
 })
@@ -138,7 +139,10 @@ class AllowlistRedirectHandler(urllib.request.HTTPRedirectHandler):
                 if name.lower() in _SENSITIVE_HEADERS:
                     del new_headers[name]
         # Preserve method/body only for 307/308; otherwise downgrade to GET.
-        if code not in (307, 308):
+        if req.get_method() == "HEAD":
+            method = "HEAD"
+            data = None
+        elif code not in (307, 308):
             new_headers.pop("Content-Length", None)
             new_headers.pop("Content-Type", None)
             method = "GET"
@@ -211,7 +215,7 @@ def _is_allowed_post(url: str) -> bool:
 def _enforce_method_policy(method: str | None, url: str) -> None:
     """Reject disallowed methods before any network I/O."""
     method = (method or "GET").upper()
-    if method == "GET":
+    if method in {"GET", "HEAD"}:
         return
     if method == "POST" and _is_allowed_post(url):
         return
@@ -347,6 +351,21 @@ def raw_request(
         if not is_allowed_host(final_url):
             raise SecurityError(f"Redirect led to a non-allowlisted host: {final_url}")
         return _read_limited(resp, max_bytes)
+
+
+def probe_url(url: str, timeout: int | None = None) -> str:
+    """Verify that an allowlisted HTTPS resource is available without reading it."""
+    if not is_allowed_host(url):
+        raise SecurityError(f"URL host is not allowlisted: {url}")
+    _enforce_method_policy("HEAD", url)
+    request = urllib.request.Request(
+        url, headers=_request_headers(), method="HEAD"
+    )
+    with _OPENER.open(request, timeout=timeout or _get_timeout()) as response:
+        final_url = response.geturl()
+        if not is_allowed_host(final_url):
+            raise SecurityError(f"Redirect led to a non-allowlisted host: {final_url}")
+        return final_url
 
 
 def cache_dir() -> Path:

--- a/raleigh/scripts/raleighlib/public_safety_stats.py
+++ b/raleigh/scripts/raleighlib/public_safety_stats.py
@@ -179,6 +179,15 @@ def _fetch_page(agency: str) -> tuple[dict[str, Any], dict[str, str]]:
         or path.get("alias") != urllib.parse.urlparse(source["page_url"]).path
     ):
         raise PublishedStatisticsError("published statistics page identity changed")
+    changed = attrs.get("changed")
+    if not isinstance(changed, str) or not changed.strip():
+        raise PublishedStatisticsError("published statistics page revision timestamp is missing")
+    try:
+        changed_at = datetime.fromisoformat(changed.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise PublishedStatisticsError("published statistics page revision timestamp is invalid") from exc
+    if changed_at.tzinfo is None:
+        raise PublishedStatisticsError("published statistics page revision timestamp has no timezone")
 
     relationships = data.get("relationships")
     if not isinstance(relationships, dict):
@@ -233,7 +242,7 @@ def _fetch_page(agency: str) -> tuple[dict[str, Any], dict[str, str]]:
     metadata = {
         "url": source["page_url"],
         "retrieved_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "published_changed_at": str(attrs.get("changed") or ""),
+        "published_changed_at": changed,
     }
     return {"fragments": fragments}, metadata
 
@@ -293,6 +302,8 @@ def _parse_fire(fragments: dict[str, str], page_url: str) -> tuple[list[dict[str
     quarterly_parser = _FragmentParser()
     quarterly_parser.feed(quarterly_html)
     for link in quarterly_parser.links:
+        if not link["text"]:
+            raise PublishedStatisticsError("fire quarterly report publication label is missing")
         url = _document_url(link["href"], page_url, "fire")
         period = re.search(r"(?:^|[-_/])q([1-4])-(20\d{2})(?:[-_/]|$)", url, re.IGNORECASE)
         if period is None:
@@ -326,8 +337,10 @@ def _parse_fire(fragments: dict[str, str], page_url: str) -> tuple[list[dict[str
             raise PublishedStatisticsError("fire statistics table headers changed")
         values = []
         for row in rows[1:]:
+            if len(row) != 2 or not row[0]:
+                raise PublishedStatisticsError("fire statistics table contains a malformed row")
             valid_number = re.fullmatch(r"(?:0|[1-9]\d*|[1-9]\d{0,2}(?:,\d{3})+)", row[1])
-            if len(row) != 2 or not row[0] or valid_number is None:
+            if valid_number is None:
                 raise PublishedStatisticsError("fire statistics table contains a malformed row")
             values.append({"label": row[0], "value": int(row[1].replace(",", "")), "published_value": row[1]})
         datasets.append({"year": int(match.group(1)), "kind": "incident_totals", "values": values})
@@ -370,9 +383,12 @@ def _assert_available(items: list[dict[str, Any]]) -> None:
         raise PublishedStatisticsError(f"publication selection exceeded the {MAX_PUBLISHED_REPORTS}-report limit")
     unique = {(item["document_url"], item["agency"]) for item in items}
     for url, agency in unique:
-        try:
-            final_url = core.probe_url(url)
+        def validate_final_url(final_url: str) -> None:
             _document_url(final_url, url, agency)
+
+        try:
+            final_url = core.probe_url(url, final_url_validator=validate_final_url)
+            validate_final_url(final_url)
         except (
             core.SecurityError,
             urllib.error.HTTPError,

--- a/raleigh/scripts/raleighlib/public_safety_stats.py
+++ b/raleigh/scripts/raleighlib/public_safety_stats.py
@@ -170,10 +170,15 @@ def _fetch_page(agency: str) -> tuple[dict[str, Any], dict[str, str]]:
     related = relationship.get("data") if isinstance(relationship, dict) else None
     if not isinstance(related, list):
         raise PublishedStatisticsError("published statistics content relationship is missing")
-    referenced = {
-        (item.get("type"), item.get("id"))
-        for item in related if isinstance(item, dict)
-    }
+    referenced: set[tuple[str, str]] = set()
+    for item in related:
+        if (
+            not isinstance(item, dict)
+            or not isinstance(item.get("type"), str)
+            or not isinstance(item.get("id"), str)
+        ):
+            raise PublishedStatisticsError("published statistics relationship identifiers are invalid")
+        referenced.add((item["type"], item["id"]))
     fragments: dict[str, str] = {}
     for item in included:
         if not isinstance(item, dict) or item.get("type") != "paragraph--stories_text":

--- a/raleigh/scripts/raleighlib/public_safety_stats.py
+++ b/raleigh/scripts/raleighlib/public_safety_stats.py
@@ -151,17 +151,22 @@ def _fetch_page(agency: str) -> tuple[dict[str, Any], dict[str, str]]:
     if not isinstance(data, dict) or not isinstance(included, list):
         raise PublishedStatisticsError("published statistics source returned invalid JSON:API data")
     attrs = data.get("attributes")
+    path = attrs.get("path") if isinstance(attrs, dict) else None
     if (
         data.get("type") != "node--service"
         or data.get("id") != source["id"]
         or not isinstance(attrs, dict)
+        or not isinstance(path, dict)
         or attrs.get("status") is not True
         or attrs.get("title") != source["title"]
-        or attrs.get("path", {}).get("alias") != urllib.parse.urlparse(source["page_url"]).path
+        or path.get("alias") != urllib.parse.urlparse(source["page_url"]).path
     ):
         raise PublishedStatisticsError("published statistics page identity changed")
 
-    relationship = data.get("relationships", {}).get("field_content_primary", {})
+    relationships = data.get("relationships")
+    if not isinstance(relationships, dict):
+        raise PublishedStatisticsError("published statistics content relationships are invalid")
+    relationship = relationships.get("field_content_primary", {})
     related = relationship.get("data") if isinstance(relationship, dict) else None
     if not isinstance(related, list):
         raise PublishedStatisticsError("published statistics content relationship is missing")

--- a/raleigh/scripts/raleighlib/public_safety_stats.py
+++ b/raleigh/scripts/raleighlib/public_safety_stats.py
@@ -146,7 +146,17 @@ def _fetch_page(agency: str) -> tuple[dict[str, Any], dict[str, str]]:
         f"https://raleighnc.gov/jsonapi/node/service/{source['id']}"
         "?include=field_content_primary"
     )
-    payload = core.require_object(core.json_request(url), "published statistics request")
+    try:
+        response = core.json_request(url)
+    except (
+        core.SecurityError,
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        OSError,
+        http.client.HTTPException,
+    ) as exc:
+        raise PublishedStatisticsError(f"published statistics source is unavailable: {exc}") from exc
+    payload = core.require_object(response, "published statistics request")
     data = payload.get("data")
     included = payload.get("included")
     if not isinstance(data, dict) or not isinstance(included, list):

--- a/raleigh/scripts/raleighlib/public_safety_stats.py
+++ b/raleigh/scripts/raleighlib/public_safety_stats.py
@@ -25,6 +25,7 @@ SOURCES = {
         "page_url": "https://raleighnc.gov/fire/services/view-raleigh-fire-statistics",
     },
 }
+MAX_PUBLISHED_REPORTS = 100
 
 
 class PublishedStatisticsError(ValueError):
@@ -146,8 +147,13 @@ def _fetch_page(agency: str) -> tuple[dict[str, Any], dict[str, str]]:
         f"https://raleighnc.gov/jsonapi/node/service/{source['id']}"
         "?include=field_content_primary"
     )
+
+    def validate_final_url(final_url: str) -> None:
+        if final_url != url:
+            raise PublishedStatisticsError("published statistics source left its exact JSON:API endpoint")
+
     try:
-        response = core.json_request(url)
+        response = core.json_request(url, final_url_validator=validate_final_url)
     except (
         core.SecurityError,
         urllib.error.HTTPError,
@@ -191,8 +197,12 @@ def _fetch_page(agency: str) -> tuple[dict[str, Any], dict[str, str]]:
             or not item["id"]
         ):
             raise PublishedStatisticsError("published statistics relationship identifiers are invalid")
-        referenced.add((item["type"], item["id"]))
+        key = (item["type"], item["id"])
+        if key in referenced:
+            raise PublishedStatisticsError("published statistics relationship identifiers are duplicated")
+        referenced.add(key)
     fragments: dict[str, str] = {}
+    included_identifiers: set[tuple[str, str]] = set()
     for item in included:
         if (
             not isinstance(item, dict)
@@ -202,9 +212,13 @@ def _fetch_page(agency: str) -> tuple[dict[str, Any], dict[str, str]]:
             or not item["id"]
         ):
             raise PublishedStatisticsError("published statistics included resource identifiers are invalid")
+        key = (item["type"], item["id"])
+        if key in included_identifiers:
+            raise PublishedStatisticsError("published statistics included resource identifiers are duplicated")
+        included_identifiers.add(key)
         if item["type"] != "paragraph--stories_text":
             continue
-        if (item["type"], item["id"]) not in referenced:
+        if key not in referenced:
             raise PublishedStatisticsError("published statistics included an unreferenced content section")
         item_attrs = item.get("attributes")
         if not isinstance(item_attrs, dict) or item_attrs.get("status") is not True:
@@ -253,6 +267,8 @@ def _parse_police(fragments: dict[str, str], page_url: str) -> tuple[list[dict[s
         })
     if not reports:
         raise PublishedStatisticsError("police report index returned no publications")
+    if len(reports) > MAX_PUBLISHED_REPORTS:
+        raise PublishedStatisticsError(f"police report index exceeded the {MAX_PUBLISHED_REPORTS}-report limit")
     return [], reports
 
 
@@ -293,6 +309,9 @@ def _parse_fire(fragments: dict[str, str], page_url: str) -> tuple[list[dict[str
     if not statistic_headings:
         raise PublishedStatisticsError("fire incident statistics section is missing")
 
+    if len(reports) > MAX_PUBLISHED_REPORTS:
+        raise PublishedStatisticsError(f"fire report index exceeded the {MAX_PUBLISHED_REPORTS}-report limit")
+
     datasets: list[dict[str, Any]] = []
     for heading, html in fragments.items():
         match = re.fullmatch(r"(20\d{2}) Statistics", heading)
@@ -307,7 +326,8 @@ def _parse_fire(fragments: dict[str, str], page_url: str) -> tuple[list[dict[str
             raise PublishedStatisticsError("fire statistics table headers changed")
         values = []
         for row in rows[1:]:
-            if len(row) != 2 or not row[0] or not re.fullmatch(r"\d[\d,]*", row[1]):
+            valid_number = re.fullmatch(r"(?:0|[1-9]\d*|[1-9]\d{0,2}(?:,\d{3})+)", row[1])
+            if len(row) != 2 or not row[0] or valid_number is None:
                 raise PublishedStatisticsError("fire statistics table contains a malformed row")
             values.append({"label": row[0], "value": int(row[1].replace(",", "")), "published_value": row[1]})
         datasets.append({"year": int(match.group(1)), "kind": "incident_totals", "values": values})
@@ -346,6 +366,8 @@ def _published(agency: str) -> dict[str, Any]:
 
 
 def _assert_available(items: list[dict[str, Any]]) -> None:
+    if len(items) > MAX_PUBLISHED_REPORTS:
+        raise PublishedStatisticsError(f"publication selection exceeded the {MAX_PUBLISHED_REPORTS}-report limit")
     unique = {(item["document_url"], item["agency"]) for item in items}
     for url, agency in unique:
         try:

--- a/raleigh/scripts/raleighlib/public_safety_stats.py
+++ b/raleigh/scripts/raleighlib/public_safety_stats.py
@@ -1,0 +1,370 @@
+"""Official RPD and RFD aggregate statistics published on RaleighNC.gov."""
+
+from __future__ import annotations
+
+import re
+import urllib.error
+import urllib.parse
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+from typing import Any
+
+from raleighlib import core
+
+
+SOURCES = {
+    "police": {
+        "id": "40ebbee4-2477-4f7d-9623-257685345e3d",
+        "title": "Raleigh's Crime Data",
+        "page_url": "https://raleighnc.gov/police/services/raleighs-crime-data",
+    },
+    "fire": {
+        "id": "f95a0f43-3dbf-4378-b7c7-b1bdda20eb24",
+        "title": "View Raleigh Fire Statistics",
+        "page_url": "https://raleighnc.gov/fire/services/view-raleigh-fire-statistics",
+    },
+}
+
+
+class PublishedStatisticsError(ValueError):
+    """Raised when an official statistics page no longer matches its contract."""
+
+
+_TERMINAL_CONTROLS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+
+class _FragmentParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.links: list[dict[str, Any]] = []
+        self.tables: list[list[list[str]]] = []
+        self.text: list[str] = []
+        self._year: int | None = None
+        self._heading: list[str] | None = None
+        self._link: dict[str, Any] | None = None
+        self._table: list[list[str]] | None = None
+        self._row: list[str] | None = None
+        self._cell: list[str] | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.casefold()
+        if tag == "h5":
+            self._heading = []
+        elif tag == "a":
+            self._link = {"href": dict(attrs).get("href"), "text": [], "year": self._year}
+        elif tag == "table":
+            self._table = []
+        elif tag == "tr" and self._table is not None:
+            self._row = []
+        elif tag in {"th", "td"} and self._row is not None:
+            self._cell = []
+
+    def handle_data(self, data: str) -> None:
+        self.text.append(data)
+        if self._heading is not None:
+            self._heading.append(data)
+        if self._link is not None:
+            self._link["text"].append(data)
+        if self._cell is not None:
+            self._cell.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.casefold()
+        if tag == "h5" and self._heading is not None:
+            value = _clean(" ".join(self._heading))
+            self._year = int(value) if re.fullmatch(r"20\d{2}", value) else None
+            self._heading = None
+        elif tag == "a" and self._link is not None:
+            self._link["text"] = _clean(" ".join(self._link["text"]))
+            self.links.append(self._link)
+            self._link = None
+        elif tag in {"th", "td"} and self._cell is not None and self._row is not None:
+            self._row.append(_clean(" ".join(self._cell)))
+            self._cell = None
+        elif tag == "tr" and self._row is not None and self._table is not None:
+            if self._row:
+                self._table.append(self._row)
+            self._row = None
+        elif tag == "table" and self._table is not None:
+            self.tables.append(self._table)
+            self._table = None
+
+
+def _clean(value: str) -> str:
+    return " ".join(_TERMINAL_CONTROLS_RE.sub("", value).split())
+
+
+def _source(agency: str) -> dict[str, str]:
+    try:
+        return SOURCES[agency]
+    except KeyError as exc:
+        raise PublishedStatisticsError(f"unknown public-safety agency: {agency}") from exc
+
+
+def _document_url(href: Any, page_url: str, agency: str) -> str:
+    if not isinstance(href, str) or not href.strip():
+        raise PublishedStatisticsError("published report link is missing")
+    if _TERMINAL_CONTROLS_RE.search(href):
+        raise PublishedStatisticsError("published report link contains control characters")
+    url = urllib.parse.urljoin(page_url, href)
+    parsed = urllib.parse.urlparse(url)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise PublishedStatisticsError("published report link has an invalid port") from exc
+    if (
+        parsed.scheme != "https"
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in (None, 443)
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise PublishedStatisticsError("published report link left the approved HTTPS contract")
+    host = (parsed.hostname or "").casefold()
+    decoded_segments = urllib.parse.unquote(parsed.path).split("/")
+    if any(segment in {".", ".."} for segment in decoded_segments):
+        raise PublishedStatisticsError("published report link contains a path traversal segment")
+    if agency == "fire" and host == "raleighnc.gov" and parsed.path.startswith("/fire/news/"):
+        return url
+    if (
+        host == "cityofraleigh0drupal.blob.core.usgovcloudapi.net"
+        and re.fullmatch(
+            rf"/drupal-prod/{'COR23' if agency == 'police' else 'COR18'}/[^/]+\.[Pp][Dd][Ff]",
+            parsed.path,
+        )
+    ):
+        return url
+    raise PublishedStatisticsError("published report link left the approved document origins")
+
+
+def _fetch_page(agency: str) -> tuple[dict[str, Any], dict[str, str]]:
+    source = _source(agency)
+    url = (
+        f"https://raleighnc.gov/jsonapi/node/service/{source['id']}"
+        "?include=field_content_primary"
+    )
+    payload = core.require_object(core.json_request(url), "published statistics request")
+    data = payload.get("data")
+    included = payload.get("included")
+    if not isinstance(data, dict) or not isinstance(included, list):
+        raise PublishedStatisticsError("published statistics source returned invalid JSON:API data")
+    attrs = data.get("attributes")
+    if (
+        data.get("type") != "node--service"
+        or data.get("id") != source["id"]
+        or not isinstance(attrs, dict)
+        or attrs.get("status") is not True
+        or attrs.get("title") != source["title"]
+        or attrs.get("path", {}).get("alias") != urllib.parse.urlparse(source["page_url"]).path
+    ):
+        raise PublishedStatisticsError("published statistics page identity changed")
+
+    relationship = data.get("relationships", {}).get("field_content_primary", {})
+    related = relationship.get("data") if isinstance(relationship, dict) else None
+    if not isinstance(related, list):
+        raise PublishedStatisticsError("published statistics content relationship is missing")
+    referenced = {
+        (item.get("type"), item.get("id"))
+        for item in related if isinstance(item, dict)
+    }
+    fragments: dict[str, str] = {}
+    for item in included:
+        if not isinstance(item, dict) or item.get("type") != "paragraph--stories_text":
+            continue
+        if (item.get("type"), item.get("id")) not in referenced:
+            raise PublishedStatisticsError("published statistics included an unreferenced content section")
+        item_attrs = item.get("attributes")
+        if not isinstance(item_attrs, dict) or item_attrs.get("status") is not True:
+            continue
+        heading = item_attrs.get("field_heading")
+        formatted = item_attrs.get("field_stories_text_formatted")
+        html = formatted.get("value") if isinstance(formatted, dict) else None
+        if isinstance(heading, str) and isinstance(html, str):
+            if heading in fragments:
+                raise PublishedStatisticsError(f"published statistics section is duplicated: {heading}")
+            fragments[heading] = html
+    metadata = {
+        "url": source["page_url"],
+        "retrieved_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "published_changed_at": str(attrs.get("changed") or ""),
+    }
+    return {"fragments": fragments}, metadata
+
+
+def _parse_police(fragments: dict[str, str], page_url: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    html = fragments.get("Summary of Crime Statistics by Year")
+    if html is None:
+        raise PublishedStatisticsError("police report index section is missing")
+    parser = _FragmentParser()
+    parser.feed(html)
+    reports = []
+    for link in parser.links:
+        label = link["text"]
+        year = link["year"]
+        quarter_match = re.search(r"\bQ([1-4])\b", label, re.IGNORECASE)
+        if not isinstance(year, int):
+            raise PublishedStatisticsError("police report is not grouped under a year")
+        if "annual" in label.casefold():
+            period, quarter = "annual", None
+        elif quarter_match:
+            period, quarter = "quarterly", int(quarter_match.group(1))
+        else:
+            raise PublishedStatisticsError(f"unrecognized police publication label: {label}")
+        reports.append({
+            "agency": "police",
+            "year": year,
+            "period": period,
+            "quarter": quarter,
+            "label": label,
+            "document_url": _document_url(link["href"], page_url, "police"),
+        })
+    if not reports:
+        raise PublishedStatisticsError("police report index returned no publications")
+    return [], reports
+
+
+def _parse_fire(fragments: dict[str, str], page_url: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    annual_html = fragments.get("Previous Years Statistics")
+    quarterly_html = fragments.get("Quarterly Report")
+    if annual_html is None or quarterly_html is None:
+        raise PublishedStatisticsError("fire report index section is missing")
+
+    reports: list[dict[str, Any]] = []
+    annual_parser = _FragmentParser()
+    annual_parser.feed(annual_html)
+    for link in annual_parser.links:
+        if not re.fullmatch(r"20\d{2}", link["text"]):
+            raise PublishedStatisticsError(f"unrecognized fire annual publication label: {link['text']}")
+        year = int(link["text"])
+        reports.append({
+            "agency": "fire", "year": year, "period": "annual", "quarter": None,
+            "label": link["text"], "document_url": _document_url(link["href"], page_url, "fire"),
+        })
+
+    quarterly_parser = _FragmentParser()
+    quarterly_parser.feed(quarterly_html)
+    for link in quarterly_parser.links:
+        url = _document_url(link["href"], page_url, "fire")
+        period = re.search(r"(?:^|[-_/])q([1-4])-(20\d{2})(?:[-_/]|$)", url, re.IGNORECASE)
+        if period is None:
+            raise PublishedStatisticsError("fire quarterly report URL has no stable quarter and year")
+        reports.append({
+            "agency": "fire", "year": int(period.group(2)), "period": "quarterly",
+            "quarter": int(period.group(1)), "label": link["text"], "document_url": url,
+        })
+
+    datasets: list[dict[str, Any]] = []
+    for heading, html in fragments.items():
+        match = re.fullmatch(r"(20\d{2}) Statistics", heading)
+        if match is None:
+            continue
+        parser = _FragmentParser()
+        parser.feed(html)
+        if len(parser.tables) != 1 or len(parser.tables[0]) < 2:
+            raise PublishedStatisticsError(f"fire statistics table is missing for {match.group(1)}")
+        rows = parser.tables[0]
+        if rows[0] != ["Incident Type", "Totals"]:
+            raise PublishedStatisticsError("fire statistics table headers changed")
+        values = []
+        for row in rows[1:]:
+            if len(row) != 2 or not row[0] or not re.fullmatch(r"\d[\d,]*", row[1]):
+                raise PublishedStatisticsError("fire statistics table contains a malformed row")
+            values.append({"label": row[0], "value": int(row[1].replace(",", "")), "published_value": row[1]})
+        datasets.append({"year": int(match.group(1)), "kind": "incident_totals", "values": values})
+
+    sprinkler_html = fragments.get("Sprinkler Saves Stats")
+    if sprinkler_html is not None:
+        parser = _FragmentParser()
+        parser.feed(sprinkler_html)
+        year_match = re.search(r"\b(20\d{2}) Sprinkler Saves Statistics\b", _clean(" ".join(parser.text)))
+        if year_match is None or len(parser.tables) != 1 or len(parser.tables[0]) < 2:
+            raise PublishedStatisticsError("fire sprinkler statistics contract changed")
+        rows = parser.tables[0]
+        if rows[0] != ["Type", "Description", "Statistic", "Percentage"]:
+            raise PublishedStatisticsError("fire sprinkler statistics table headers changed")
+        values = []
+        for row in rows[1:]:
+            if len(row) != 4 or not row[1] or not row[2]:
+                raise PublishedStatisticsError("fire sprinkler statistics table contains a malformed row")
+            values.append({"type": row[0] or None, "label": row[1], "published_value": row[2], "published_percentage": row[3]})
+        datasets.append({"year": int(year_match.group(1)), "kind": "sprinkler_saves", "values": values})
+
+    if not reports or not datasets:
+        raise PublishedStatisticsError("fire statistics source returned no publications or structured totals")
+    return datasets, reports
+
+
+def _published(agency: str) -> dict[str, Any]:
+    page, metadata = _fetch_page(agency)
+    fragments = page["fragments"]
+    if agency == "police":
+        datasets, reports = _parse_police(fragments, metadata["url"])
+    else:
+        datasets, reports = _parse_fire(fragments, metadata["url"])
+    return {"datasets": datasets, "reports": reports, "source": metadata}
+
+
+def _assert_available(items: list[dict[str, Any]]) -> None:
+    unique = {(item["document_url"], item["agency"]) for item in items}
+    for url, agency in unique:
+        try:
+            final_url = core.probe_url(url)
+            _document_url(final_url, url, agency)
+        except (core.SecurityError, urllib.error.HTTPError, urllib.error.URLError) as exc:
+            raise PublishedStatisticsError(f"published document is unavailable: {url}: {exc}") from exc
+
+
+def statistics(agency: str, year: int | None = None) -> dict[str, Any]:
+    published = _published(agency)
+    years = sorted({item["year"] for item in published["datasets"] + published["reports"]}, reverse=True)
+    if year is not None and year not in years:
+        raise PublishedStatisticsError(f"no published {agency} statistics found for {year}")
+    datasets = [item for item in published["datasets"] if year is None or item["year"] == year]
+    reports = [item for item in published["reports"] if year is None or item["year"] == year]
+    _assert_available(reports)
+    warnings = []
+    if year is not None and not datasets:
+        warnings.append("Published totals are document-only for this year; PDF contents were not parsed.")
+    if agency == "fire":
+        warnings.append(
+            "Published medical totals are aggregate-only and must not be joined to or used to infer excluded incident records."
+        )
+    return {
+        "agency": agency,
+        "classification": "official_published_statistics",
+        "year": year,
+        "available_years": years,
+        "datasets": datasets,
+        "reports": reports,
+        "source": published["source"],
+        "warnings": warnings,
+    }
+
+
+def reports(agency: str, year: int | None = None, quarter: int | None = None) -> dict[str, Any]:
+    if quarter is not None and year is None:
+        raise PublishedStatisticsError("--quarter requires --year")
+    published = _published(agency)
+    available_years = sorted({item["year"] for item in published["reports"]}, reverse=True)
+    if year is not None and year not in available_years:
+        raise PublishedStatisticsError(f"no published {agency} reports found for {year}")
+    selected = [
+        item for item in published["reports"]
+        if (year is None or item["year"] == year) and (quarter is None or item["quarter"] == quarter)
+    ]
+    if not selected:
+        period = f" Q{quarter}" if quarter is not None else ""
+        raise PublishedStatisticsError(f"no published {agency} report found for {year}{period}")
+    _assert_available(selected)
+    return {
+        "agency": agency,
+        "classification": "official_published_reports",
+        "year": year,
+        "quarter": quarter,
+        "available_years": available_years,
+        "reports": selected,
+        "source": published["source"],
+        "warnings": ["Document links are preserved from the official index; PDF contents were not parsed."],
+    }

--- a/raleigh/scripts/raleighlib/public_safety_stats.py
+++ b/raleigh/scripts/raleighlib/public_safety_stats.py
@@ -176,14 +176,24 @@ def _fetch_page(agency: str) -> tuple[dict[str, Any], dict[str, str]]:
             not isinstance(item, dict)
             or not isinstance(item.get("type"), str)
             or not isinstance(item.get("id"), str)
+            or not item["type"]
+            or not item["id"]
         ):
             raise PublishedStatisticsError("published statistics relationship identifiers are invalid")
         referenced.add((item["type"], item["id"]))
     fragments: dict[str, str] = {}
     for item in included:
-        if not isinstance(item, dict) or item.get("type") != "paragraph--stories_text":
+        if (
+            not isinstance(item, dict)
+            or not isinstance(item.get("type"), str)
+            or not isinstance(item.get("id"), str)
+            or not item["type"]
+            or not item["id"]
+        ):
+            raise PublishedStatisticsError("published statistics included resource identifiers are invalid")
+        if item["type"] != "paragraph--stories_text":
             continue
-        if (item.get("type"), item.get("id")) not in referenced:
+        if (item["type"], item["id"]) not in referenced:
             raise PublishedStatisticsError("published statistics included an unreferenced content section")
         item_attrs = item.get("attributes")
         if not isinstance(item_attrs, dict) or item_attrs.get("status") is not True:

--- a/raleigh/scripts/raleighlib/public_safety_stats.py
+++ b/raleigh/scripts/raleighlib/public_safety_stats.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import http.client
 import urllib.error
 import urllib.parse
 from datetime import datetime, timezone
@@ -340,7 +341,13 @@ def _assert_available(items: list[dict[str, Any]]) -> None:
         try:
             final_url = core.probe_url(url)
             _document_url(final_url, url, agency)
-        except (core.SecurityError, urllib.error.HTTPError, urllib.error.URLError) as exc:
+        except (
+            core.SecurityError,
+            urllib.error.HTTPError,
+            urllib.error.URLError,
+            OSError,
+            http.client.HTTPException,
+        ) as exc:
             raise PublishedStatisticsError(f"published document is unavailable: {url}: {exc}") from exc
 
 

--- a/raleigh/scripts/raleighlib/public_safety_stats.py
+++ b/raleigh/scripts/raleighlib/public_safety_stats.py
@@ -260,6 +260,13 @@ def _parse_fire(fragments: dict[str, str], page_url: str) -> tuple[list[dict[str
             "quarter": int(period.group(1)), "label": link["text"], "document_url": url,
         })
 
+    statistic_headings = [
+        heading for heading in fragments
+        if re.fullmatch(r"20\d{2} Statistics", heading)
+    ]
+    if not statistic_headings:
+        raise PublishedStatisticsError("fire incident statistics section is missing")
+
     datasets: list[dict[str, Any]] = []
     for heading, html in fragments.items():
         match = re.fullmatch(r"(20\d{2}) Statistics", heading)
@@ -280,21 +287,22 @@ def _parse_fire(fragments: dict[str, str], page_url: str) -> tuple[list[dict[str
         datasets.append({"year": int(match.group(1)), "kind": "incident_totals", "values": values})
 
     sprinkler_html = fragments.get("Sprinkler Saves Stats")
-    if sprinkler_html is not None:
-        parser = _FragmentParser()
-        parser.feed(sprinkler_html)
-        year_match = re.search(r"\b(20\d{2}) Sprinkler Saves Statistics\b", _clean(" ".join(parser.text)))
-        if year_match is None or len(parser.tables) != 1 or len(parser.tables[0]) < 2:
-            raise PublishedStatisticsError("fire sprinkler statistics contract changed")
-        rows = parser.tables[0]
-        if rows[0] != ["Type", "Description", "Statistic", "Percentage"]:
-            raise PublishedStatisticsError("fire sprinkler statistics table headers changed")
-        values = []
-        for row in rows[1:]:
-            if len(row) != 4 or not row[1] or not row[2]:
-                raise PublishedStatisticsError("fire sprinkler statistics table contains a malformed row")
-            values.append({"type": row[0] or None, "label": row[1], "published_value": row[2], "published_percentage": row[3]})
-        datasets.append({"year": int(year_match.group(1)), "kind": "sprinkler_saves", "values": values})
+    if sprinkler_html is None:
+        raise PublishedStatisticsError("fire sprinkler statistics section is missing")
+    parser = _FragmentParser()
+    parser.feed(sprinkler_html)
+    year_match = re.search(r"\b(20\d{2}) Sprinkler Saves Statistics\b", _clean(" ".join(parser.text)))
+    if year_match is None or len(parser.tables) != 1 or len(parser.tables[0]) < 2:
+        raise PublishedStatisticsError("fire sprinkler statistics contract changed")
+    rows = parser.tables[0]
+    if rows[0] != ["Type", "Description", "Statistic", "Percentage"]:
+        raise PublishedStatisticsError("fire sprinkler statistics table headers changed")
+    values = []
+    for row in rows[1:]:
+        if len(row) != 4 or not row[1] or not row[2]:
+            raise PublishedStatisticsError("fire sprinkler statistics table contains a malformed row")
+        values.append({"type": row[0] or None, "label": row[1], "published_value": row[2], "published_percentage": row[3]})
+    datasets.append({"year": int(year_match.group(1)), "kind": "sprinkler_saves", "values": values})
 
     if not reports or not datasets:
         raise PublishedStatisticsError("fire statistics source returned no publications or structured totals")

--- a/raleigh/tests/fixtures/published-fire-statistics.json
+++ b/raleigh/tests/fixtures/published-fire-statistics.json
@@ -1,0 +1,56 @@
+{
+  "data": {
+    "type": "node--service",
+    "id": "f95a0f43-3dbf-4378-b7c7-b1bdda20eb24",
+    "attributes": {
+      "status": true,
+      "title": "View Raleigh Fire Statistics",
+      "changed": "2026-04-23T13:21:39+00:00",
+      "path": {"alias": "/fire/services/view-raleigh-fire-statistics"}
+    },
+    "relationships": {"field_content_primary": {"data": [
+      {"type": "paragraph--stories_text", "id": "current"},
+      {"type": "paragraph--stories_text", "id": "history"},
+      {"type": "paragraph--stories_text", "id": "quarter"},
+      {"type": "paragraph--stories_text", "id": "sprinkler"}
+    ]}}
+  },
+  "included": [
+    {
+      "type": "paragraph--stories_text",
+      "id": "current",
+      "attributes": {
+        "status": true,
+        "field_heading": "2026 Statistics",
+        "field_stories_text_formatted": {"value": "<table><tr><td><strong>Incident Type</strong></td><td><strong>Totals</strong></td></tr><tr><td><strong>Fire</strong></td><td>401</td></tr><tr><td><strong>Medical</strong></td><td>7,882</td></tr></table>"}
+      }
+    },
+    {
+      "type": "paragraph--stories_text",
+      "id": "history",
+      "attributes": {
+        "status": true,
+        "field_heading": "Previous Years Statistics",
+        "field_stories_text_formatted": {"value": "<p><a href=\"https://cityofraleigh0drupal.blob.core.usgovcloudapi.net/drupal-prod/COR18/2026.pdf\">2026</a> | <a href=\"https://cityofraleigh0drupal.blob.core.usgovcloudapi.net/drupal-prod/COR18/2025.pdf\">2025</a></p>"}
+      }
+    },
+    {
+      "type": "paragraph--stories_text",
+      "id": "quarter",
+      "attributes": {
+        "status": true,
+        "field_heading": "Quarterly Report",
+        "field_stories_text_formatted": {"value": "<p>View <a href=\"/fire/news/keeping-score-q1-2025-fire-statistics\">fire statistics from the previous quarter</a>.</p>"}
+      }
+    },
+    {
+      "type": "paragraph--stories_text",
+      "id": "sprinkler",
+      "attributes": {
+        "status": true,
+        "field_heading": "Sprinkler Saves Stats",
+        "field_stories_text_formatted": {"value": "<p><strong>2024 Sprinkler Saves Statistics</strong></p><table><tr><th>Type</th><th>Description</th><th>Statistic</th><th>Percentage</th></tr><tr><td>Fire Sprinkler Protected Properties</td><td>Total Property Value</td><td>$365,426,749</td><td>n/a</td></tr><tr><td></td><td>Total Number of Sprinkler Saves 2024 (YTD)</td><td>20</td><td>n/a</td></tr></table>"}
+      }
+    }
+  ]
+}

--- a/raleigh/tests/fixtures/published-police-statistics.json
+++ b/raleigh/tests/fixtures/published-police-statistics.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "type": "node--service",
+    "id": "40ebbee4-2477-4f7d-9623-257685345e3d",
+    "attributes": {
+      "status": true,
+      "title": "Raleigh's Crime Data",
+      "changed": "2026-07-10T13:59:08+00:00",
+      "path": {"alias": "/police/services/raleighs-crime-data"}
+    },
+    "relationships": {"field_content_primary": {"data": [{"type": "paragraph--stories_text", "id": "summary"}]}}
+  },
+  "included": [
+    {
+      "type": "paragraph--stories_text",
+      "id": "summary",
+      "attributes": {
+        "status": true,
+        "field_heading": "Summary of Crime Statistics by Year",
+        "field_stories_text_formatted": {
+          "value": "<h5><span>2026</span></h5><ul><li><a href=\"https://cityofraleigh0drupal.blob.core.usgovcloudapi.net/drupal-prod/COR23/rpd-crime-data-26q1.pdf\">Q1 stats</a> (PDF)</li></ul><h5>2025</h5><ul><li><a href=\"https://cityofraleigh0drupal.blob.core.usgovcloudapi.net/drupal-prod/COR23/annual-crime-data-2025.pdf\">Annual Crime Data</a> (PDF)</li><li><a href=\"https://cityofraleigh0drupal.blob.core.usgovcloudapi.net/drupal-prod/COR23/raleigh-crime-data-q4-2025.pdf\"><span>Q4 stats</span></a> (PDF)</li></ul>"
+        }
+      }
+    }
+  ]
+}

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -3153,6 +3153,17 @@ class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
         self.assertIn("published document is unavailable", err.getvalue())
         self.assertNotIn("Traceback", err.getvalue())
 
+    def test_jsonapi_transport_timeout_is_a_concise_cli_error(self):
+        with patch("raleighlib.public_safety_stats.core.json_request", side_effect=TimeoutError("timed out")):
+            out, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                code = cli.main(["--json", "fire", "stats", "--year", "2026"])
+        self.assertEqual(code, 1)
+        self.assertEqual(out.getvalue(), "")
+        self.assertIn("published statistics source is unavailable", err.getvalue())
+        self.assertNotIn("Traceback", err.getvalue())
+        self.probe.assert_not_called()
+
     def test_document_redirect_outside_publication_contract_fails(self):
         self.probe.side_effect = None
         self.probe.return_value = "https://data.raleighnc.gov/admin"

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -45,6 +45,7 @@ import raleighlib.police as police
 import raleighlib.fire as fire
 import raleighlib.fire_protection as fire_protection
 import raleighlib.rfd_reports as rfd_reports
+import raleighlib.public_safety_stats as public_safety_stats
 from raleighlib import cli as cli_lib
 
 CLI_SCRIPT = _SCRIPT_DIR / "raleigh"
@@ -85,6 +86,26 @@ class CoreTests(unittest.TestCase):
     def test_raw_request_rejects_unlisted_hosts(self):
         with self.assertRaises(core.SecurityError):
             core.raw_request("https://evil.example.com/data.bin")
+
+    def test_probe_url_uses_head_without_reading_document(self):
+        url = "https://cityofraleigh0drupal.blob.core.usgovcloudapi.net/drupal-prod/COR23/report.pdf"
+        response = MagicMock()
+        response.geturl.return_value = url
+        response.__enter__.return_value = response
+        with patch.object(core._OPENER, "open", return_value=response) as opened:
+            self.assertEqual(core.probe_url(url), url)
+        request = opened.call_args.args[0]
+        self.assertEqual(request.get_method(), "HEAD")
+        response.read.assert_not_called()
+
+    def test_head_redirect_preserves_head_method(self):
+        source = "https://raleighnc.gov/fire/news/report"
+        destination = "https://raleighnc.gov/fire/news/revised-report"
+        request = urllib.request.Request(source, method="HEAD")
+        redirected = core.AllowlistRedirectHandler().redirect_request(
+            request, None, 302, "redirect", {}, destination
+        )
+        self.assertEqual(redirected.get_method(), "HEAD")
 
     def test_cache_read_write_roundtrip(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -2988,6 +3009,173 @@ class FireTests(unittest.TestCase):
             with redirect_stdout(out), redirect_stderr(io.StringIO()):
                 code = cli.main(["--json", "fire", "response-times", "--since", "1y"])
         self.assertEqual(code, 0)
+
+
+class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
+    """Official aggregate totals and publication indexes from RaleighNC.gov."""
+
+    FIXTURES = pathlib.Path(__file__).parent / "fixtures"
+
+    def setUp(self):
+        self.probe_patcher = patch("raleighlib.public_safety_stats.core.probe_url")
+        self.probe = self.probe_patcher.start()
+        self.probe.side_effect = lambda url: url
+        self.addCleanup(self.probe_patcher.stop)
+
+    def _fixture(self, agency: str):
+        return json.loads((self.FIXTURES / f"published-{agency}-statistics.json").read_text())
+
+    def test_police_reports_preserve_runtime_year_label_and_document_url(self):
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("police")):
+            result = public_safety_stats.reports("police", 2025, 4)
+        self.assertEqual(result["classification"], "official_published_reports")
+        self.assertEqual(result["reports"][0]["label"], "Q4 stats")
+        self.assertEqual(result["reports"][0]["quarter"], 4)
+        self.assertTrue(result["reports"][0]["document_url"].endswith("q4-2025.pdf"))
+
+    def test_police_document_only_year_is_explicit(self):
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("police")):
+            result = public_safety_stats.statistics("police", 2025)
+        self.assertEqual(result["datasets"], [])
+        self.assertEqual(result["reports"][0]["period"], "annual")
+        self.assertIn("document-only", result["warnings"][0])
+
+    def test_fire_totals_preserve_labels_values_year_and_source(self):
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("fire")):
+            result = public_safety_stats.statistics("fire", 2026)
+        totals = result["datasets"][0]
+        medical = next(item for item in totals["values"] if item["label"] == "Medical")
+        self.assertEqual(totals["year"], 2026)
+        self.assertEqual(medical["value"], 7882)
+        self.assertEqual(medical["published_value"], "7,882")
+        self.assertEqual(result["source"]["url"], public_safety_stats.SOURCES["fire"]["page_url"])
+        self.assertIn("retrieved_at", result["source"])
+
+    def test_fire_medical_totals_remain_aggregate_only(self):
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("fire")):
+            result = public_safety_stats.statistics("fire", 2026)
+        self.assertIn("must not be joined", result["warnings"][0])
+        self.assertNotIn("incident_number", json.dumps(result))
+
+    def test_fire_sprinkler_statistics_are_a_distinct_dataset(self):
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("fire")):
+            result = public_safety_stats.statistics("fire", 2024)
+        self.assertEqual(result["datasets"][0]["kind"], "sprinkler_saves")
+        saves = next(item for item in result["datasets"][0]["values"] if "Number" in item["label"])
+        self.assertEqual(saves["published_value"], "20")
+
+    def test_missing_year_and_quarter_fail_visibly(self):
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("police")):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "no published"):
+                public_safety_stats.statistics("police", 2024)
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "no published"):
+                public_safety_stats.reports("police", 2026, 4)
+
+    def test_report_link_outside_canonical_origins_fails_closed(self):
+        fixture = self._fixture("police")
+        html = fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"]
+        fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"] = html.replace(
+            "https://cityofraleigh0drupal.blob.core.usgovcloudapi.net", "https://example.com"
+        )
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "document origins"):
+                public_safety_stats.reports("police")
+
+    def test_report_link_parameters_fail_closed(self):
+        fixture = self._fixture("police")
+        html = fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"]
+        fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"] = html.replace(
+            "q4-2025.pdf", "q4-2025.pdf;download"
+        )
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "HTTPS contract"):
+                public_safety_stats.reports("police")
+
+    def test_fire_report_dot_segments_fail_closed(self):
+        fixture = self._fixture("fire")
+        html = fixture["included"][2]["attributes"]["field_stories_text_formatted"]["value"]
+        fixture["included"][2]["attributes"]["field_stories_text_formatted"]["value"] = html.replace(
+            "/fire/news/keeping-score-q1-2025-fire-statistics",
+            "https://raleighnc.gov/fire/news/%2e%2e/%2e%2e/admin-q1-2025",
+        )
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "traversal"):
+                public_safety_stats.reports("fire")
+
+    def test_unavailable_document_fails_visibly(self):
+        self.probe.side_effect = urllib.error.HTTPError(
+            "https://example.invalid/report.pdf", 404, "Not Found", {}, None
+        )
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("police")):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "unavailable"):
+                public_safety_stats.reports("police", 2025, 4)
+
+    def test_document_redirect_outside_publication_contract_fails(self):
+        self.probe.side_effect = None
+        self.probe.return_value = "https://data.raleighnc.gov/admin"
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("police")):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "document origins"):
+                public_safety_stats.reports("police", 2025, 4)
+
+    def test_terminal_controls_are_removed_from_published_text(self):
+        fixture = self._fixture("police")
+        html = fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"]
+        fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"] = html.replace(
+            "Q4 stats", "Q4 \x1b]52;c;Y2xpcGJvYXJk\x07 stats"
+        )
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+            result = public_safety_stats.reports("police", 2025, 4)
+        self.assertNotIn("\x1b", result["reports"][0]["label"])
+        self.assertNotIn("\x07", result["reports"][0]["label"])
+
+    def test_fire_table_markup_drift_fails_visibly(self):
+        fixture = self._fixture("fire")
+        html = fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"]
+        fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"] = html.replace(
+            "Incident Type", "Changed Header"
+        )
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "headers changed"):
+                public_safety_stats.statistics("fire", 2026)
+
+    def test_header_only_fire_table_fails_visibly(self):
+        fixture = self._fixture("fire")
+        fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"] = (
+            "<table><tr><td>Incident Type</td><td>Totals</td></tr></table>"
+        )
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "table is missing"):
+                public_safety_stats.statistics("fire", 2026)
+
+    def test_cli_police_reports_and_fire_stats_json(self):
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("police")):
+            out = io.StringIO()
+            with redirect_stdout(out):
+                code = cli.main(["--json", "police", "reports", "--year", "2025", "--quarter", "4"])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out.getvalue())["reports"][0]["quarter"], 4)
+
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("fire")):
+            out = io.StringIO()
+            with redirect_stdout(out):
+                code = cli.main(["--json", "fire", "stats", "--year", "2026"])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out.getvalue())["datasets"][0]["kind"], "incident_totals")
+
+    def test_fire_reports_year_uses_publication_index_without_incident_query(self):
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("fire")), patch(
+            "raleighlib.cli.fire.query_reports"
+        ) as incidents:
+            out = io.StringIO()
+            with redirect_stdout(out):
+                code = cli.main(["--json", "fire", "reports", "--year", "2025", "--quarter", "1"])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out.getvalue())["classification"], "official_published_reports")
+        incidents.assert_not_called()
+
+    def test_fire_reports_rejects_mixed_incident_and_publication_modes(self):
+        with self.assertRaisesRegex(SystemExit, "cannot be combined"):
+            cli.main(["fire", "reports", "--date", "2026-07-24", "--year", "2026"])
 
 
 class FireReportTests(unittest.TestCase):

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -3071,6 +3071,21 @@ class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
             with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "no published"):
                 public_safety_stats.reports("police", 2026, 4)
 
+    def test_malformed_jsonapi_nested_objects_fail_visibly(self):
+        for field, value, message in (
+            ("path", None, "page identity changed"),
+            ("relationships", None, "relationships are invalid"),
+        ):
+            with self.subTest(field=field):
+                fixture = self._fixture("police")
+                if field == "path":
+                    fixture["data"]["attributes"][field] = value
+                else:
+                    fixture["data"][field] = value
+                with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+                    with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, message):
+                        public_safety_stats.reports("police")
+
     def test_report_link_outside_canonical_origins_fails_closed(self):
         fixture = self._fixture("police")
         html = fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"]

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -3094,6 +3094,15 @@ class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
             with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "identifiers are invalid"):
                 public_safety_stats.reports("police")
 
+    def test_malformed_jsonapi_included_resource_fails_visibly(self):
+        for value in ([], {"type": "paragraph--stories_text", "id": []}):
+            with self.subTest(value=value):
+                fixture = self._fixture("police")
+                fixture["included"][0] = value
+                with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+                    with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "included resource identifiers are invalid"):
+                        public_safety_stats.reports("police")
+
     def test_report_link_outside_canonical_origins_fails_closed(self):
         fixture = self._fixture("police")
         html = fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"]

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -3162,6 +3162,18 @@ class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
             with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "table is missing"):
                 public_safety_stats.statistics("fire", 2026)
 
+    def test_missing_fire_statistics_sections_fail_visibly(self):
+        for index, heading, message in (
+            (0, "Renamed Current Totals", "incident statistics section is missing"),
+            (3, "Renamed Sprinkler Totals", "sprinkler statistics section is missing"),
+        ):
+            with self.subTest(heading=heading):
+                fixture = self._fixture("fire")
+                fixture["included"][index]["attributes"]["field_heading"] = heading
+                with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+                    with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, message):
+                        public_safety_stats.statistics("fire")
+
     def test_cli_police_reports_and_fire_stats_json(self):
         with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("police")):
             out = io.StringIO()

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -3142,6 +3142,17 @@ class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
             with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "unavailable"):
                 public_safety_stats.reports("police", 2025, 4)
 
+    def test_document_transport_timeout_is_a_concise_cli_error(self):
+        self.probe.side_effect = TimeoutError("timed out")
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=self._fixture("police")):
+            out, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                code = cli.main(["--json", "police", "reports", "--year", "2025", "--quarter", "4"])
+        self.assertEqual(code, 1)
+        self.assertEqual(out.getvalue(), "")
+        self.assertIn("published document is unavailable", err.getvalue())
+        self.assertNotIn("Traceback", err.getvalue())
+
     def test_document_redirect_outside_publication_contract_fails(self):
         self.probe.side_effect = None
         self.probe.return_value = "https://data.raleighnc.gov/admin"

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -3103,6 +3103,42 @@ class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
                     with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "included resource identifiers are invalid"):
                         public_safety_stats.reports("police")
 
+    def test_duplicate_jsonapi_resource_identifiers_fail_visibly(self):
+        for field, message in (
+            ("relationship", "relationship identifiers are duplicated"),
+            ("included", "included resource identifiers are duplicated"),
+        ):
+            with self.subTest(field=field):
+                fixture = self._fixture("police")
+                if field == "relationship":
+                    data = fixture["data"]["relationships"]["field_content_primary"]["data"]
+                else:
+                    data = fixture["included"]
+                data.append(data[0])
+                with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+                    with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, message):
+                        public_safety_stats.reports("police")
+
+    def test_jsonapi_redirect_outside_exact_endpoint_fails(self):
+        fixture = self._fixture("police")
+
+        def redirected(url, **kwargs):
+            kwargs["final_url_validator"]("https://data.raleighnc.gov/other")
+            return fixture
+
+        with patch("raleighlib.public_safety_stats.core.json_request", side_effect=redirected):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "exact JSON:API endpoint"):
+                public_safety_stats.reports("police")
+
+    def test_police_report_index_has_a_fanout_limit(self):
+        fixture = self._fixture("police")
+        formatted = fixture["included"][0]["attributes"]["field_stories_text_formatted"]
+        link = '<a href="https://cityofraleigh0drupal.blob.core.usgovcloudapi.net/drupal-prod/COR23/report.pdf">Q1 stats</a>'
+        formatted["value"] = "<h5>2026</h5>" + link * (public_safety_stats.MAX_PUBLISHED_REPORTS + 1)
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "report limit"):
+                public_safety_stats.reports("police")
+
     def test_report_link_outside_canonical_origins_fails_closed(self):
         fixture = self._fixture("police")
         html = fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"]
@@ -3190,6 +3226,14 @@ class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
         )
         with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
             with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "headers changed"):
+                public_safety_stats.statistics("fire", 2026)
+
+    def test_malformed_published_thousands_separator_fails_visibly(self):
+        fixture = self._fixture("fire")
+        formatted = fixture["included"][0]["attributes"]["field_stories_text_formatted"]
+        formatted["value"] = formatted["value"].replace("7,882", "7,8,82")
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "malformed row"):
                 public_safety_stats.statistics("fire", 2026)
 
     def test_header_only_fire_table_fails_visibly(self):

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -107,6 +107,18 @@ class CoreTests(unittest.TestCase):
         )
         self.assertEqual(redirected.get_method(), "HEAD")
 
+    def test_redirect_runs_request_specific_validator_before_following(self):
+        source = "https://raleighnc.gov/jsonapi/node/service/example"
+        destination = "https://data.raleighnc.gov/other"
+        request = urllib.request.Request(source, method="GET")
+        validator = MagicMock(side_effect=core.SecurityError("wrong endpoint"))
+        setattr(request, "_raleigh_final_url_validator", validator)
+        with self.assertRaisesRegex(core.SecurityError, "wrong endpoint"):
+            core.AllowlistRedirectHandler().redirect_request(
+                request, None, 302, "redirect", {}, destination
+            )
+        validator.assert_called_once_with(destination)
+
     def test_cache_read_write_roundtrip(self):
         with tempfile.TemporaryDirectory() as tmp:
             os.environ["RALEIGH_CACHE"] = tmp
@@ -3019,7 +3031,9 @@ class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
     def setUp(self):
         self.probe_patcher = patch("raleighlib.public_safety_stats.core.probe_url")
         self.probe = self.probe_patcher.start()
-        self.probe.side_effect = lambda url: url
+        self.probe.side_effect = lambda url, **kwargs: (
+            kwargs.get("final_url_validator", lambda value: None)(url) or url
+        )
         self.addCleanup(self.probe_patcher.stop)
 
     def _fixture(self, agency: str):
@@ -3082,6 +3096,15 @@ class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
                     fixture["data"]["attributes"][field] = value
                 else:
                     fixture["data"][field] = value
+                with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+                    with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, message):
+                        public_safety_stats.reports("police")
+
+    def test_invalid_jsonapi_revision_timestamp_fails_visibly(self):
+        for value, message in ((None, "timestamp is missing"), ("not-a-date", "timestamp is invalid")):
+            with self.subTest(value=value):
+                fixture = self._fixture("police")
+                fixture["data"]["attributes"]["changed"] = value
                 with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
                     with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, message):
                         public_safety_stats.reports("police")
@@ -3227,6 +3250,27 @@ class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
         with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
             with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "headers changed"):
                 public_safety_stats.statistics("fire", 2026)
+
+    def test_one_cell_fire_statistics_row_fails_visibly(self):
+        fixture = self._fixture("fire")
+        formatted = fixture["included"][0]["attributes"]["field_stories_text_formatted"]
+        formatted["value"] = formatted["value"].replace(
+            "<tr><td><strong>Fire</strong></td><td>401</td></tr>",
+            "<tr><td><strong>Fire</strong></td></tr>",
+        )
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "malformed row"):
+                public_safety_stats.statistics("fire", 2026)
+
+    def test_empty_fire_quarterly_label_fails_visibly(self):
+        fixture = self._fixture("fire")
+        formatted = fixture["included"][2]["attributes"]["field_stories_text_formatted"]
+        formatted["value"] = formatted["value"].replace(
+            ">fire statistics from the previous quarter</a>", "></a>"
+        )
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "publication label is missing"):
+                public_safety_stats.reports("fire")
 
     def test_malformed_published_thousands_separator_fails_visibly(self):
         fixture = self._fixture("fire")

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -3086,6 +3086,14 @@ class PublishedPublicSafetyStatisticsTests(unittest.TestCase):
                     with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, message):
                         public_safety_stats.reports("police")
 
+    def test_malformed_jsonapi_relationship_identifier_fails_visibly(self):
+        fixture = self._fixture("police")
+        relationship = fixture["data"]["relationships"]["field_content_primary"]["data"][0]
+        relationship["id"] = []
+        with patch("raleighlib.public_safety_stats.core.json_request", return_value=fixture):
+            with self.assertRaisesRegex(public_safety_stats.PublishedStatisticsError, "identifiers are invalid"):
+                public_safety_stats.reports("police")
+
     def test_report_link_outside_canonical_origins_fails_closed(self):
         fixture = self._fixture("police")
         html = fixture["included"][0]["attributes"]["field_stories_text_formatted"]["value"]


### PR DESCRIPTION
## Summary

Expose official Raleigh Police and Fire aggregate statistics without reconstructing official totals from privacy-filtered incident rows.

- Add `police stats`, `police reports`, and `fire stats` commands.
- Extend `fire reports` with aggregate year/quarter mode while preserving exact incident-report lookups.
- Parse structured RaleighNC.gov JSON:API content, preserve canonical document links, and verify document availability without parsing PDFs.
- Keep RFD medical totals aggregate-only and distinct from excluded incident-level records.
- Fail visibly on source drift, malformed content, unsafe redirects, unavailable reports, or excessive publication fanout.

Closes #126

## Validation

- [x] `ruby scripts/validate-skills.rb`
- [x] Skill-specific checks, if applicable: <!-- command and result -->

`PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py` (368 passed); Ruff passed; eval validation passed; skill quality passed; eval coverage ratchet passed; live police/fire aggregate and legacy incident-report commands passed.

## Documentation

- [x] I updated the relevant `SKILL.md`, `README.md`, or reference files.
- [x] Links are relative and resolve from a fresh clone.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] I have disclosed meaningful AI assistance in the description or commit message.

Implementation, tests, documentation, live verification, and review remediation were completed with OpenCode, an AI coding agent, on behalf of Magnus Hedemark.

## Review notes

- [x] Final-head review evidence is tied to commit SHA `<sha>`, and all actionable findings are resolved.

Reviewed head: `1bd7b061121ca647c32eb447621209907a5c5029`; no actionable findings remained.

Compatibility: existing `fire reports --date` and `--incident-number` behavior remains intact. PDF contents are intentionally not parsed; links are canonicalized and availability-probed with bounded `HEAD` requests.
