### PR TITLE
chore: complete bundle-manifest migration for legacy bundles (#236)

### DIFF
--- a/bundles/neckbeard/manifest.yaml
+++ b/bundles/neckbeard/manifest.yaml
@@ -1,0 +1,204 @@
+# Bundle manifest (bundle-manifest-v1) — see schemas/bundle-manifest-v1.schema.json
+# and docs/bundle-manifest-design.md. Paths are relative to this bundle dir.
+
+schema_version: 1
+bundle_name: neckbeard
+
+purpose: >-
+  A disciplined SDLC delivery operating model for non-trivial software change —
+  fix, build, refactor, review, verify, or release — that routes the work
+  through framing, discovery, design, implementation, review, verification,
+  delivery, and learning, choosing the smallest *safe* intervention, proving it
+  at the real delivery boundary, and leaving an inspectable evidence ledger.
+
+audience: >-
+  Software engineers and agents delivering non-trivial software changes (bug
+  fixes, features, refactors, reviews, releases) that need a bounded,
+  stage-aware path to a defensible 'done' with recorded evidence; teams running
+  issue-to-PR change-request journeys with gates and an authorized release.
+
+stages:
+  - name: Intake and framing
+    skills:
+      - ../../product-discovery/SKILL.md
+  - name: Current-state discovery
+    skills:
+      - ../../software-architecture-analysis/SKILL.md
+      - ../../systematic-debugging/SKILL.md
+  - name: Design
+    skills:
+      - ../../api-design-and-evolution/SKILL.md
+      - ../../product-design-and-ux/SKILL.md
+  - name: Specification
+    skills:
+      - ../../spec-driven-development/SKILL.md
+  - name: Test planning
+    skills:
+      - ../../qa-methodology/SKILL.md
+  - name: Implementation
+    skills:
+      - ../../secure-software-engineering/SKILL.md
+      - ../../web-accessibility/SKILL.md
+  - name: Review and verification
+    skills:
+      - ../../verification-methodology/SKILL.md
+      - ../../technical-documentation/SKILL.md
+  - name: Readiness and release
+    skills:
+      - ../../release-engineering/SKILL.md
+      - ../../site-reliability-engineering/SKILL.md
+
+included_skills:
+  - ../../product-discovery/SKILL.md
+  - ../../software-architecture-analysis/SKILL.md
+  - ../../systematic-debugging/SKILL.md
+  - ../../api-design-and-evolution/SKILL.md
+  - ../../product-design-and-ux/SKILL.md
+  - ../../spec-driven-development/SKILL.md
+  - ../../qa-methodology/SKILL.md
+  - ../../secure-software-engineering/SKILL.md
+  - ../../web-accessibility/SKILL.md
+  - ../../verification-methodology/SKILL.md
+  - ../../technical-documentation/SKILL.md
+  - ../../release-engineering/SKILL.md
+  - ../../site-reliability-engineering/SKILL.md
+
+prerequisites:
+  - artifact: A non-trivial change request, issue, or task with a verifiable contract
+  - artifact: Current-state evidence (repository, tests, config, recent history)
+    skill: ../../software-architecture-analysis/SKILL.md
+  - artifact: Change contract and evidence ledger entries
+    skill: ../../verification-methodology/SKILL.md
+
+outputs:
+  - change-contract
+  - evidence-ledger
+  - delivery-packet
+  - implementation-plan
+  - verification-report
+  - release-record
+
+handoffs:
+  - to: verification-methodology
+    artifact: verification-report
+    note: >-
+      The verification report records the declared verification target and the
+      boundary actually exercised; verdicts bind to the exact head and never
+      claim a boundary that was not checked.
+  - to: release-engineering
+    artifact: release-record
+    note: >-
+      Release planning, versioning, pipeline promotion, readiness, and
+      authorized release routing for the delivered change.
+  - to: human reviewer
+    artifact: delivery-packet
+    note: >-
+      Change-request journeys hand the delivery packet — gates and evidence —
+      to the required review before merge; a timed-out review is inconclusive,
+      not a reason to launch repeated review rounds.
+  - to: next change (via evidence ledger)
+    artifact: evidence-ledger
+    note: >-
+      Each run emits a compact evidence record (intent, inspected artifacts,
+      assumptions, rejected alternatives, checks run, observed outputs,
+      unverified boundaries) that carries learning into the next change.
+
+conflicts:
+  - skill: ../../product-discovery/SKILL.md
+    with: product-lifecycle
+    guidance: >-
+      Product discovery is shared. Route by context: neckbeard loads it for
+      intake and framing of a change request; product-lifecycle owns the full
+      discovery phase of a product lifecycle.
+  - skill: ../../product-design-and-ux/SKILL.md
+    with: product-lifecycle
+    guidance: >-
+      Product design is shared. neckbeard loads it for user-facing behavior,
+      interaction, and information architecture during design;
+      product-lifecycle owns the UX and requirements phase of a product.
+  - skill: ../../spec-driven-development/SKILL.md
+    with: product-lifecycle
+    guidance: >-
+      Specification is shared. neckbeard uses it for formal specification and
+      phase gates on a change request; product-lifecycle uses it for
+      requirements and acceptance criteria in its lifecycle phases.
+  - skill: ../../qa-methodology/SKILL.md
+    with: product-lifecycle
+    guidance: >-
+      QA methodology is shared. neckbeard loads it for test strategy and
+      regression gates on a change; product-lifecycle routes to it for phase 6
+      quality gates.
+  - skill: ../../qa-methodology/SKILL.md
+    with: production-excellence
+    guidance: >-
+      QA methodology is shared. neckbeard loads it for change-request test
+      planning; production-excellence uses it for launch verification
+      evidence.
+  - skill: ../../secure-software-engineering/SKILL.md
+    with: product-lifecycle
+    guidance: >-
+      Security engineering is shared. Route by context: change-level security
+      review and threat modeling (neckbeard) versus lifecycle-phase security
+      needs (product-lifecycle).
+  - skill: ../../secure-software-engineering/SKILL.md
+    with: production-excellence
+    guidance: >-
+      Security engineering is shared. Route by context: change-level security
+      review (neckbeard) versus launch-gate security evidence
+      (production-excellence).
+  - skill: ../../secure-software-engineering/SKILL.md
+    with: agent-production-operations
+    guidance: >-
+      Security engineering is shared. Route by context: change-level security
+      review (neckbeard) versus agent authority contracts and disablement
+      security (agent-production-operations).
+  - skill: ../../verification-methodology/SKILL.md
+    with: product-lifecycle
+    guidance: >-
+      Verification methodology is shared. neckbeard requires it to exercise
+      the declared verification boundary on a change; product-lifecycle uses
+      it at every phase gate for evidence.
+  - skill: ../../verification-methodology/SKILL.md
+    with: production-excellence
+    guidance: >-
+      Verification methodology is shared. neckbeard uses it for change-request
+      verification verdicts; production-excellence uses it for boundary
+      labeling of launch evidence.
+  - skill: ../../release-engineering/SKILL.md
+    with: product-lifecycle
+    guidance: >-
+      Release engineering is shared. Route by context: change-request release
+      planning (neckbeard) versus lifecycle delivery handoff
+      (product-lifecycle).
+  - skill: ../../release-engineering/SKILL.md
+    with: production-excellence
+    guidance: >-
+      Release engineering is shared. Route by context: change-request release
+      planning (neckbeard) versus launch-gate release evidence
+      (production-excellence).
+  - skill: ../../release-engineering/SKILL.md
+    with: agent-production-operations
+    guidance: >-
+      Release engineering is shared. Route by context: change-request release
+      planning (neckbeard) versus agent staged-rollout planning
+      (agent-production-operations).
+  - skill: ../../site-reliability-engineering/SKILL.md
+    with: product-lifecycle
+    guidance: >-
+      SRE is shared. neckbeard routes to it for reliability and operational
+      recovery of a delivered change; product-lifecycle routes to it for
+      delivery reliability.
+  - skill: ../../site-reliability-engineering/SKILL.md
+    with: production-excellence
+    guidance: >-
+      SRE is shared. Route by context: change-level reliability (neckbeard)
+      versus gate-entry SLO/error-budget evidence (production-excellence).
+  - skill: ../../site-reliability-engineering/SKILL.md
+    with: agent-production-operations
+    guidance: >-
+      SRE is shared. Route by context: change-level reliability (neckbeard)
+      versus agent runtime latency/cost budgets and incident handoff
+      (agent-production-operations).
+
+eval_suite:
+  - evals/evals.json

--- a/bundles/research-and-vault/evals/evals.json
+++ b/bundles/research-and-vault/evals/evals.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "skill_name": "research-and-vault",
+  "evals": [
+    {
+      "id": "research-to-note-complete-sequence",
+      "prompt": "Our team needs to understand the current state of vector-database benchmark methodology before we pick a database. Run the full research-to-note sequence for this topic and produce the durable note.",
+      "expected_output": "Scenario: a full research-to-note run of the bundle. The agent performs web research on vector-database benchmark methodology, captures each source URL and access date before any interpretation, extracts independent atomic claims from each source, and only then synthesizes the durable note. The note reports its output path and any unresolved gaps in source coverage. The sequence order is: research, source capture, atomic extraction, synthesis, report — no interpretation precedes URL/date capture, and no synthesis precedes atomic extraction.",
+      "assertions": [
+        "Source URLs and access dates are recorded before interpretation of the source content",
+        "Independent atomic claims are extracted per source before synthesis",
+        "The durable note is written only after source coverage and gaps are explicit",
+        "The note reports its output path and unresolved gaps",
+        "The bundle loads research-methodology for the research stage"
+      ]
+    },
+    {
+      "id": "source-capture-before-interpretation",
+      "prompt": "I found three articles about MLOps cost estimation and I want to know what the consensus is. Capture the sources and tell me the consensus.",
+      "expected_output": "Scenario: source capture precedes interpretation. The agent records the three article URLs and access dates first, then reads and interprets them. Each claim in the summary is traceable to a captured source. If a source cannot be captured with a date, the agent flags it as a gap rather than silently relying on it.",
+      "assertions": [
+        "The three source URLs and access dates are recorded before any interpretation is offered",
+        "Claims in the consensus summary are traceable to captured sources",
+        "A source without a recorded date is flagged as a gap, not silently used",
+        "The response does not offer interpretation of a source whose URL/date was never captured"
+      ]
+    },
+    {
+      "id": "atomic-extraction-before-synthesis",
+      "prompt": "Synthesize what the literature says about retrieval-augmented generation evaluation. I have collected five papers.",
+      "expected_output": "Scenario: atomic extraction precedes synthesis. The agent first extracts independent atomic claims from each of the five papers (one claim per distinct finding, each tied to its paper), then synthesizes across the papers. The synthesis distinguishes supported claims, contested claims, and gaps, and never merges distinct findings into a vague composite.",
+      "assertions": [
+        "Atomic claims are extracted per paper before any synthesis is produced",
+        "Each extracted claim is tied to its source paper",
+        "Synthesis distinguishes supported, contested, and missing/gap findings",
+        "Distinct findings are not merged into a vague composite claim"
+      ]
+    },
+    {
+      "id": "gap-explicit-reporting",
+      "prompt": "Research whether local-first synchronization is production-ready, then write the durable note. Note that I could not get access to one of the key blog posts you might find.",
+      "expected_output": "Scenario: the run completes with an explicit gap report. The agent completes the research-to-note sequence, and the durable note records the inaccessible key blog post as an unresolved gap in source coverage. The gap section lists what was missing and the impact on the conclusions, and the note does not overstate confidence where a key source is missing.",
+      "assertions": [
+        "The durable note contains an explicit unresolved-gaps section",
+        "The inaccessible blog post is named in the gap section",
+        "The impact of the missing source on the conclusions is stated",
+        "Confidence in conclusions is not overstated given the missing source"
+      ]
+    },
+    {
+      "id": "single-lookup-routing",
+      "prompt": "What is the HTTP status code for 'I'm a teapot'?",
+      "expected_output": "Scenario: a single factual lookup, NOT a research-to-note sequence. The bundle routes the question to the appropriate domain skill (or answers directly) instead of running the full five-step sequence. No durable note is produced, no atomic extraction is performed, and no source-capture record is created. The response is the short factual answer.",
+      "assertions": [
+        "The full research-to-note sequence is NOT invoked for a single lookup",
+        "No durable-note artifact is produced",
+        "The question is answered directly or routed to the domain skill",
+        "The response is the short factual answer"
+      ]
+    }
+  ]
+}

