### PR TITLE
fix: require evidence for Grafana dashboard defaults

### DIFF
--- a/grafana/SKILL.md
+++ b/grafana/SKILL.md
@@ -76,7 +76,7 @@ Compare the running object with every potential writer. Do not edit a provisione
 
 ### 3. Validate semantics before presentation
 
-Run representative queries over a known time range. Confirm metric/log/trace type, units, labels, aggregation, cardinality, null/no-data behavior, time zone, refresh interval, and query cost. For repeated panels or multi-dimensional alerts, bound the dimension set and prove it remains actionable.
+Run representative queries over a known time range. Confirm metric/log/trace type, units, labels, aggregation, cardinality, null/no-data behavior, time zone, refresh interval, and query cost. Derive defaults, thresholds, refresh cadence, top-N limits, and minimum-traffic cutoffs from target evidence, approved policy, or an explicit measurement objective; otherwise leave them open rather than choosing plausible values. For repeated panels or multi-dimensional alerts, bound the dimension set and prove it remains actionable.
 
 ### 4. Preview and apply through the owner
 


### PR DESCRIPTION
## Summary

- Require Grafana dashboard defaults, thresholds, refresh cadence, ranking limits, and traffic cutoffs to come from target evidence, approved policy, or an explicit measurement objective.
- Leave unsupported values open rather than presenting plausible-looking operational defaults.
- No production Grafana change was made. The production deployment on saru was inspected read-only only.

## Validation

- [x] `ruby scripts/validate-skills.rb`
- [x] `python3 scripts/validate-evals.py grafana/evals/evals.json`
- [x] 3 SkillOpt epochs: Epoch 1 retained a 5/5 training and 5/5 held-out baseline; Epoch 2 accepted one paired-validation edit; Epoch 3 passed 3/3 rollout and 2/2 installed-artifact held-out regressions.

## Documentation

- [x] Updated `grafana/SKILL.md`.
- [x] Links remain relative and resolve from a fresh clone.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] AI assistance: Jasper ran the bounded SkillOpt rollout and validation cycle; Magnus requested three autonomous epochs.

## Review notes

- [x] Final-head self-review passed for commit `a3d83c5991c4b85f62ddd773193855d831291e32`; no actionable findings. CI is pending.
- The change promotes an existing evidence-governed principle into the core workflow. It does not prescribe specific operational values.
