### PR TITLE
fix: handle invalid CNCF Landscape URLs

### DIFF
--- a/cncf-landscape/scripts/landscape_query.py
+++ b/cncf-landscape/scripts/landscape_query.py
@@ -205,13 +205,16 @@ def fetch_records(
     timeout: float,
     opener: Callable[..., Any] | None = None,
 ) -> tuple[list[Mapping[str, Any]], Mapping[str, Any]]:
-    request = Request(
-        url,
-        headers={
-            "Accept": "application/json",
-            "User-Agent": "cncf-landscape-agent-skill/1.0",
-        },
-    )
+    try:
+        request = Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "cncf-landscape-agent-skill/1.0",
+            },
+        )
+    except ValueError as exc:
+        raise LandscapeError(f"Invalid Landscape API URL {url}: {exc}") from exc
     open_url = opener or urlopen
     try:
         with open_url(request, timeout=timeout) as response:

--- a/cncf-landscape/tests/test_landscape_query.py
+++ b/cncf-landscape/tests/test_landscape_query.py
@@ -2,8 +2,10 @@
 """Offline tests for the CNCF Landscape query client."""
 
 import importlib.util
+import io
 import json
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "landscape_query.py"
@@ -141,6 +143,15 @@ class LandscapeQueryTests(unittest.TestCase):
         response = FakeResponse(b"<html>single page app</html>", content_type="text/html")
         with self.assertRaisesRegex(MODULE.LandscapeError, "Expected JSON"):
             MODULE.fetch_records("https://example.test/api/projects/all.json", 4.0, fake_opener(response))
+
+    def test_malformed_base_url_uses_cli_error_path(self):
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            exit_code = MODULE.main(["--base-url", "not-a-url", "--timeout", "1"])
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("Error: Invalid Landscape API URL", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
 
     def test_non_object_records_fail_closed(self):
         response = FakeResponse(b"[{}\n,\"not an object\"]")


### PR DESCRIPTION
## Summary

Fixes a post-merge edge case in `cncf-landscape`: malformed `--base-url` values previously exposed an uncaught `urllib.request.Request` `ValueError` traceback.

- Routes invalid URL construction through the existing `LandscapeError` CLI path.
- Adds a regression test proving exit code `2`, an actionable `Error:` line, and no traceback.
- No catalog, documentation, dependency, or unrelated code changes.

## Validation

- [x] `ruby scripts/validate-skills.rb`
- [x] `ruby scripts/validate-skill-quality.rb --base origin/main`
- [x] `python3 scripts/validate-evals.py`
- [x] `python3 scripts/eval-coverage.py --modified-from origin/main`
- [x] `python3 scripts/check-artifacts.py`
- [x] `python3 scripts/validate-agents-md.py`
- [x] `python3 -m unittest discover -s cncf-landscape/tests -p 'test_*.py'` (7 passed)
- [x] `ruff check cncf-landscape/scripts/landscape_query.py cncf-landscape/tests/test_landscape_query.py`
- [x] `python3 -m py_compile cncf-landscape/scripts/landscape_query.py cncf-landscape/tests/test_landscape_query.py`
- [x] Direct CLI reproduction: malformed URL exits `2` with `Error:` and no traceback
- [x] Added-line security scan and `git diff --cached --check`

Meaningful AI assistance is disclosed: this follow-up was implemented and verified with AI assistance.