--- a/bundles/research-and-vault/manifest.yaml
+++ b/bundles/research-and-vault/manifest.yaml
@@ -1,0 +1,67 @@
+# Bundle manifest (bundle-manifest-v1) — see schemas/bundle-manifest-v1.schema.json
+# and docs/bundle-manifest-design.md. Paths are relative to this bundle dir.
+
+schema_version: 1
+bundle_name: research-and-vault
+
+purpose: >-
+  Chain web research, atomic extraction, and durable knowledge capture into a
+  repeatable research-to-note workflow: capture source URLs and dates before
+  interpretation, extract independent atomic claims before synthesis, and write
+  the durable note only after source coverage and gaps are explicit.
+
+audience: >-
+  Agents and knowledge workers that repeatedly need the full research-to-note
+  sequence (web research, atomic extraction, durable capture) and want a stable
+  order of operations with a clear handoff artifact instead of ad-hoc steps;
+  not for single lookups or single notes, which route to the domain skill
+  directly.
+
+stages:
+  - name: Web research
+    skills:
+      - ../../research-methodology/SKILL.md
+  - name: Source capture
+    skills:
+      - ../../research-methodology/SKILL.md
+  - name: Atomic extraction
+    skills:
+      - ../../research-methodology/SKILL.md
+  - name: Synthesis and durable capture
+    skills:
+      - ../../research-methodology/SKILL.md
+
+included_skills:
+  - ../../research-methodology/SKILL.md
+
+prerequisites:
+  - artifact: A research question or topic and access to web-research tooling
+    skill: ../../research-methodology/SKILL.md
+
+outputs:
+  - source-capture-record
+  - atomic-claim-extract
+  - durable-note
+
+handoffs:
+  - to: research-methodology
+    artifact: source-capture-record
+    note: >-
+      Source URLs and dates are captured before interpretation and carried into
+      extraction and synthesis; never interpret a source before its URL and
+      date are recorded.
+  - to: research-methodology
+    artifact: atomic-claim-extract
+    note: >-
+      Independent atomic claims are extracted before synthesis so the durable
+      note can trace each claim to its source.
+  - to: user
+    artifact: durable-note
+    note: >-
+      The finished durable note reports its output path and any unresolved gaps
+      in source coverage.
+
+conflicts: []
+
+eval_suite:
+  - evals/evals.json

--- a/bundles/tailscale/evals/evals.json
+++ b/bundles/tailscale/evals/evals.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "skill_name": "tailscale",
+  "evals": [
+    {
+      "id": "headscale-deploy-full",
+      "prompt": "Stand up a self-hosted tailnet: install and configure the Headscale control server on a fresh Ubuntu 24.04 host with a custom domain, then verify it is healthy.",
+      "expected_output": "Scenario: full control-server deployment. The agent loads headscale-deploy, installs Headscale (release binary or distro package), writes a headscale config binding to the custom domain, enables and starts the service, and verifies health with the health-check script (server version, DB integrity). HEADSCALE_URL and an API key are created/recorded. The deployment records the config file path and the verification output, and does not proceed to client registration until the server reports healthy.",
+      "assertions": [
+        "The headscale-deploy sub-skill is loaded and followed",
+        "A headscale config is written binding the server to the custom domain",
+        "The service is enabled and started",
+        "Health is verified (version, DB integrity) before proceeding",
+        "HEADSCALE_URL and an API key are available for downstream sub-skills"
+      ]
+    },
+    {
+      "id": "acl-policy-segmented",
+      "prompt": "We have three teams (eng, ops, finance) sharing one tailnet. Finance nodes must talk only to finance nodes; eng and ops can talk to each other but not to finance; ops nodes can reach the database subnet router. Write the ACL policy.",
+      "expected_output": "Scenario: tagged, segmented ACL policy design. The agent loads tailnet-policy and writes a policy file with tag owners and ACL rules: finance-to-finance only, eng+ops mutual access, ops access to the database subnet router, all other traffic denied by default. The policy is validated against the policy schema before being applied, and the apply step is gated on explicit confirmation because it changes access control on a live tailnet.",
+      "assertions": [
+        "The tailnet-policy sub-skill is loaded",
+        "Tag owners and tags are declared for the three teams",
+        "ACL rules enforce finance isolation, eng/ops mutual access, and ops-to-database-router access",
+        "Default-deny is preserved for everything else",
+        "Applying the policy to the live tailnet is gated on explicit confirmation"
+      ]
+    },
+    {
+      "id": "node-lifecycle-preauth",
+      "prompt": "Provision five new servers into the tailnet: generate pre-authenticated keys, install and register the tailscale client on each, approve the nodes, then decommission two of them that are no longer needed.",
+      "expected_output": "Scenario: node lifecycle management. The agent loads headscale-node-lifecycle, generates a reusable (or single-use) pre-auth key, registers the five nodes, approves them, and verifies they show up in node list with the expected tags. The two decommissioned nodes are removed via the headscale CLI and confirmed absent from node list. Auth-key and node lifecycle operations are recorded with the commands and output observed.",
+      "assertions": [
+        "The headscale-node-lifecycle sub-skill is loaded",
+        "A pre-auth key is generated and used for node registration",
+        "The five nodes are registered and approved",
+        "The two decommissioned nodes are removed and confirmed absent",
+        "Commands and observed outputs are recorded"
+      ]
+    },
+    {
+      "id": "subnet-router-and-exit-node",
+      "prompt": "Expose our 192.168.10.0/24 lab network through a subnet router on node relay-1, and let the tailnet use node exit-1 as an exit node. Advertise and approve both.",
+      "expected_output": "Scenario: routing configuration. The agent loads headscale-routing, configures relay-1 to advertise 192.168.10.0/24, approves the route on the control server, and configures exit-1 to advertise exit-node capability with the exit-node approval. The final tailscale status shows the routes accepted and the exit node available. The difference between subnet-router and exit-node approval is handled explicitly.",
+      "assertions": [
+        "The headscale-routing sub-skill is loaded",
+        "relay-1 advertises 192.168.10.0/24 and the route is approved",
+        "exit-1 advertises exit-node capability and is approved",
+        "Final status confirms routes accepted and exit node available",
+        "Subnet-router and exit-node approvals are handled distinctly"
+      ]
+    },
+    {
+      "id": "derp-relay-config",
+      "prompt": "Direct peer connections fail across the office NAT. Configure a custom DERP relay map for our region and verify clients can relay through it.",
+      "expected_output": "Scenario: DERP relay operation. The agent loads headscale-derp, writes a custom DERP map (region, relay node, STUN) into the headscale config, reloads/restarts the control server, and verifies a client can establish a DERP connection when direct connection fails. The verification observes the relay path in tailscale status rather than assuming the config was picked up.",
+      "assertions": [
+        "The headscale-derp sub-skill is loaded",
+        "A custom DERP map with region, relay node, and STUN is written",
+        "The headscale config is reloaded/restarted",
+        "Relay connectivity is verified via tailscale status, not assumed"
+      ]
+    },
+    {
+      "id": "backup-and-restore",
+      "prompt": "Back up our production headscale server (sqlite + config + policy + certs), then simulate a restore onto a fresh host to prove the backup works.",
+      "expected_output": "Scenario: backup and restore drill. The agent loads headscale-backup, runs the backup script to produce an archive, inspects its contents (sqlite, config, policy, certs present), then restores the archive onto a fresh host and verifies the server starts with the same tailnet state (nodes, policy). The restore is exercised, not just documented. The backup archive is noted as the disaster-recovery artifact kept off the control-server host.",
+      "assertions": [
+        "The headscale-backup sub-skill is loaded",
+        "A backup archive is produced containing sqlite, config, policy, and certs",
+        "The archive is restored onto a fresh host",
+        "The restored server verifiably starts with the same tailnet state",
+        "The backup archive is stored off the control-server host"
+      ]
+    }
+  ]
+}

--- a/bundles/tailscale/manifest.yaml
+++ b/bundles/tailscale/manifest.yaml
@@ -1,0 +1,93 @@
+# Bundle manifest (bundle-manifest-v1) — see schemas/bundle-manifest-v1.schema.json
+# and docs/bundle-manifest-design.md. Paths are relative to this bundle dir.
+
+schema_version: 1
+bundle_name: tailscale
+
+purpose: >-
+  Operate a self-hosted Tailscale/Headscale ecosystem end to end: deploy and
+  manage a Headscale control server, configure Tailscale clients, define ACL
+  policy, manage node lifecycle, advertise subnet routes and exit nodes,
+  operate DERP relays, and back up, restore, or migrate the control plane.
+
+audience: >-
+  Platform and homelab operators running self-hosted Tailscale/Headscale
+  infrastructure; agents that need to know which sub-skill to load for deploy,
+  policy, client, node, routing, DERP, or backup tasks in a WireGuard mesh.
+
+stages:
+  - name: Deploy control server
+    skills:
+      - skills/headscale-deploy/SKILL.md
+  - name: Policy
+    skills:
+      - skills/tailnet-policy/SKILL.md
+  - name: Client connectivity
+    skills:
+      - skills/tailscale-client/SKILL.md
+  - name: Node lifecycle
+    skills:
+      - skills/headscale-node-lifecycle/SKILL.md
+  - name: Routing
+    skills:
+      - skills/headscale-routing/SKILL.md
+  - name: DERP relays
+    skills:
+      - skills/headscale-derp/SKILL.md
+  - name: Backup and restore
+    skills:
+      - skills/headscale-backup/SKILL.md
+
+included_skills:
+  - skills/headscale-deploy/SKILL.md
+  - skills/tailnet-policy/SKILL.md
+  - skills/tailscale-client/SKILL.md
+  - skills/headscale-node-lifecycle/SKILL.md
+  - skills/headscale-routing/SKILL.md
+  - skills/headscale-derp/SKILL.md
+  - skills/headscale-backup/SKILL.md
+
+prerequisites:
+  - artifact: A Linux host and install target for the Headscale control server
+    skill: skills/headscale-deploy/SKILL.md
+  - artifact: HEADSCALE_URL and HEADSCALE_API_KEY credentials
+    skill: skills/headscale-deploy/SKILL.md
+  - artifact: A running Headscale instance with the headscale CLI available
+    skill: skills/headscale-deploy/SKILL.md
+
+outputs:
+  - headscale-server
+  - tailnet-policy
+  - registered-nodes
+  - routed-networks
+  - derp-map
+  - backup-archive
+  - restored-instance
+
+handoffs:
+  - to: tailnet-policy
+    artifact: headscale-server
+    note: >-
+      A running control server is required before ACL policy is applied and
+      before the tailnet opens to other users.
+  - to: headscale-node-lifecycle
+    artifact: headscale-server
+    note: >-
+      Nodes are registered, approved, tagged, and decommissioned against the
+      running control server.
+  - to: headscale-backup
+    artifact: headscale-server
+    note: >-
+      Backups (sqlite + config + policy + certs) run regularly against the
+      production control server; restore re-creates the instance from the
+      archive.
+  - to: user
+    artifact: backup-archive
+    note: >-
+      The backup archive is the disaster-recovery artifact for the tailnet;
+      keep it off the control server host.
+
+conflicts: []
+
+eval_suite:
+  - evals/evals.json

