### PR TITLE
Require dated commitments for chief-of-staff tasks

### DIFF
--- a/chief-of-staff-methodology/README.md
+++ b/chief-of-staff-methodology/README.md
@@ -19,7 +19,7 @@ speculative profiles of employees.
 
 | Path | What it provides |
 |---|---|
-| `SKILL.md` | A host-neutral operating method, authority limits, and trigger guidance. |
+| `SKILL.md` | A host-neutral operating method, authority limits, task-creation discipline, and trigger guidance. |
 | `references/gatekeeping-and-triage.md` | Decision-rights routing and accessible escalation paths. |
 | `references/executive-briefing.md` | Reviewable decision briefs and update structures. |
 | `references/force-multiplication.md` | Observable leverage mechanisms for leader support. |

--- a/chief-of-staff-methodology/SKILL.md
+++ b/chief-of-staff-methodology/SKILL.md
@@ -60,6 +60,34 @@ means; no specific profile, memory, calendar, or orchestration system is assumed
 4. Prepare options and trade-offs, then give a clearly labeled recommendation when the request calls for one. The accountable human reviews and decides.
 5. Record only decision-relevant material under the access, retention, correction, and handoff rules in the applicable reference.
 
+## Task Creation Discipline
+
+**Applicability:** Only when creating or updating tasks in an authorized task system.
+
+A task is a record of a concrete, documented commitment, not a place to store
+advice, aspirations, meeting summaries, inferred next steps, or recurring
+leadership habits. Create a task only when the source establishes all of the
+following:
+
+1. A discrete outcome or next action that can be completed or explicitly reviewed.
+2. An accountable owner who has made, confirmed, or accepted the commitment.
+3. A realistic due date grounded in an explicit deadline, an agreed review date,
+   or context that supports a specific date. Never invent a date merely to fill
+   a required field.
+4. Enough provenance in the task or linked record for the owner to understand
+   the commitment and correct it.
+
+Before creating the task, check all four conditions. If the source offers a
+recommendation, a general principle, or an inferred action without an owner or
+defensible due date, preserve it as a briefing observation or ask the accountable
+human to confirm the commitment and date. Do not create the task.
+
+When a task is created, include the owner and due date in the creation request,
+then read it back and verify both fields persisted. If either is absent or wrong,
+repair it before reporting success. A past deadline is a triage signal: surface
+it as overdue for an explicit reschedule, completion, or closure decision rather
+than silently assigning a new date.
+
 ## Accountable Human Authority
 
 This skill supports an accountable human leader. It may prepare, advise, triage,

--- a/chief-of-staff-methodology/SKILL.md
+++ b/chief-of-staff-methodology/SKILL.md
@@ -34,6 +34,14 @@ Load this skill for executive-office work involving:
 - Institutional memory, leadership transitions, documented decisions, or commitments.
 - Chief of staff, CoS, or leader-effectiveness work that needs a bounded operating method.
 
+## When Not to Use
+
+Do not use this skill as a meeting-transcript action-item generator or a general
+backlog-capture mechanism. A recommendation, a discussion topic, or an inferred
+next step belongs in a briefing or decision record unless an accountable owner
+has confirmed a discrete commitment and a realistic due date. Use the authorized
+task-system skill only after those conditions are satisfied.
+
 ## What This Skill Provides
 
 This skill provides six methodology domains as progressive disclosure through

--- a/chief-of-staff-methodology/evals/evals.json
+++ b/chief-of-staff-methodology/evals/evals.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": 1,
+  "skill_name": "chief-of-staff-methodology",
+  "evals": [
+    {
+      "id": "documented-commitment-with-deadline",
+      "prompt": "In the meeting, Jordan said: ‘I will send the revised operating plan to Priya by 2026-08-07.’ Add it to our authorized task system.",
+      "expected_output": "A task for Jordan with a discrete action, a 2026-08-07 due date, and a link or citation to the meeting record; the agent reads it back to verify owner and date.",
+      "assertions": [
+        "Creates exactly one task with Jordan as the accountable owner.",
+        "The task has a due date of 2026-08-07.",
+        "The task states the discrete deliverable, revised operating plan.",
+        "The task preserves meeting provenance or links to the record.",
+        "The completion report confirms a post-creation read-back of the owner and due date."
+      ]
+    },
+    {
+      "id": "meeting-advice-is-not-a-task",
+      "prompt": "The retrospective suggested that senior engineers should join more customer conversations. Put the action items in our task system.",
+      "expected_output": "No task is created because the statement is a general recommendation without an accountable owner, a discrete committed action, or a due date. The agent retains it as a briefing observation or requests confirmation.",
+      "assertions": [
+        "Does not create a task from the recommendation.",
+        "Explains which task-creation conditions are missing.",
+        "Offers a non-task briefing or a request for an accountable owner and due date."
+      ]
+    },
+    {
+      "id": "commitment-without-date",
+      "prompt": "I committed to review the vendor proposal, but we did not agree on a deadline. Create a task assigned to me.",
+      "expected_output": "The agent does not create the task until a realistic due date is confirmed or defensibly derived from stated context; it does not invent a date just to satisfy a task-system field.",
+      "assertions": [
+        "Does not create a task with a missing due date.",
+        "Does not invent an arbitrary due date.",
+        "Requests or identifies the information needed to set a realistic date."
+      ]
+    },
+    {
+      "id": "overdue-commitment-triage",
+      "prompt": "A task says I would submit the board packet by 2026-07-01, but today is 2026-07-29 and it is still open. Update its due date.",
+      "expected_output": "The agent treats the deadline as an overdue triage item and asks for or presents a reschedule, completion, or closure decision instead of silently choosing a new date.",
+      "assertions": [
+        "Identifies the task as overdue.",
+        "Does not silently assign a replacement date.",
+        "Requests or presents explicit reschedule, completion, or closure options."
+      ]
+    },
+    {
+      "id": "verify-persisted-task-fields",
+      "prompt": "Create an authorized task: I will approve the Q3 communications brief by 2026-08-03. Assign it to me.",
+      "expected_output": "The agent creates one task with the stated owner and due date, then reads it back and reports the verified persisted values.",
+      "assertions": [
+        "Creates one task assigned to the stated owner.",
+        "The task has a due date of 2026-08-03.",
+        "The task names approval of the Q3 communications brief as the outcome.",
+        "Reports read-back verification of both assignment and due date."
+      ]
+    },
+    {
+      "id": "batch-task-date-gate",
+      "prompt": "From these meeting notes, create the commitments in our authorized task system: (1) ‘Mina will send the security exception to legal by 2026-08-05’; (2) ‘We should improve cross-team communication.’",
+      "expected_output": "The agent creates only Mina's dated commitment, verifies the persisted owner and due date, and leaves the generic recommendation out of the task system.",
+      "assertions": [
+        "Every task created in the batch has a non-empty due date.",
+        "Creates exactly one task, for Mina's security-exception commitment.",
+        "The created task has a due date of 2026-08-05.",
+        "Does not create a task for the generic cross-team-communication recommendation.",
+        "Reports a read-back verification of the created task's owner and due date."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- require a concrete commitment, accountable owner, realistic due date, and provenance before creating a task
- require post-create read-back verification of owner and due date
- add six task-discipline evals, including a batch gate that rejects any created task without a due date

## Validation
- `ruby scripts/validate-skills.rb`
- `git diff --check`
- JSON schema and required batch due-date assertion check

The earlier task batch showed why this matters: generalized meeting recommendations were recorded as assigned tasks without dates. The new rule routes such material to briefing/confirmation rather than task creation.