--- a/bundles/workflow-architect/evals/evals.json
+++ b/bundles/workflow-architect/evals/evals.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": 1,
+  "skill_name": "workflow-architect",
+  "evals": [
+    {
+      "id": "active-interview-convergence",
+      "prompt": "/workflow-architect — I don't have a formal process for my mornings. Interview me to figure out my actual routine.",
+      "expected_output": "Scenario: active interrogation mode. The agent loads skills/interviewer/SKILL.md and guides the user through 8-15 adaptive questions covering entry points, phases, branching signals, tool preferences, loop conditions, exit criteria, and pain points. The interviewer branches its probes on the user's answers, records workflow state under workflow-architect:state:, and converges when phases, branching signals, and tool preferences are stable. On convergence it loads skills/bundle-builder/SKILL.md to synthesize the bundle. The interview stops asking questions once convergence is reached rather than continuing indefinitely.",
+      "assertions": [
+        "skills/interviewer/SKILL.md is loaded in active mode",
+        "The interview asks adaptive questions across entry points, phases, branching signals, tools, loops, exits, and pain points",
+        "Probes branch based on the user's answers",
+        "Workflow state is persisted under the workflow-architect:state: prefix",
+        "Convergence triggers bundle-builder synthesis instead of unbounded questioning"
+      ]
+    },
+    {
+      "id": "passive-observation-trigger",
+      "prompt": "I've been working in this session for a while. /workflow-architect passive — figure out what I do. (Then the user says 'analyze my process'.)",
+      "expected_output": "Scenario: passive observation mode. The agent loads skills/observer/SKILL.md silently and does nothing until the trigger phrase ('analyze my process') appears, then scans the session context and reconstructs the workflow phases, branching signals, and tool preferences from what actually happened. If the session context is too thin (fewer than ~20 substantive turns), the observer recommends switching to active interrogation instead of fabricating a workflow from sparse evidence.",
+      "assertions": [
+        "skills/observer/SKILL.md is loaded and stays dormant until a trigger phrase",
+        "No workflow analysis is produced before the trigger phrase",
+        "Session context is scanned only after the trigger",
+        "Thin context results in a recommendation to switch to active mode, not fabrication",
+        "Workflow state is persisted under the workflow-architect:state: prefix"
+      ]
+    },
+    {
+      "id": "bundle-generation-output",
+      "prompt": "I finished the interview and we converged on my workflow: morning triage, deep work, and end-of-day review phases. Generate my skills bundle.",
+      "expected_output": "Scenario: bundle synthesis. The agent loads skills/bundle-builder/SKILL.md and renders a valid Agent Skills bundle: an umbrella SKILL.md with trigger-oriented description, one sub-skill per phase with its own description and triggers, a manifest mapping skill names to trigger conditions and transition signals, and a Mermaid decision map. The bundle is written to the host skill directory, the umbrella and sub-skills are registered, and the agent verifies the umbrella and at least one sub-skill load. The user is told where it landed, what skills it contains, and a trigger phrase they can use to enter the workflow.",
+      "assertions": [
+        "skills/bundle-builder/SKILL.md is loaded for synthesis",
+        "The output bundle has an umbrella SKILL.md and one sub-skill per workflow phase",
+        "The manifest maps skill names to trigger conditions and transition signals",
+        "A Mermaid decision map is produced",
+        "The umbrella and at least one sub-skill are verified to load",
+        "The user is told the output location, skill list, and an entry trigger phrase"
+      ]
+    },
+    {
+      "id": "thin-context-degradation",
+      "prompt": "/workflow-architect passive — I just started this session and there are only two messages. Tell me my workflow.",
+      "expected_output": "Scenario: degraded observation input. The session has far fewer than 20 substantive turns, so the observer does NOT reconstruct a workflow. It explicitly states that observation mode needs more context and recommends switching to active interrogation mode (the 8-15 question interview) to build the workflow model reliably. No workflow bundle is generated from the thin context.",
+      "assertions": [
+        "No workflow is reconstructed from the thin session context",
+        "The limitation (needs ~20+ substantive turns) is stated explicitly",
+        "The observer recommends active interrogation mode as the alternative",
+        "No bundle is generated from sparse evidence"
+      ]
+    },
+    {
+      "id": "kanban-decision-criteria",
+      "prompt": "My workflow is a single linear pipeline: triage inbox, draft, edit, publish. Should the generated bundle include a kanban board?",
+      "expected_output": "Scenario: kanban inclusion decision. The agent applies the kanban decision criteria from references/kanban-decision-criteria.md: a predictable linear path with clear lane transitions can benefit from a kanban board with WIP limits. For this triage → draft → edit → publish pipeline the board is included, with board slug, phases, and WIP limits in the generated bundle. The decision is explained; a non-linear, context-heavy workflow would omit the board.",
+      "assertions": [
+        "The kanban decision criteria reference is consulted",
+        "The linear triage → draft → edit → publish pipeline is recognized as a kanban candidate",
+        "The generated bundle includes a kanban board with phases and WIP limits",
+        "The decision rationale is explained to the user"
+      ]
+    },
+    {
+      "id": "trigger-condition-quality",
+      "prompt": "Generate my workflow bundle. One of my phases is 'deep work' — what should its description look like?",
+      "expected_output": "Scenario: trigger-condition authoring. The sub-skill descriptions follow the Agent Skills trigger format: an imperative-verb description that both positively and negatively bounds when the sub-skill loads (e.g., 'load when the user shifts into deep work mode' with a negative boundary for shallow task-switching). The description vocabulary matches how the user actually talks about entering that phase, and the umbrella description carries the broad entry triggers for the bundle. No sub-skill description is a bare phase name with no trigger guidance.",
+      "assertions": [
+        "Sub-skill descriptions start with an imperative verb and define a positive trigger",
+        "Sub-skill descriptions include a negative boundary for when not to load",
+        "Trigger vocabulary matches how the user describes entering the phase",
+        "No sub-skill description is a bare phase name without trigger guidance"
+      ]
+    }
+  ]
+}

--- a/bundles/workflow-architect/manifest.yaml
+++ b/bundles/workflow-architect/manifest.yaml
@@ -1,0 +1,72 @@
+# Bundle manifest (bundle-manifest-v1) — see schemas/bundle-manifest-v1.schema.json
+# and docs/bundle-manifest-design.md. Paths are relative to this bundle dir.
+
+schema_version: 1
+bundle_name: workflow-architect
+
+purpose: >-
+  Discover a user's actual workflow through active interrogation or passive
+  observation, then generate a tailored Agent Skills bundle that encodes it as
+  loadable skills with trigger conditions, a decision map, a manifest, and an
+  optional kanban board — turning a session that feels aimless into structure.
+
+audience: >-
+  Users and agents that want to formalize how they work — understand their own
+  process, encode it as trigger-driven skills they can reuse, or share it with
+  collaborators. Not for single factual questions or tasks already owned by a
+  more specific skill.
+
+stages:
+  - name: Active interview
+    skills:
+      - skills/interviewer/SKILL.md
+  - name: Passive observation
+    skills:
+      - skills/observer/SKILL.md
+  - name: Synthesis and generation
+    skills:
+      - skills/bundle-builder/SKILL.md
+
+included_skills:
+  - skills/interviewer/SKILL.md
+  - skills/observer/SKILL.md
+  - skills/bundle-builder/SKILL.md
+
+prerequisites:
+  - artifact: Session context with enough turns for observation (or user answers for interview)
+    skill: skills/observer/SKILL.md
+  - artifact: Convergence on workflow phases, branching signals, and tool preferences
+    skill: skills/interviewer/SKILL.md
+
+outputs:
+  - skills-bundle
+  - decision-map
+  - manifest
+  - kanban-board
+
+handoffs:
+  - to: user
+    artifact: skills-bundle
+    note: >-
+      The generated bundle is written to the host skill directory and
+      registered so the umbrella and sub-skills load on trigger phrases.
+  - to: user
+    artifact: decision-map
+    note: >-
+      The Mermaid decision map visualizes workflow phases and branching
+      signals for review and sharing.
+  - to: user
+    artifact: manifest
+    note: >-
+      The generated manifest maps skill names to trigger conditions, entry
+      points, and transition signals for the bundle.
+  - to: user
+    artifact: kanban-board
+    note: >-
+      The kanban board is included only when the workflow follows a predictable
+      linear path where WIP limits and lane transitions add value.
+
+conflicts: []
+
+eval_suite:
+  - evals/evals.json

--- a/docs/lifecycle-capability-matrix.json
+++ b/docs/lifecycle-capability-matrix.json
@@ -208,53 +208,235 @@
     },
     {
       "name": "neckbeard",
-      "derivation": "frontmatter-description-and-deferred-migration",
-      "source": "bundles/neckbeard/SKILL.md",
+      "derivation": "manifest",
+      "source": "bundles/neckbeard/manifest.yaml",
       "fields": {
         "purpose": {
-          "value": "Use when asked to fix, build, refactor, review, verify, or release software and the work is non-trivial — including delivering a change request (issue, ticket, or request) from intake through planning, gates, implementation, review, verified PR, and authorized post-merge release. neckbeard routes the change through framing, discovery, design, implementation, review, verification, delivery, and learning — choosing the smallest *safe* intervention, proving it at the real delivery boundary, and leaving an inspectable evidence ledger. For change-request / issue-to-PR work, conditionally loads a 9-phase journey with gates, delivery packet, and lifecycle integration. Composes specialist catalog skills rather than replacing them. Not a persona, not a '10x developer' prompt, not a LOC-minimizer. The journey is not loaded for plain fixes, refactors, or reviews that lack an issue/ticket trajectory.",
-          "source": "bundles/neckbeard/SKILL.md#/description",
-          "derivation": "frontmatter-description"
+          "value": "A disciplined SDLC delivery operating model for non-trivial software change — fix, build, refactor, review, verify, or release — that routes the work through framing, discovery, design, implementation, review, verification, delivery, and learning, choosing the smallest *safe* intervention, proving it at the real delivery boundary, and leaving an inspectable evidence ledger.",
+          "source": "bundles/neckbeard/manifest.yaml#/purpose"
         },
         "audience": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": "Software engineers and agents delivering non-trivial software changes (bug fixes, features, refactors, reviews, releases) that need a bounded, stage-aware path to a defensible 'done' with recorded evidence; teams running issue-to-PR change-request journeys with gates and an authorized release.",
+          "source": "bundles/neckbeard/manifest.yaml#/audience"
         },
         "stages": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "name": "Intake and framing",
+              "skills": [
+                "../../product-discovery/SKILL.md"
+              ]
+            },
+            {
+              "name": "Current-state discovery",
+              "skills": [
+                "../../software-architecture-analysis/SKILL.md",
+                "../../systematic-debugging/SKILL.md"
+              ]
+            },
+            {
+              "name": "Design",
+              "skills": [
+                "../../api-design-and-evolution/SKILL.md",
+                "../../product-design-and-ux/SKILL.md"
+              ]
+            },
+            {
+              "name": "Specification",
+              "skills": [
+                "../../spec-driven-development/SKILL.md"
+              ]
+            },
+            {
+              "name": "Test planning",
+              "skills": [
+                "../../qa-methodology/SKILL.md"
+              ]
+            },
+            {
+              "name": "Implementation",
+              "skills": [
+                "../../secure-software-engineering/SKILL.md",
+                "../../web-accessibility/SKILL.md"
+              ]
+            },
+            {
+              "name": "Review and verification",
+              "skills": [
+                "../../verification-methodology/SKILL.md",
+                "../../technical-documentation/SKILL.md"
+              ]
+            },
+            {
+              "name": "Readiness and release",
+              "skills": [
+                "../../release-engineering/SKILL.md",
+                "../../site-reliability-engineering/SKILL.md"
+              ]
+            }
+          ],
+          "source": "bundles/neckbeard/manifest.yaml#/stages"
         },
         "included_skills": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "../../product-discovery/SKILL.md",
+            "../../software-architecture-analysis/SKILL.md",
+            "../../systematic-debugging/SKILL.md",
+            "../../api-design-and-evolution/SKILL.md",
+            "../../product-design-and-ux/SKILL.md",
+            "../../spec-driven-development/SKILL.md",
+            "../../qa-methodology/SKILL.md",
+            "../../secure-software-engineering/SKILL.md",
+            "../../web-accessibility/SKILL.md",
+            "../../verification-methodology/SKILL.md",
+            "../../technical-documentation/SKILL.md",
+            "../../release-engineering/SKILL.md",
+            "../../site-reliability-engineering/SKILL.md"
+          ],
+          "source": "bundles/neckbeard/manifest.yaml#/included_skills"
         },
         "prerequisites": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "artifact": "A non-trivial change request, issue, or task with a verifiable contract"
+            },
+            {
+              "artifact": "Current-state evidence (repository, tests, config, recent history)",
+              "skill": "../../software-architecture-analysis/SKILL.md"
+            },
+            {
+              "artifact": "Change contract and evidence ledger entries",
+              "skill": "../../verification-methodology/SKILL.md"
+            }
+          ],
+          "source": "bundles/neckbeard/manifest.yaml#/prerequisites"
         },
         "outputs": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "change-contract",
+            "evidence-ledger",
+            "delivery-packet",
+            "implementation-plan",
+            "verification-report",
+            "release-record"
+          ],
+          "source": "bundles/neckbeard/manifest.yaml#/outputs"
         },
         "handoffs": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "to": "verification-methodology",
+              "artifact": "verification-report",
+              "note": "The verification report records the declared verification target and the boundary actually exercised; verdicts bind to the exact head and never claim a boundary that was not checked."
+            },
+            {
+              "to": "release-engineering",
+              "artifact": "release-record",
+              "note": "Release planning, versioning, pipeline promotion, readiness, and authorized release routing for the delivered change."
+            },
+            {
+              "to": "human reviewer",
+              "artifact": "delivery-packet",
+              "note": "Change-request journeys hand the delivery packet — gates and evidence — to the required review before merge; a timed-out review is inconclusive, not a reason to launch repeated review rounds."
+            },
+            {
+              "to": "next change (via evidence ledger)",
+              "artifact": "evidence-ledger",
+              "note": "Each run emits a compact evidence record (intent, inspected artifacts, assumptions, rejected alternatives, checks run, observed outputs, unverified boundaries) that carries learning into the next change."
+            }
+          ],
+          "source": "bundles/neckbeard/manifest.yaml#/handoffs"
         },
         "conflicts": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "skill": "../../product-discovery/SKILL.md",
+              "with": "product-lifecycle",
+              "guidance": "Product discovery is shared. Route by context: neckbeard loads it for intake and framing of a change request; product-lifecycle owns the full discovery phase of a product lifecycle."
+            },
+            {
+              "skill": "../../product-design-and-ux/SKILL.md",
+              "with": "product-lifecycle",
+              "guidance": "Product design is shared. neckbeard loads it for user-facing behavior, interaction, and information architecture during design; product-lifecycle owns the UX and requirements phase of a product."
+            },
+            {
+              "skill": "../../spec-driven-development/SKILL.md",
+              "with": "product-lifecycle",
+              "guidance": "Specification is shared. neckbeard uses it for formal specification and phase gates on a change request; product-lifecycle uses it for requirements and acceptance criteria in its lifecycle phases."
+            },
+            {
+              "skill": "../../qa-methodology/SKILL.md",
+              "with": "product-lifecycle",
+              "guidance": "QA methodology is shared. neckbeard loads it for test strategy and regression gates on a change; product-lifecycle routes to it for phase 6 quality gates."
+            },
+            {
+              "skill": "../../qa-methodology/SKILL.md",
+              "with": "production-excellence",
+              "guidance": "QA methodology is shared. neckbeard loads it for change-request test planning; production-excellence uses it for launch verification evidence."
+            },
+            {
+              "skill": "../../secure-software-engineering/SKILL.md",
+              "with": "product-lifecycle",
+              "guidance": "Security engineering is shared. Route by context: change-level security review and threat modeling (neckbeard) versus lifecycle-phase security needs (product-lifecycle)."
+            },
+            {
+              "skill": "../../secure-software-engineering/SKILL.md",
+              "with": "production-excellence",
+              "guidance": "Security engineering is shared. Route by context: change-level security review (neckbeard) versus launch-gate security evidence (production-excellence)."
+            },
+            {
+              "skill": "../../secure-software-engineering/SKILL.md",
+              "with": "agent-production-operations",
+              "guidance": "Security engineering is shared. Route by context: change-level security review (neckbeard) versus agent authority contracts and disablement security (agent-production-operations)."
+            },
+            {
+              "skill": "../../verification-methodology/SKILL.md",
+              "with": "product-lifecycle",
+              "guidance": "Verification methodology is shared. neckbeard requires it to exercise the declared verification boundary on a change; product-lifecycle uses it at every phase gate for evidence."
+            },
+            {
+              "skill": "../../verification-methodology/SKILL.md",
+              "with": "production-excellence",
+              "guidance": "Verification methodology is shared. neckbeard uses it for change-request verification verdicts; production-excellence uses it for boundary labeling of launch evidence."
+            },
+            {
+              "skill": "../../release-engineering/SKILL.md",
+              "with": "product-lifecycle",
+              "guidance": "Release engineering is shared. Route by context: change-request release planning (neckbeard) versus lifecycle delivery handoff (product-lifecycle)."
+            },
+            {
+              "skill": "../../release-engineering/SKILL.md",
+              "with": "production-excellence",
+              "guidance": "Release engineering is shared. Route by context: change-request release planning (neckbeard) versus launch-gate release evidence (production-excellence)."
+            },
+            {
+              "skill": "../../release-engineering/SKILL.md",
+              "with": "agent-production-operations",
+              "guidance": "Release engineering is shared. Route by context: change-request release planning (neckbeard) versus agent staged-rollout planning (agent-production-operations)."
+            },
+            {
+              "skill": "../../site-reliability-engineering/SKILL.md",
+              "with": "product-lifecycle",
+              "guidance": "SRE is shared. neckbeard routes to it for reliability and operational recovery of a delivered change; product-lifecycle routes to it for delivery reliability."
+            },
+            {
+              "skill": "../../site-reliability-engineering/SKILL.md",
+              "with": "production-excellence",
+              "guidance": "SRE is shared. Route by context: change-level reliability (neckbeard) versus gate-entry SLO/error-budget evidence (production-excellence)."
+            },
+            {
+              "skill": "../../site-reliability-engineering/SKILL.md",
+              "with": "agent-production-operations",
+              "guidance": "SRE is shared. Route by context: change-level reliability (neckbeard) versus agent runtime latency/cost budgets and incident handoff (agent-production-operations)."
+            }
+          ],
+          "source": "bundles/neckbeard/manifest.yaml#/conflicts"
         },
         "eval_suite": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "evals/evals.json"
+          ],
+          "source": "bundles/neckbeard/manifest.yaml#/eval_suite"
         }
       }
     },
@@ -730,157 +912,345 @@
     },
     {
       "name": "research-and-vault",
-      "derivation": "frontmatter-description-and-deferred-migration",
-      "source": "bundles/research-and-vault/SKILL.md",
+      "derivation": "manifest",
+      "source": "bundles/research-and-vault/manifest.yaml",
       "fields": {
         "purpose": {
-          "value": "Chain web research, atomic extraction, and durable knowledge capture into a repeatable workflow when the same research-to-notes sequence is needed.",
-          "source": "bundles/research-and-vault/SKILL.md#/description",
-          "derivation": "frontmatter-description"
+          "value": "Chain web research, atomic extraction, and durable knowledge capture into a repeatable research-to-note workflow: capture source URLs and dates before interpretation, extract independent atomic claims before synthesis, and write the durable note only after source coverage and gaps are explicit.",
+          "source": "bundles/research-and-vault/manifest.yaml#/purpose"
         },
         "audience": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": "Agents and knowledge workers that repeatedly need the full research-to-note sequence (web research, atomic extraction, durable capture) and want a stable order of operations with a clear handoff artifact instead of ad-hoc steps; not for single lookups or single notes, which route to the domain skill directly.",
+          "source": "bundles/research-and-vault/manifest.yaml#/audience"
         },
         "stages": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "name": "Web research",
+              "skills": [
+                "../../research-methodology/SKILL.md"
+              ]
+            },
+            {
+              "name": "Source capture",
+              "skills": [
+                "../../research-methodology/SKILL.md"
+              ]
+            },
+            {
+              "name": "Atomic extraction",
+              "skills": [
+                "../../research-methodology/SKILL.md"
+              ]
+            },
+            {
+              "name": "Synthesis and durable capture",
+              "skills": [
+                "../../research-methodology/SKILL.md"
+              ]
+            }
+          ],
+          "source": "bundles/research-and-vault/manifest.yaml#/stages"
         },
         "included_skills": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "../../research-methodology/SKILL.md"
+          ],
+          "source": "bundles/research-and-vault/manifest.yaml#/included_skills"
         },
         "prerequisites": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "artifact": "A research question or topic and access to web-research tooling",
+              "skill": "../../research-methodology/SKILL.md"
+            }
+          ],
+          "source": "bundles/research-and-vault/manifest.yaml#/prerequisites"
         },
         "outputs": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "source-capture-record",
+            "atomic-claim-extract",
+            "durable-note"
+          ],
+          "source": "bundles/research-and-vault/manifest.yaml#/outputs"
         },
         "handoffs": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "to": "research-methodology",
+              "artifact": "source-capture-record",
+              "note": "Source URLs and dates are captured before interpretation and carried into extraction and synthesis; never interpret a source before its URL and date are recorded."
+            },
+            {
+              "to": "research-methodology",
+              "artifact": "atomic-claim-extract",
+              "note": "Independent atomic claims are extracted before synthesis so the durable note can trace each claim to its source."
+            },
+            {
+              "to": "user",
+              "artifact": "durable-note",
+              "note": "The finished durable note reports its output path and any unresolved gaps in source coverage."
+            }
+          ],
+          "source": "bundles/research-and-vault/manifest.yaml#/handoffs"
         },
         "conflicts": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+
+          ],
+          "source": "bundles/research-and-vault/manifest.yaml#/conflicts"
         },
         "eval_suite": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "evals/evals.json"
+          ],
+          "source": "bundles/research-and-vault/manifest.yaml#/eval_suite"
         }
       }
     },
     {
       "name": "tailscale",
-      "derivation": "frontmatter-description-and-deferred-migration",
-      "source": "bundles/tailscale/SKILL.md",
+      "derivation": "manifest",
+      "source": "bundles/tailscale/manifest.yaml",
       "fields": {
         "purpose": {
-          "value": "Self-hosted Tailscale/Headscale ecosystem: deploy and manage a Headscale control server, configure tailscale clients, manage ACL policies, node lifecycle, subnet routing, DERP relays, and backup/migration. Use when the user mentions Tailscale, Headscale, tailnet, mesh VPN, WireGuard mesh, or self-hosted VPN infrastructure.",
-          "source": "bundles/tailscale/SKILL.md#/description",
-          "derivation": "frontmatter-description"
+          "value": "Operate a self-hosted Tailscale/Headscale ecosystem end to end: deploy and manage a Headscale control server, configure Tailscale clients, define ACL policy, manage node lifecycle, advertise subnet routes and exit nodes, operate DERP relays, and back up, restore, or migrate the control plane.",
+          "source": "bundles/tailscale/manifest.yaml#/purpose"
         },
         "audience": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": "Platform and homelab operators running self-hosted Tailscale/Headscale infrastructure; agents that need to know which sub-skill to load for deploy, policy, client, node, routing, DERP, or backup tasks in a WireGuard mesh.",
+          "source": "bundles/tailscale/manifest.yaml#/audience"
         },
         "stages": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "name": "Deploy control server",
+              "skills": [
+                "skills/headscale-deploy/SKILL.md"
+              ]
+            },
+            {
+              "name": "Policy",
+              "skills": [
+                "skills/tailnet-policy/SKILL.md"
+              ]
+            },
+            {
+              "name": "Client connectivity",
+              "skills": [
+                "skills/tailscale-client/SKILL.md"
+              ]
+            },
+            {
+              "name": "Node lifecycle",
+              "skills": [
+                "skills/headscale-node-lifecycle/SKILL.md"
+              ]
+            },
+            {
+              "name": "Routing",
+              "skills": [
+                "skills/headscale-routing/SKILL.md"
+              ]
+            },
+            {
+              "name": "DERP relays",
+              "skills": [
+                "skills/headscale-derp/SKILL.md"
+              ]
+            },
+            {
+              "name": "Backup and restore",
+              "skills": [
+                "skills/headscale-backup/SKILL.md"
+              ]
+            }
+          ],
+          "source": "bundles/tailscale/manifest.yaml#/stages"
         },
         "included_skills": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "skills/headscale-deploy/SKILL.md",
+            "skills/tailnet-policy/SKILL.md",
+            "skills/tailscale-client/SKILL.md",
+            "skills/headscale-node-lifecycle/SKILL.md",
+            "skills/headscale-routing/SKILL.md",
+            "skills/headscale-derp/SKILL.md",
+            "skills/headscale-backup/SKILL.md"
+          ],
+          "source": "bundles/tailscale/manifest.yaml#/included_skills"
         },
         "prerequisites": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "artifact": "A Linux host and install target for the Headscale control server",
+              "skill": "skills/headscale-deploy/SKILL.md"
+            },
+            {
+              "artifact": "HEADSCALE_URL and HEADSCALE_API_KEY credentials",
+              "skill": "skills/headscale-deploy/SKILL.md"
+            },
+            {
+              "artifact": "A running Headscale instance with the headscale CLI available",
+              "skill": "skills/headscale-deploy/SKILL.md"
+            }
+          ],
+          "source": "bundles/tailscale/manifest.yaml#/prerequisites"
         },
         "outputs": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "headscale-server",
+            "tailnet-policy",
+            "registered-nodes",
+            "routed-networks",
+            "derp-map",
+            "backup-archive",
+            "restored-instance"
+          ],
+          "source": "bundles/tailscale/manifest.yaml#/outputs"
         },
         "handoffs": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "to": "tailnet-policy",
+              "artifact": "headscale-server",
+              "note": "A running control server is required before ACL policy is applied and before the tailnet opens to other users."
+            },
+            {
+              "to": "headscale-node-lifecycle",
+              "artifact": "headscale-server",
+              "note": "Nodes are registered, approved, tagged, and decommissioned against the running control server."
+            },
+            {
+              "to": "headscale-backup",
+              "artifact": "headscale-server",
+              "note": "Backups (sqlite + config + policy + certs) run regularly against the production control server; restore re-creates the instance from the archive."
+            },
+            {
+              "to": "user",
+              "artifact": "backup-archive",
+              "note": "The backup archive is the disaster-recovery artifact for the tailnet; keep it off the control server host."
+            }
+          ],
+          "source": "bundles/tailscale/manifest.yaml#/handoffs"
         },
         "conflicts": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+
+          ],
+          "source": "bundles/tailscale/manifest.yaml#/conflicts"
         },
         "eval_suite": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "evals/evals.json"
+          ],
+          "source": "bundles/tailscale/manifest.yaml#/eval_suite"
         }
       }
     },
     {
       "name": "workflow-architect",
-      "derivation": "frontmatter-description-and-deferred-migration",
-      "source": "bundles/workflow-architect/SKILL.md",
+      "derivation": "manifest",
+      "source": "bundles/workflow-architect/manifest.yaml",
       "fields": {
         "purpose": {
-          "value": "Discover your actual workflow through conversation or observation, then generate a tailored skills bundle that encodes it as loadable agent skills with trigger conditions. Use when you want to understand your own process, formalize it, or share it with collaborators. Also use when a session feels aimless — this skill gives it structure.",
-          "source": "bundles/workflow-architect/SKILL.md#/description",
-          "derivation": "frontmatter-description"
+          "value": "Discover a user's actual workflow through active interrogation or passive observation, then generate a tailored Agent Skills bundle that encodes it as loadable skills with trigger conditions, a decision map, a manifest, and an optional kanban board — turning a session that feels aimless into structure.",
+          "source": "bundles/workflow-architect/manifest.yaml#/purpose"
         },
         "audience": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": "Users and agents that want to formalize how they work — understand their own process, encode it as trigger-driven skills they can reuse, or share it with collaborators. Not for single factual questions or tasks already owned by a more specific skill.",
+          "source": "bundles/workflow-architect/manifest.yaml#/audience"
         },
         "stages": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "name": "Active interview",
+              "skills": [
+                "skills/interviewer/SKILL.md"
+              ]
+            },
+            {
+              "name": "Passive observation",
+              "skills": [
+                "skills/observer/SKILL.md"
+              ]
+            },
+            {
+              "name": "Synthesis and generation",
+              "skills": [
+                "skills/bundle-builder/SKILL.md"
+              ]
+            }
+          ],
+          "source": "bundles/workflow-architect/manifest.yaml#/stages"
         },
         "included_skills": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "skills/interviewer/SKILL.md",
+            "skills/observer/SKILL.md",
+            "skills/bundle-builder/SKILL.md"
+          ],
+          "source": "bundles/workflow-architect/manifest.yaml#/included_skills"
         },
         "prerequisites": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "artifact": "Session context with enough turns for observation (or user answers for interview)",
+              "skill": "skills/observer/SKILL.md"
+            },
+            {
+              "artifact": "Convergence on workflow phases, branching signals, and tool preferences",
+              "skill": "skills/interviewer/SKILL.md"
+            }
+          ],
+          "source": "bundles/workflow-architect/manifest.yaml#/prerequisites"
         },
         "outputs": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "skills-bundle",
+            "decision-map",
+            "manifest",
+            "kanban-board"
+          ],
+          "source": "bundles/workflow-architect/manifest.yaml#/outputs"
         },
         "handoffs": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            {
+              "to": "user",
+              "artifact": "skills-bundle",
+              "note": "The generated bundle is written to the host skill directory and registered so the umbrella and sub-skills load on trigger phrases."
+            },
+            {
+              "to": "user",
+              "artifact": "decision-map",
+              "note": "The Mermaid decision map visualizes workflow phases and branching signals for review and sharing."
+            },
+            {
+              "to": "user",
+              "artifact": "manifest",
+              "note": "The generated manifest maps skill names to trigger conditions, entry points, and transition signals for the bundle."
+            },
+            {
+              "to": "user",
+              "artifact": "kanban-board",
+              "note": "The kanban board is included only when the workflow follows a predictable linear path where WIP limits and lane transitions add value."
+            }
+          ],
+          "source": "bundles/workflow-architect/manifest.yaml#/handoffs"
         },
         "conflicts": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+
+          ],
+          "source": "bundles/workflow-architect/manifest.yaml#/conflicts"
         },
         "eval_suite": {
-          "value": "migration deferred — see docs/bundle-manifest-design.md §Migration path",
-          "source": "docs/bundle-manifest-design.md#migration-path",
-          "derivation": "migration-deferred"
+          "value": [
+            "evals/evals.json"
+          ],
+          "source": "bundles/workflow-architect/manifest.yaml#/eval_suite"
         }
       }
     }

--- a/docs/lifecycle-capability-matrix.md
+++ b/docs/lifecycle-capability-matrix.md
@@ -11,12 +11,12 @@ the migration path, and the field definitions. Regenerate with
 | Bundle | Purpose | Audience | Lifecycle stages | Included skills | Prerequisites | Outputs | Handoffs | Conflicts | Eval suite |
 |---|---|---|---|---|---|---|---|---|---|
 | agent-production-operations | Operate an evaluated agent with tools and authority in production through a runtime control plane covering versioning, staged rollout, fallback, cost and latency budgets, tool health, human escalation, disablement, and trace-to-eval feedback. | Agent operators and platform teams running evaluated agents with tools and delegated authority in production; agents that need the runtime control decisions between evaluation, release, SRE, security, and platform specialists. | Contract definition → Versioning and rollout planning → Staged rollout → Runtime monitoring → Trace-to-eval feedback → Learning and disablement | agent-evals-and-observability, release-engineering, site-reliability-engineering, secure-software-engineering, platform-engineering, production-readiness, incident-learning, privacy-engineering | Agent evaluation results and observability instrumentation(agent-evals-and-observability); Production-readiness evidence (go/no-go/defer/exception outcomes)(production-readiness); Incident-learning records (verified closure, follow-up work map)(incident-learning); Release pipeline and artifact promotion baseline(release-engineering) | agent-production-contract, runtime-control-plan, staged-rollout-plan, tool-authority-health-record, trace-to-eval-feedback-loop, disablement-record | staged-rollout-plan → release-engineering; trace-to-eval-feedback-loop → agent-evals-and-observability; tool-authority-health-record → incident-learning; disablement-record → human operator | production-readiness (with production-excellence); production-readiness (with product-lifecycle); release-engineering (with production-excellence); release-engineering (with product-lifecycle); site-reliability-engineering (with production-excellence); site-reliability-engineering (with product-lifecycle); secure-software-engineering (with production-excellence); secure-software-engineering (with product-lifecycle); platform-engineering (with production-excellence); platform-engineering (with product-lifecycle); incident-learning (with production-excellence); privacy-engineering (with product-lifecycle) | evals/evals.json |
-| neckbeard | Use when asked to fix, build, refactor, review, verify, or release software and the work is non-trivial — including delivering a change request (issue, ticket, or request) from intake through planning, gates, implementation, review, verified PR, and authorized post-merge release. neckbeard routes the change through framing, discovery, design, implementation, review, verification, delivery, and learning — choosing the smallest *safe* intervention, proving it at the real delivery boundary, and leaving an inspectable evidence ledger. For change-request / issue-to-PR work, conditionally loads a 9-phase journey with gates, delivery packet, and lifecycle integration. Composes specialist catalog skills rather than replacing them. Not a persona, not a '10x developer' prompt, not a LOC-minimizer. The journey is not loaded for plain fixes, refactors, or reviews that lack an issue/ticket trajectory. | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path |
+| neckbeard | A disciplined SDLC delivery operating model for non-trivial software change — fix, build, refactor, review, verify, or release — that routes the work through framing, discovery, design, implementation, review, verification, delivery, and learning, choosing the smallest *safe* intervention, proving it at the real delivery boundary, and leaving an inspectable evidence ledger. | Software engineers and agents delivering non-trivial software changes (bug fixes, features, refactors, reviews, releases) that need a bounded, stage-aware path to a defensible 'done' with recorded evidence; teams running issue-to-PR change-request journeys with gates and an authorized release. | Intake and framing → Current-state discovery → Design → Specification → Test planning → Implementation → Review and verification → Readiness and release | product-discovery, software-architecture-analysis, systematic-debugging, api-design-and-evolution, product-design-and-ux, spec-driven-development, qa-methodology, secure-software-engineering, web-accessibility, verification-methodology, technical-documentation, release-engineering, site-reliability-engineering | A non-trivial change request, issue, or task with a verifiable contract; Current-state evidence (repository, tests, config, recent history)(software-architecture-analysis); Change contract and evidence ledger entries(verification-methodology) | change-contract, evidence-ledger, delivery-packet, implementation-plan, verification-report, release-record | verification-report → verification-methodology; release-record → release-engineering; delivery-packet → human reviewer; evidence-ledger → next change (via evidence ledger) | product-discovery (with product-lifecycle); product-design-and-ux (with product-lifecycle); spec-driven-development (with product-lifecycle); qa-methodology (with product-lifecycle); qa-methodology (with production-excellence); secure-software-engineering (with product-lifecycle); secure-software-engineering (with production-excellence); secure-software-engineering (with agent-production-operations); verification-methodology (with product-lifecycle); verification-methodology (with production-excellence); release-engineering (with product-lifecycle); release-engineering (with production-excellence); release-engineering (with agent-production-operations); site-reliability-engineering (with product-lifecycle); site-reliability-engineering (with production-excellence); site-reliability-engineering (with agent-production-operations) | evals/evals.json |
 | product-lifecycle | Route a product through its full lifecycle — discovery, strategy and portfolio choice, roadmap, UX and requirements, experimentation, delivery handoff, adoption, success, and lifecycle review — by composing existing specialist product skills with phase-entry evidence, handoff artifacts, and escalation rules. | Product managers, product operations, and portfolio teams navigating a product across multiple lifecycle phases; agents that need to know which specialist skill to load at each phase and what evidence to hand off to the next phase. | Discovery → Strategy and portfolio choice → Roadmap → UX and requirements → Experimentation → Delivery handoff → Adoption → Success → Lifecycle review | product-discovery, product-strategy, strategy-frameworks, product-roadmapping-and-portfolio, product-design-and-ux, product-experimentation, implementation-planning, production-readiness, release-engineering, product-adoption, product-analytics-and-measurement, conditional-customer-success, product-lifecycle-learning, product-methodology, product-operations-and-governance, financial-modeling, go-to-market, data-scientist, spec-driven-development, privacy-engineering, secure-software-engineering, verification-methodology, qa-methodology, site-reliability-engineering, platform-engineering, neckbeard | Product idea, market signal, or stakeholder request; Problem statement and discovery log(product-discovery); Strategic assessment and portfolio decision(product-strategy); Roadmap entry and bet record(product-roadmapping-and-portfolio); UX contracts and acceptance criteria(product-design-and-ux); Experiment readout and assumptions register(product-experimentation) | lifecycle-evidence-ledger, problem-statement, strategic-assessment, roadmap-entry, interface-contracts, experiment-brief, implementation-plan, readiness-verdict, release-plan, adoption-plan, outcome-measurement, outcome-review, lifecycle-decision | readiness-verdict → production-excellence bundle; implementation-plan → delivery team; lifecycle-evidence-ledger → next phase (via evidence ledger); lifecycle-decision → product-lifecycle-learning | production-readiness (with production-excellence); production-readiness (with agent-production-operations); release-engineering (with production-excellence); release-engineering (with agent-production-operations); site-reliability-engineering (with production-excellence); site-reliability-engineering (with agent-production-operations); secure-software-engineering (with production-excellence); secure-software-engineering (with agent-production-operations); platform-engineering (with production-excellence); platform-engineering (with agent-production-operations); privacy-engineering (with agent-production-operations); qa-methodology (with production-excellence); verification-methodology (with production-excellence) | evals/evals.json |
 | production-excellence | Route cross-domain production evidence (readiness, migration, recovery, capacity/cost, incident-learning) into a launch or operational decision — go, no-go, defer, exception, or escalation — with an accountable owner and a post-launch learning path. | Service owners, SRE, release, platform, security, data, and QA teams coordinating a production change; agents assembling cross-domain production evidence into a defensible launch decision without re-deriving specialist runbooks. | Cross-domain evidence assembly → Gate evaluation → Operational handoff → Post-launch learning | production-readiness, migration-engineering, resilience-and-recovery, capacity-and-cost-engineering, incident-learning, site-reliability-engineering, release-engineering, platform-engineering, secure-software-engineering, data-engineering, qa-methodology, verification-methodology | Readiness review evidence packet (risk-scaled, 11 categories)(production-readiness); Migration plan, compatibility windows, and reconciliation evidence(migration-engineering); Resilience and recovery evidence (RTO/RPO, restore tests, game days)(resilience-and-recovery); Capacity and cost model evidence (demand, scaling, unit cost)(capacity-and-cost-engineering); Incident history, causal hypotheses, and verified-closure records(incident-learning); SLO and error-budget status(site-reliability-engineering); Release plan and rollback strategy(release-engineering) | gate-decision, operational-handoff-record, accountable-owner-record, evidence-gap-register | operational-handoff-record → incident-learning; operational-handoff-record → product-lifecycle-learning; gate-decision → agent-production-operations; accountable-owner-record → service owner | production-readiness (with product-lifecycle); production-readiness (with agent-production-operations); release-engineering (with product-lifecycle); release-engineering (with agent-production-operations); site-reliability-engineering (with product-lifecycle); site-reliability-engineering (with agent-production-operations); secure-software-engineering (with product-lifecycle); secure-software-engineering (with agent-production-operations); platform-engineering (with product-lifecycle); platform-engineering (with agent-production-operations); incident-learning (with agent-production-operations); qa-methodology (with product-lifecycle); verification-methodology (with product-lifecycle) | evals/evals.json |
-| research-and-vault | Chain web research, atomic extraction, and durable knowledge capture into a repeatable workflow when the same research-to-notes sequence is needed. | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path |
-| tailscale | Self-hosted Tailscale/Headscale ecosystem: deploy and manage a Headscale control server, configure tailscale clients, manage ACL policies, node lifecycle, subnet routing, DERP relays, and backup/migration. Use when the user mentions Tailscale, Headscale, tailnet, mesh VPN, WireGuard mesh, or self-hosted VPN infrastructure. | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path |
-| workflow-architect | Discover your actual workflow through conversation or observation, then generate a tailored skills bundle that encodes it as loadable agent skills with trigger conditions. Use when you want to understand your own process, formalize it, or share it with collaborators. Also use when a session feels aimless — this skill gives it structure. | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path | migration deferred — see docs/bundle-manifest-design.md §Migration path |
+| research-and-vault | Chain web research, atomic extraction, and durable knowledge capture into a repeatable research-to-note workflow: capture source URLs and dates before interpretation, extract independent atomic claims before synthesis, and write the durable note only after source coverage and gaps are explicit. | Agents and knowledge workers that repeatedly need the full research-to-note sequence (web research, atomic extraction, durable capture) and want a stable order of operations with a clear handoff artifact instead of ad-hoc steps; not for single lookups or single notes, which route to the domain skill directly. | Web research → Source capture → Atomic extraction → Synthesis and durable capture | research-methodology | A research question or topic and access to web-research tooling(research-methodology) | source-capture-record, atomic-claim-extract, durable-note | source-capture-record → research-methodology; atomic-claim-extract → research-methodology; durable-note → user | none declared | evals/evals.json |
+| tailscale | Operate a self-hosted Tailscale/Headscale ecosystem end to end: deploy and manage a Headscale control server, configure Tailscale clients, define ACL policy, manage node lifecycle, advertise subnet routes and exit nodes, operate DERP relays, and back up, restore, or migrate the control plane. | Platform and homelab operators running self-hosted Tailscale/Headscale infrastructure; agents that need to know which sub-skill to load for deploy, policy, client, node, routing, DERP, or backup tasks in a WireGuard mesh. | Deploy control server → Policy → Client connectivity → Node lifecycle → Routing → DERP relays → Backup and restore | headscale-deploy, tailnet-policy, tailscale-client, headscale-node-lifecycle, headscale-routing, headscale-derp, headscale-backup | A Linux host and install target for the Headscale control server(headscale-deploy); HEADSCALE_URL and HEADSCALE_API_KEY credentials(headscale-deploy); A running Headscale instance with the headscale CLI available(headscale-deploy) | headscale-server, tailnet-policy, registered-nodes, routed-networks, derp-map, backup-archive, restored-instance | headscale-server → tailnet-policy; headscale-server → headscale-node-lifecycle; headscale-server → headscale-backup; backup-archive → user | none declared | evals/evals.json |
+| workflow-architect | Discover a user's actual workflow through active interrogation or passive observation, then generate a tailored Agent Skills bundle that encodes it as loadable skills with trigger conditions, a decision map, a manifest, and an optional kanban board — turning a session that feels aimless into structure. | Users and agents that want to formalize how they work — understand their own process, encode it as trigger-driven skills they can reuse, or share it with collaborators. Not for single factual questions or tasks already owned by a more specific skill. | Active interview → Passive observation → Synthesis and generation | interviewer, observer, bundle-builder | Session context with enough turns for observation (or user answers for interview)(observer); Convergence on workflow phases, branching signals, and tool preferences(interviewer) | skills-bundle, decision-map, manifest, kanban-board | skills-bundle → user; decision-map → user; manifest → user; kanban-board → user | none declared | evals/evals.json |
 
 ## Details
 
@@ -69,16 +69,60 @@ the migration path, and the field definitions. Regenerate with
 
 ### neckbeard
 
-- Derivation: `frontmatter-description-and-deferred-migration` — source: `bundles/neckbeard/SKILL.md`
-- **Purpose:** Use when asked to fix, build, refactor, review, verify, or release software and the work is non-trivial — including delivering a change request (issue, ticket, or request) from intake through planning, gates, implementation, review, verified PR, and authorized post-merge release. neckbeard routes the change through framing, discovery, design, implementation, review, verification, delivery, and learning — choosing the smallest *safe* intervention, proving it at the real delivery boundary, and leaving an inspectable evidence ledger. For change-request / issue-to-PR work, conditionally loads a 9-phase journey with gates, delivery packet, and lifecycle integration. Composes specialist catalog skills rather than replacing them. Not a persona, not a '10x developer' prompt, not a LOC-minimizer. The journey is not loaded for plain fixes, refactors, or reviews that lack an issue/ticket trajectory.
-- **Audience:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Stages:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Included skills:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Prerequisites:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Outputs:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Handoffs:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Conflicts:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Eval suite:** migration deferred — see docs/bundle-manifest-design.md §Migration path
+- Derivation: `manifest` — source: `bundles/neckbeard/manifest.yaml`
+- **Purpose:** A disciplined SDLC delivery operating model for non-trivial software change — fix, build, refactor, review, verify, or release — that routes the work through framing, discovery, design, implementation, review, verification, delivery, and learning, choosing the smallest *safe* intervention, proving it at the real delivery boundary, and leaving an inspectable evidence ledger.
+- **Audience:** Software engineers and agents delivering non-trivial software changes (bug fixes, features, refactors, reviews, releases) that need a bounded, stage-aware path to a defensible 'done' with recorded evidence; teams running issue-to-PR change-request journeys with gates and an authorized release.
+- **Stages (ordered):**
+  1. Intake and framing — product-discovery (`../../product-discovery/SKILL.md`)
+  2. Current-state discovery — software-architecture-analysis (`../../software-architecture-analysis/SKILL.md`), systematic-debugging (`../../systematic-debugging/SKILL.md`)
+  3. Design — api-design-and-evolution (`../../api-design-and-evolution/SKILL.md`), product-design-and-ux (`../../product-design-and-ux/SKILL.md`)
+  4. Specification — spec-driven-development (`../../spec-driven-development/SKILL.md`)
+  5. Test planning — qa-methodology (`../../qa-methodology/SKILL.md`)
+  6. Implementation — secure-software-engineering (`../../secure-software-engineering/SKILL.md`), web-accessibility (`../../web-accessibility/SKILL.md`)
+  7. Review and verification — verification-methodology (`../../verification-methodology/SKILL.md`), technical-documentation (`../../technical-documentation/SKILL.md`)
+  8. Readiness and release — release-engineering (`../../release-engineering/SKILL.md`), site-reliability-engineering (`../../site-reliability-engineering/SKILL.md`)
+- **Included skills:**
+  - product-discovery (`../../product-discovery/SKILL.md`)
+  - software-architecture-analysis (`../../software-architecture-analysis/SKILL.md`)
+  - systematic-debugging (`../../systematic-debugging/SKILL.md`)
+  - api-design-and-evolution (`../../api-design-and-evolution/SKILL.md`)
+  - product-design-and-ux (`../../product-design-and-ux/SKILL.md`)
+  - spec-driven-development (`../../spec-driven-development/SKILL.md`)
+  - qa-methodology (`../../qa-methodology/SKILL.md`)
+  - secure-software-engineering (`../../secure-software-engineering/SKILL.md`)
+  - web-accessibility (`../../web-accessibility/SKILL.md`)
+  - verification-methodology (`../../verification-methodology/SKILL.md`)
+  - technical-documentation (`../../technical-documentation/SKILL.md`)
+  - release-engineering (`../../release-engineering/SKILL.md`)
+  - site-reliability-engineering (`../../site-reliability-engineering/SKILL.md`)
+- **Prerequisites:**
+  - A non-trivial change request, issue, or task with a verifiable contract
+  - Current-state evidence (repository, tests, config, recent history) — via software-architecture-analysis (`../../software-architecture-analysis/SKILL.md`)
+  - Change contract and evidence ledger entries — via verification-methodology (`../../verification-methodology/SKILL.md`)
+- **Outputs:** change-contract, evidence-ledger, delivery-packet, implementation-plan, verification-report, release-record
+- **Handoffs:**
+  - verification-report → verification-methodology — The verification report records the declared verification target and the boundary actually exercised; verdicts bind to the exact head and never claim a boundary that was not checked.
+  - release-record → release-engineering — Release planning, versioning, pipeline promotion, readiness, and authorized release routing for the delivered change.
+  - delivery-packet → human reviewer — Change-request journeys hand the delivery packet — gates and evidence — to the required review before merge; a timed-out review is inconclusive, not a reason to launch repeated review rounds.
+  - evidence-ledger → next change (via evidence ledger) — Each run emits a compact evidence record (intent, inspected artifacts, assumptions, rejected alternatives, checks run, observed outputs, unverified boundaries) that carries learning into the next change.
+- **Conflicts:**
+  - product-discovery (`../../product-discovery/SKILL.md`) with product-lifecycle — Product discovery is shared. Route by context: neckbeard loads it for intake and framing of a change request; product-lifecycle owns the full discovery phase of a product lifecycle.
+  - product-design-and-ux (`../../product-design-and-ux/SKILL.md`) with product-lifecycle — Product design is shared. neckbeard loads it for user-facing behavior, interaction, and information architecture during design; product-lifecycle owns the UX and requirements phase of a product.
+  - spec-driven-development (`../../spec-driven-development/SKILL.md`) with product-lifecycle — Specification is shared. neckbeard uses it for formal specification and phase gates on a change request; product-lifecycle uses it for requirements and acceptance criteria in its lifecycle phases.
+  - qa-methodology (`../../qa-methodology/SKILL.md`) with product-lifecycle — QA methodology is shared. neckbeard loads it for test strategy and regression gates on a change; product-lifecycle routes to it for phase 6 quality gates.
+  - qa-methodology (`../../qa-methodology/SKILL.md`) with production-excellence — QA methodology is shared. neckbeard loads it for change-request test planning; production-excellence uses it for launch verification evidence.
+  - secure-software-engineering (`../../secure-software-engineering/SKILL.md`) with product-lifecycle — Security engineering is shared. Route by context: change-level security review and threat modeling (neckbeard) versus lifecycle-phase security needs (product-lifecycle).
+  - secure-software-engineering (`../../secure-software-engineering/SKILL.md`) with production-excellence — Security engineering is shared. Route by context: change-level security review (neckbeard) versus launch-gate security evidence (production-excellence).
+  - secure-software-engineering (`../../secure-software-engineering/SKILL.md`) with agent-production-operations — Security engineering is shared. Route by context: change-level security review (neckbeard) versus agent authority contracts and disablement security (agent-production-operations).
+  - verification-methodology (`../../verification-methodology/SKILL.md`) with product-lifecycle — Verification methodology is shared. neckbeard requires it to exercise the declared verification boundary on a change; product-lifecycle uses it at every phase gate for evidence.
+  - verification-methodology (`../../verification-methodology/SKILL.md`) with production-excellence — Verification methodology is shared. neckbeard uses it for change-request verification verdicts; production-excellence uses it for boundary labeling of launch evidence.
+  - release-engineering (`../../release-engineering/SKILL.md`) with product-lifecycle — Release engineering is shared. Route by context: change-request release planning (neckbeard) versus lifecycle delivery handoff (product-lifecycle).
+  - release-engineering (`../../release-engineering/SKILL.md`) with production-excellence — Release engineering is shared. Route by context: change-request release planning (neckbeard) versus launch-gate release evidence (production-excellence).
+  - release-engineering (`../../release-engineering/SKILL.md`) with agent-production-operations — Release engineering is shared. Route by context: change-request release planning (neckbeard) versus agent staged-rollout planning (agent-production-operations).
+  - site-reliability-engineering (`../../site-reliability-engineering/SKILL.md`) with product-lifecycle — SRE is shared. neckbeard routes to it for reliability and operational recovery of a delivered change; product-lifecycle routes to it for delivery reliability.
+  - site-reliability-engineering (`../../site-reliability-engineering/SKILL.md`) with production-excellence — SRE is shared. Route by context: change-level reliability (neckbeard) versus gate-entry SLO/error-budget evidence (production-excellence).
+  - site-reliability-engineering (`../../site-reliability-engineering/SKILL.md`) with agent-production-operations — SRE is shared. Route by context: change-level reliability (neckbeard) versus agent runtime latency/cost budgets and incident handoff (agent-production-operations).
+- **Eval suite:** evals/evals.json
 
 ### product-lifecycle
 
@@ -206,39 +250,81 @@ the migration path, and the field definitions. Regenerate with
 
 ### research-and-vault
 
-- Derivation: `frontmatter-description-and-deferred-migration` — source: `bundles/research-and-vault/SKILL.md`
-- **Purpose:** Chain web research, atomic extraction, and durable knowledge capture into a repeatable workflow when the same research-to-notes sequence is needed.
-- **Audience:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Stages:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Included skills:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Prerequisites:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Outputs:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Handoffs:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Conflicts:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Eval suite:** migration deferred — see docs/bundle-manifest-design.md §Migration path
+- Derivation: `manifest` — source: `bundles/research-and-vault/manifest.yaml`
+- **Purpose:** Chain web research, atomic extraction, and durable knowledge capture into a repeatable research-to-note workflow: capture source URLs and dates before interpretation, extract independent atomic claims before synthesis, and write the durable note only after source coverage and gaps are explicit.
+- **Audience:** Agents and knowledge workers that repeatedly need the full research-to-note sequence (web research, atomic extraction, durable capture) and want a stable order of operations with a clear handoff artifact instead of ad-hoc steps; not for single lookups or single notes, which route to the domain skill directly.
+- **Stages (ordered):**
+  1. Web research — research-methodology (`../../research-methodology/SKILL.md`)
+  2. Source capture — research-methodology (`../../research-methodology/SKILL.md`)
+  3. Atomic extraction — research-methodology (`../../research-methodology/SKILL.md`)
+  4. Synthesis and durable capture — research-methodology (`../../research-methodology/SKILL.md`)
+- **Included skills:**
+  - research-methodology (`../../research-methodology/SKILL.md`)
+- **Prerequisites:**
+  - A research question or topic and access to web-research tooling — via research-methodology (`../../research-methodology/SKILL.md`)
+- **Outputs:** source-capture-record, atomic-claim-extract, durable-note
+- **Handoffs:**
+  - source-capture-record → research-methodology — Source URLs and dates are captured before interpretation and carried into extraction and synthesis; never interpret a source before its URL and date are recorded.
+  - atomic-claim-extract → research-methodology — Independent atomic claims are extracted before synthesis so the durable note can trace each claim to its source.
+  - durable-note → user — The finished durable note reports its output path and any unresolved gaps in source coverage.
+- **Conflicts:** none declared
+- **Eval suite:** evals/evals.json
 
 ### tailscale
 
-- Derivation: `frontmatter-description-and-deferred-migration` — source: `bundles/tailscale/SKILL.md`
-- **Purpose:** Self-hosted Tailscale/Headscale ecosystem: deploy and manage a Headscale control server, configure tailscale clients, manage ACL policies, node lifecycle, subnet routing, DERP relays, and backup/migration. Use when the user mentions Tailscale, Headscale, tailnet, mesh VPN, WireGuard mesh, or self-hosted VPN infrastructure.
-- **Audience:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Stages:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Included skills:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Prerequisites:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Outputs:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Handoffs:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Conflicts:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Eval suite:** migration deferred — see docs/bundle-manifest-design.md §Migration path
+- Derivation: `manifest` — source: `bundles/tailscale/manifest.yaml`
+- **Purpose:** Operate a self-hosted Tailscale/Headscale ecosystem end to end: deploy and manage a Headscale control server, configure Tailscale clients, define ACL policy, manage node lifecycle, advertise subnet routes and exit nodes, operate DERP relays, and back up, restore, or migrate the control plane.
+- **Audience:** Platform and homelab operators running self-hosted Tailscale/Headscale infrastructure; agents that need to know which sub-skill to load for deploy, policy, client, node, routing, DERP, or backup tasks in a WireGuard mesh.
+- **Stages (ordered):**
+  1. Deploy control server — headscale-deploy (`skills/headscale-deploy/SKILL.md`)
+  2. Policy — tailnet-policy (`skills/tailnet-policy/SKILL.md`)
+  3. Client connectivity — tailscale-client (`skills/tailscale-client/SKILL.md`)
+  4. Node lifecycle — headscale-node-lifecycle (`skills/headscale-node-lifecycle/SKILL.md`)
+  5. Routing — headscale-routing (`skills/headscale-routing/SKILL.md`)
+  6. DERP relays — headscale-derp (`skills/headscale-derp/SKILL.md`)
+  7. Backup and restore — headscale-backup (`skills/headscale-backup/SKILL.md`)
+- **Included skills:**
+  - headscale-deploy (`skills/headscale-deploy/SKILL.md`)
+  - tailnet-policy (`skills/tailnet-policy/SKILL.md`)
+  - tailscale-client (`skills/tailscale-client/SKILL.md`)
+  - headscale-node-lifecycle (`skills/headscale-node-lifecycle/SKILL.md`)
+  - headscale-routing (`skills/headscale-routing/SKILL.md`)
+  - headscale-derp (`skills/headscale-derp/SKILL.md`)
+  - headscale-backup (`skills/headscale-backup/SKILL.md`)
+- **Prerequisites:**
+  - A Linux host and install target for the Headscale control server — via headscale-deploy (`skills/headscale-deploy/SKILL.md`)
+  - HEADSCALE_URL and HEADSCALE_API_KEY credentials — via headscale-deploy (`skills/headscale-deploy/SKILL.md`)
+  - A running Headscale instance with the headscale CLI available — via headscale-deploy (`skills/headscale-deploy/SKILL.md`)
+- **Outputs:** headscale-server, tailnet-policy, registered-nodes, routed-networks, derp-map, backup-archive, restored-instance
+- **Handoffs:**
+  - headscale-server → tailnet-policy — A running control server is required before ACL policy is applied and before the tailnet opens to other users.
+  - headscale-server → headscale-node-lifecycle — Nodes are registered, approved, tagged, and decommissioned against the running control server.
+  - headscale-server → headscale-backup — Backups (sqlite + config + policy + certs) run regularly against the production control server; restore re-creates the instance from the archive.
+  - backup-archive → user — The backup archive is the disaster-recovery artifact for the tailnet; keep it off the control server host.
+- **Conflicts:** none declared
+- **Eval suite:** evals/evals.json
 
 ### workflow-architect
 
-- Derivation: `frontmatter-description-and-deferred-migration` — source: `bundles/workflow-architect/SKILL.md`
-- **Purpose:** Discover your actual workflow through conversation or observation, then generate a tailored skills bundle that encodes it as loadable agent skills with trigger conditions. Use when you want to understand your own process, formalize it, or share it with collaborators. Also use when a session feels aimless — this skill gives it structure.
-- **Audience:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Stages:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Included skills:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Prerequisites:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Outputs:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Handoffs:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Conflicts:** migration deferred — see docs/bundle-manifest-design.md §Migration path
-- **Eval suite:** migration deferred — see docs/bundle-manifest-design.md §Migration path
+- Derivation: `manifest` — source: `bundles/workflow-architect/manifest.yaml`
+- **Purpose:** Discover a user's actual workflow through active interrogation or passive observation, then generate a tailored Agent Skills bundle that encodes it as loadable skills with trigger conditions, a decision map, a manifest, and an optional kanban board — turning a session that feels aimless into structure.
+- **Audience:** Users and agents that want to formalize how they work — understand their own process, encode it as trigger-driven skills they can reuse, or share it with collaborators. Not for single factual questions or tasks already owned by a more specific skill.
+- **Stages (ordered):**
+  1. Active interview — interviewer (`skills/interviewer/SKILL.md`)
+  2. Passive observation — observer (`skills/observer/SKILL.md`)
+  3. Synthesis and generation — bundle-builder (`skills/bundle-builder/SKILL.md`)
+- **Included skills:**
+  - interviewer (`skills/interviewer/SKILL.md`)
+  - observer (`skills/observer/SKILL.md`)
+  - bundle-builder (`skills/bundle-builder/SKILL.md`)
+- **Prerequisites:**
+  - Session context with enough turns for observation (or user answers for interview) — via observer (`skills/observer/SKILL.md`)
+  - Convergence on workflow phases, branching signals, and tool preferences — via interviewer (`skills/interviewer/SKILL.md`)
+- **Outputs:** skills-bundle, decision-map, manifest, kanban-board
+- **Handoffs:**
+  - skills-bundle → user — The generated bundle is written to the host skill directory and registered so the umbrella and sub-skills load on trigger phrases.
+  - decision-map → user — The Mermaid decision map visualizes workflow phases and branching signals for review and sharing.
+  - manifest → user — The generated manifest maps skill names to trigger conditions, entry points, and transition signals for the bundle.
+  - kanban-board → user — The kanban board is included only when the workflow follows a predictable linear path where WIP limits and lane transitions add value.
+- **Conflicts:** none declared
+- **Eval suite:** evals/evals.json


### PR DESCRIPTION
## Summary

Completes the bundle-manifest migration for the four legacy bundles (issue #236). Adds a schema-v1 `manifest.yaml` to `bundles/neckbeard`, `bundles/research-and-vault`, `bundles/tailscale`, and `bundles/workflow-architect` per `docs/bundle-manifest-design.md` (schema_version + bundle_name identity + version pin; purpose/audience/stages/included_skills/prerequisites/outputs/handoffs/conflicts/eval_suite).

- `eval_suite` resolves to real eval manifests: neckbeard points at its existing `evals/evals.json`; research-and-vault, tailscale, and workflow-architect ship new schema-valid `evals/evals.json` (6 cases each) and point at them.
- Cross-bundle overlaps on shared specialists (e.g., release-engineering, site-reliability-engineering, verification-methodology) are declared in the neckbeard manifest's `conflicts` field.
- Regenerated `docs/lifecycle-capability-matrix.md` and `.json` with `ruby scripts/gen-lifecycle-matrix.rb --write`; all 7 rows are now manifest-derived, no "migration deferred" markers remain.

Closes #236

## Validation

- [x] `ruby scripts/validate-bundles.rb` → `Validated 7 bundle manifest(s).`
- [x] `ruby scripts/test-validate-bundles.rb` → `14 runs, 307 assertions, 0 failures, 0 errors, 0 skips`
- [x] `ruby scripts/gen-lifecycle-matrix.rb` (check mode) → `lifecycle capability matrix is current (7 bundles).`
- [x] `ruby scripts/validate-lifecycle-matrix.rb` → `Validated lifecycle capability matrix (7 bundle(s)): complete, traceable, and current.`
- [x] `.venv/bin/python scripts/validate-evals.py` → `Validated 39 eval manifests ...`
- [x] `.venv/bin/python scripts/eval-coverage.py --modified-from origin/main` → exit 0, warnings [], errors [], coverage 39/132 (29.5%)
- [x] `ruby scripts/validate-skills.rb` → `Validated 132 canonical skills.`
- [x] `.venv/bin/python scripts/check-artifacts.py` → exit 0
- [x] `make validate` → `All checks passed.`

## Documentation

- [x] Regenerated lifecycle capability matrix artifacts (`docs/lifecycle-capability-matrix.md`, `.json`).
- [x] All manifest paths are relative and resolve from the bundle directory.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] AI assistance disclosed via `Co-authored-by: factory-droid[bot]` trailer on the commit.

## Review notes

- The three new eval manifests follow the evals-v1 contract (schema_version 1, ≥5 output-quality cases, `assertions` not `expectations`) so the bundles' `eval_suite` pointers are self-resolving.
- No SKILL.md files were modified; catalogs (`llms.txt`, plugin manifests) are unchanged because bundle manifests are metadata, not new installable skills.
