### PR TITLE
feat(skill): beef up financial-modeling with templates/scripts/evals

### DIFF
--- a/financial-modeling/README.md
+++ b/financial-modeling/README.md
@@ -21,10 +21,32 @@ It is an analytical aid, not financial, investment, tax, accounting, or legal ad
 | `references/fundraising.md` | Valuation methods, cap tables, term-sheet concepts, and fundraising preparation. |
 | `references/saas-metrics.md` | ARR, retention, efficiency metrics, period alignment, and metric limitations. |
 | `references/source-index.md` | Source provenance, review date, and authoritative reference links. |
+| `templates/` | Fillable records: unit-economics record, pricing decision record, fundraising scenario, and model sanity checklist. |
+| `scripts/` | `saas-metrics.py` — computes ARR, monthly and annualized logo churn, NDR, and Rule of 40 from stated inputs. |
+| `evals/` | Output-quality eval manifest for the skill's methodology cases. |
 
 ## Quick Start
 
-This is a reference-only skill. No setup, API key, command, or dependency is required.
+Compute the headline SaaS operating metrics in one command. The script needs only Python 3 (standard library) and takes stated inputs, so the same numbers you would put in a spreadsheet produce a consistent result:
+
+```bash
+python3 financial-modeling/scripts/saas-metrics.py \
+  --mrr 120000 --customers 480 --churned-customers 10 \
+  --expansion 9000 --contraction 3000 --churned-mrr 4200 \
+  --growth-pct 38 --margin-pct 6
+```
+
+Output:
+
+```text
+ARR (annualized recurring revenue): $1,440,000.00
+Monthly logo churn: 2.08%
+Annualized logo churn: 22.33%
+NDR (net dollar retention): 101.50%
+Rule of 40 (growth + margin): 44.00
+```
+
+Add `--json` for machine-readable output, pass `--churn-pct 2.1` instead of customer counts when churn is already known, and omit the `--expansion`/`--contraction`/`--churned-mrr` group (or the growth/margin pair) when those metrics are not in scope. The script exits 2 on inconsistent inputs, so it can gate a report or CI step. Load `SKILL.md` for the methodology and reference table, then use the templates to record unit economics, pricing decisions, fundraising scenarios, or a model sanity check.
 
 ## Triggers
 
@@ -34,7 +56,7 @@ This is a reference-only skill. No setup, API key, command, or dependency is req
 
 ## Requirements
 
-No software dependencies or credentials. Useful analysis requires reliable business inputs with a defined currency, time period, and accounting basis.
+No API keys or credentials. The `saas-metrics.py` script needs only Python 3 (standard library). Useful analysis requires reliable business inputs with a defined currency, time period, and accounting basis.
 
 ## Source and Maintenance
 

--- a/financial-modeling/SKILL.md
+++ b/financial-modeling/SKILL.md
@@ -48,6 +48,25 @@ Load only the reference relevant to the task:
 | [SaaS metrics](references/saas-metrics.md) | Defining and interpreting ARR, churn, NDR, Rule of 40, Magic Number, or burn multiple |
 | [Source index](references/source-index.md) | Reviewing provenance, porting scope, source URLs, and currency boundaries |
 
+## Templates
+
+| Template | When to use |
+|---|---|
+| [Unit economics record](templates/unit-economics-record.md) | Recording segment- or channel-level CAC, LTV, payback, and contribution margin with stated definitions |
+| [Pricing decision record](templates/pricing-decision-record.md) | Structuring a pricing or price-change decision: options, unit-economics trade-offs, test plan, and decision |
+| [Fundraising scenario](templates/fundraising-scenario.md) | Preparing a raise: size from the cash model, runway per case, fully diluted cap-table impact, and diligence prep |
+| [Model sanity checklist](templates/model-sanity-checklist.md) | Cross-checking a model for structure, linkage, driver consistency, and scenario coverage before sharing it |
+
+## Scripts
+
+| Script | When to use |
+|---|---|
+| [saas-metrics.py](scripts/saas-metrics.py) | Computing ARR, monthly and annualized logo churn, NDR, and Rule of 40 from stated inputs; `--json` for machine-readable output |
+
+## Evals
+
+`evals/evals.json` — output-quality eval manifest for this skill: unit-economics review, pricing decision, fundraising scenario, SaaS metrics interpretation, model sanity check, and runway and burn analysis.
+
 ## Working Method
 
 1. Define the decision, audience, currency, time period, and accounting basis before calculating anything.

--- a/financial-modeling/evals/evals.json
+++ b/financial-modeling/evals/evals.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "skill_name": "financial-modeling",
+  "evals": [
+    {
+      "id": "unit-economics-review",
+      "prompt": "A SaaS startup reports $90 monthly ARPU, 58% gross margin, $3,600 CAC, and 4.2% monthly logo churn for its self-serve segment, and the team is celebrating that LTV/CAC is above 3. Review their unit economics and tell them what to check before trusting that conclusion.",
+      "expected_output": "A unit-economics review that recomputes the headline numbers instead of accepting the claim: with a simple LTV formulation, LTV is roughly $1,240 (monthly ARPU x gross margin / monthly churn), which puts LTV/CAC near 0.35 and CAC payback around 69 months on a gross-margin basis — both far outside the claimed healthy band. The review then questions the inputs: whether CAC is blended or channel-specific, whether churn is stable and measured on the same period as ARPU and margin, and whether the segment's gross margin and expansion assumptions hold. It concludes that the 3x LTV/CAC and payback bands are context-dependent heuristics, and that the segment and channel-level numbers must be produced before any health conclusion is drawn.",
+      "assertions": [
+        "The review recomputes simple LTV from ARPU, gross margin, and monthly churn and shows LTV/CAC well below 1, contradicting the claimed 3x",
+        "The review flags a CAC payback of roughly 60-80 months as a financing concern on the stated numbers",
+        "The review asks whether CAC is blended versus segment- or channel-specific and whether ARPU, margin, and churn definitions and periods are consistent",
+        "The review treats LTV/CAC and payback thresholds as context-dependent heuristics rather than universal pass/fail rules"
+      ]
+    },
+    {
+      "id": "pricing-decision",
+      "prompt": "The team wants to raise the price of the $100/month tier to $120/month. Analysts estimate monthly logo churn will rise from 5% to 8% at the new price, with gross margin unchanged at 60%. Walk through how to decide whether the increase is worth it, using the pricing and unit-economics methodology.",
+      "expected_output": "A pricing decision analysis that works through the unit-economics trade-off before recommending anything: under the simple LTV formulation, current LTV is $1,200 (100 x 0.60 / 0.05) and the new price with higher churn drops LTV to $900 (120 x 0.60 / 0.08), so on the stated assumptions the price increase destroys customer value even though it raises price. The analysis does not stop at the LTV comparison: it treats the price change as a hypothesis to test, defines the goal (conversion, margin, expansion, or cash collection), proposes a controlled test on new customers or a segment with existing-customer treatment and contract obligations spelled out, and lists what to track — conversion, discounting, activation, retention, support demand, contribution margin, and cash timing. The decision records the trade-off explicitly and monitors the affected cohorts after rollout.",
+      "assertions": [
+        "The analysis computes current LTV of $1,200 and new LTV of $900 under the stated churn assumptions and shows the price increase lowers LTV",
+        "The analysis treats the price change as a hypothesis to test rather than a settled decision",
+        "The analysis proposes a controlled test with a defined goal and tracks conversion, discounting, retention, contribution margin, and cash timing",
+        "The analysis records an explicit trade-off and a plan to monitor the affected cohorts after rollout"
+      ]
+    },
+    {
+      "id": "fundraising-scenario",
+      "prompt": "The company needs to raise a Series A to extend runway past the base-case cash-out date. Prepare the fundraising scenario: how much to raise, what runway the round buys under base, upside, and downside cases, the fully diluted cap-table impact of a $10M pre-money round with a 15% option-pool increase, and what to prepare for diligence.",
+      "expected_output": "A fundraising scenario built from the cash model rather than a valuation headline: the raise size is tied to the base-case net monthly cash burn and target runway, and the scenario shows how long the money lasts in base, upside, and downside cases so the financing is sized against the worst realistic timing. The cap table is modeled on a fully diluted basis showing pre-money valuation, new money, post-money valuation, the option-pool increase and who bears its dilution, and ownership by holder class before terms are accepted. Key term-sheet concepts — liquidation preference, participation, anti-dilution, pro-rata and ROFR rights — are modeled at several exit values across security classes rather than taken at face value. The preparation list covers a reconciled financial model, the current cap table, historical financial statements, customer and retention analysis, material contracts, and a clear account of risks and assumptions for diligence.",
+      "assertions": [
+        "The scenario sizes the raise from the base-case cash model and shows runway under base, upside, and downside cases",
+        "The scenario models the cap table fully diluted with pre-money, new money, post-money, option-pool increase, and ownership by holder class",
+        "The scenario models key term-sheet concepts such as liquidation preference, participation, and anti-dilution across several exit values and security classes",
+        "The scenario lists diligence preparation including a reconciled financial model, cap table, customer and retention analysis, and material contracts"
+      ]
+    },
+    {
+      "id": "saas-metrics-interpretation",
+      "prompt": "A board deck claims NDR of 112%, monthly logo churn of 2.1%, and a Rule of 40 score of 38%, and concludes the company is healthy. Interpret these SaaS metrics for the board and list the questions to ask before accepting the conclusion.",
+      "expected_output": "An interpretation that first pins down definitions and periods: NDR is (starting recurring revenue plus expansion minus contraction minus churn) divided by starting recurring revenue on the same cohort and period, logo churn is customers churned over customers at the start of the month, and Rule of 40 is the revenue growth rate plus a stated profit margin (EBITDA or free-cash-flow margin — not interchangeable). The analysis then questions the health conclusion: whether the 112% NDR comes from durable expansion or one-time price changes, whether churn is segmented by customer size and contract cadence (a blended 2.1% can hide a bad enterprise or SMB cohort), and which growth and margin definitions produced the 38% Rule of 40 score. The final questions to the board cover definition changes, reclassifications, acquisitions, currency effects, and whether the metrics reconcile to customer-level or contract-level movements.",
+      "assertions": [
+        "The interpretation defines NDR, logo churn, and Rule of 40 with their period and cohort requirements and distinguishes EBITDA from free-cash-flow margin",
+        "The interpretation questions whether the 112% NDR reflects durable expansion or one-time effects",
+        "The interpretation segments churn by customer size and contract cadence instead of trusting the blended rate",
+        "The interpretation asks about definition changes, reclassifications, acquisitions, currency effects, and reconciliation to customer-level movements"
+      ]
+    },
+    {
+      "id": "model-sanity-check",
+      "prompt": "A colleague hands you a 24-month SaaS model forecasting 5x revenue growth with flat headcount and 80% gross margin, and wants to take it to the board. Sanity-check the model before it goes out.",
+      "expected_output": "A sanity check that works from structure to drivers before touching the headline numbers: the model must link the P&L, balance sheet, and cash-flow statement, reconcile ending cash to the balance sheet, and use one currency and one period convention throughout. The check then cross-checks the operational drivers against the outputs — the implied customer additions, ARPU, churn, and headcount productivity must be shown and internally consistent, and the 5x growth with flat headcount is flagged as requiring an explicit productivity or automation assumption that is not stated. The gross-margin assumption is tested against COGS and variable-cost drivers rather than accepted as a constant. The check requires base, upside, and downside scenarios and a sensitivity analysis on the drivers that most change ending cash, and it labels every illustrative figure as hypothetical rather than a forecast.",
+      "assertions": [
+        "The sanity check verifies statement linkage including ending cash reconciling to the balance sheet and consistent currency and period conventions",
+        "The sanity check cross-checks operational drivers such as customers, ARPU, churn, and headcount against the revenue and margin outputs",
+        "The sanity check flags the 5x growth with flat headcount as requiring an explicit productivity or automation assumption",
+        "The sanity check requires base, upside, and downside scenarios and sensitivity analysis on the drivers that most change ending cash"
+      ]
+    },
+    {
+      "id": "runway-burn-analysis",
+      "prompt": "The startup has $1.2M in cash, burns a net $180K per month, and forecasts $90K in monthly recurring revenue. Compute runway and tell them what to model before deciding whether to raise or cut spend.",
+      "expected_output": "A runway analysis that computes the finite quotient first — roughly 6-7 months of runway ($1.2M divided by $180K net monthly cash burn) — and then explains why the number alone is not a decision. The analysis insists on a cash-flow basis rather than P&L loss when receivables, payables, deferred revenue, and timing are material, and it tests slower collections, delayed revenue, and higher spend as sensitivity cases so the raise or cut decision is sized against the downside. Runway bands are treated as management heuristics that depend on financing access, contractual commitments, and the time needed to execute a contingency plan; one-time costs and a slower collections assumption are included in the scenario that drives the decision.",
+      "assertions": [
+        "The analysis computes runway as available cash divided by net monthly cash burn, roughly 6-7 months on the stated figures",
+        "The analysis requires a cash-flow basis rather than P&L loss where collections, deferred revenue, and timing are material",
+        "The analysis tests slower collections, delayed revenue, and higher spend as sensitivity cases",
+        "The analysis treats runway bands as management heuristics that depend on financing access and execution time"
+      ]
+    }
+  ]
+}

--- a/financial-modeling/scripts/saas-metrics.py
+++ b/financial-modeling/scripts/saas-metrics.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""SaaS operating-metrics calculator for financial-modeling.
+
+Computes the headline SaaS operating metrics from stated inputs:
+
+  ARR        = monthly recurring revenue x 12
+  logo churn = monthly rate (customers churned / starting customers, or given
+               directly as a percentage), annualized as 1 - (1 - monthly)^12
+  NDR        = (starting MRR + expansion - contraction - churned MRR)
+               / starting MRR
+  Rule of 40 = revenue growth rate (%) + profit margin (%)
+
+The tool is a computation aid, not financial advice. Every result is only as
+trustworthy as the input definitions and period alignment: state the revenue
+definition, customer population, and period for each input before acting on a
+number. All monetary inputs are in the same currency and period.
+
+Exit codes:
+  0  success
+  2  usage or validation error
+"""
+
+import argparse
+import json
+import sys
+
+ANNUAL_MONTHS = 12
+
+
+def annualize_monthly_rate(monthly_fraction):
+    """Annualize a stable monthly rate: 1 - (1 - monthly) ** 12."""
+    return 1.0 - (1.0 - monthly_fraction) ** ANNUAL_MONTHS
+
+
+def compute_metrics(
+    mrr,
+    customers=None,
+    churned_customers=None,
+    churn_pct=None,
+    expansion=None,
+    contraction=None,
+    churned_mrr=None,
+    growth_pct=None,
+    margin_pct=None,
+):
+    """Compute the requested SaaS metrics from validated inputs."""
+    metrics = {"mrr": mrr, "arr": mrr * ANNUAL_MONTHS}
+
+    if churn_pct is not None:
+        monthly_fraction = churn_pct / 100.0
+        metrics["churn_source"] = "churn-pct"
+    elif customers is not None and churned_customers is not None:
+        monthly_fraction = churned_customers / customers
+        metrics["churn_source"] = "customers"
+    else:
+        monthly_fraction = None
+
+    if monthly_fraction is not None:
+        metrics["monthly_logo_churn_pct"] = round(monthly_fraction * 100.0, 4)
+        metrics["annualized_logo_churn_pct"] = round(
+            annualize_monthly_rate(monthly_fraction) * 100.0, 4
+        )
+
+    if expansion is not None:
+        ndr = (mrr + expansion - contraction - churned_mrr) / mrr
+        metrics["ndr_pct"] = round(ndr * 100.0, 4)
+
+    if growth_pct is not None and margin_pct is not None:
+        metrics["rule_of_40"] = round(growth_pct + margin_pct, 4)
+
+    return metrics
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="saas-metrics.py",
+        description=(
+            "Compute SaaS operating metrics from stated inputs: ARR (monthly recurring "
+            "revenue annualized), monthly and annualized logo churn, net dollar "
+            "retention (NDR), and the Rule of 40 (revenue growth plus profit margin). "
+            "Exit 0 on success, 2 on usage or validation errors."
+        ),
+        epilog=(
+            "Example: python3 saas-metrics.py --mrr 120000 --customers 480 "
+            "--churned-customers 10 --expansion 9000 --contraction 3000 "
+            "--churned-mrr 4200 --growth-pct 38 --margin-pct 6 --json"
+        ),
+    )
+    parser.add_argument(
+        "--mrr",
+        type=float,
+        required=True,
+        metavar="AMOUNT",
+        help="starting monthly recurring revenue, the basis for ARR and NDR (required)",
+    )
+    churn_group = parser.add_mutually_exclusive_group()
+    churn_group.add_argument(
+        "--churn-pct",
+        type=float,
+        metavar="PCT",
+        help="monthly logo churn rate as a percentage, e.g. 2.1 for 2.1%%",
+    )
+    churn_group.add_argument(
+        "--churned-customers",
+        type=float,
+        metavar="COUNT",
+        help="customers churned in the period (requires --customers)",
+    )
+    parser.add_argument(
+        "--customers",
+        type=float,
+        metavar="COUNT",
+        help="starting customer count, the denominator for monthly logo churn",
+    )
+    parser.add_argument(
+        "--expansion",
+        type=float,
+        metavar="AMOUNT",
+        help="expansion (upsell) revenue in the period, for NDR",
+    )
+    parser.add_argument(
+        "--contraction",
+        type=float,
+        metavar="AMOUNT",
+        help="contraction (downgrade) revenue in the period, for NDR",
+    )
+    parser.add_argument(
+        "--churned-mrr",
+        type=float,
+        metavar="AMOUNT",
+        help="recurring revenue lost to churn in the period, for NDR",
+    )
+    parser.add_argument(
+        "--growth-pct",
+        type=float,
+        metavar="PCT",
+        help="recurring revenue growth rate as a percentage, for Rule of 40",
+    )
+    parser.add_argument(
+        "--margin-pct",
+        type=float,
+        metavar="PCT",
+        help="profit margin (EBITDA or free cash flow) as a percentage, for Rule of 40",
+    )
+    parser.add_argument("--json", action="store_true", help="emit a machine-readable JSON report")
+    return parser
+
+
+def validate_inputs(args):
+    """Return an error message, or None when the inputs are consistent."""
+    if args.mrr < 0:
+        return "--mrr must be non-negative"
+
+    if args.churn_pct is not None:
+        if not 0 <= args.churn_pct <= 100:
+            return "--churn-pct must be between 0 and 100"
+    elif args.churned_customers is not None or args.customers is not None:
+        if args.churned_customers is None or args.customers is None:
+            return "--churned-customers and --customers must be provided together"
+        if args.customers <= 0:
+            return "--customers must be positive"
+        if args.churned_customers < 0 or args.churned_customers > args.customers:
+            return "--churned-customers must be between 0 and --customers"
+
+    ndr_inputs = (args.expansion, args.contraction, args.churned_mrr)
+    if any(value is not None for value in ndr_inputs):
+        if not all(value is not None for value in ndr_inputs):
+            return "--expansion, --contraction, and --churned-mrr must be provided together"
+        if any(value < 0 for value in ndr_inputs):
+            return "NDR components must be non-negative"
+        if args.mrr == 0:
+            return "NDR requires --mrr greater than 0"
+        if args.churned_mrr > args.mrr:
+            return "--churned-mrr cannot exceed --mrr"
+
+    if (args.growth_pct is None) != (args.margin_pct is None):
+        return "--growth-pct and --margin-pct must be provided together"
+
+    return None
+
+
+def build_report(args, metrics):
+    inputs = {
+        "mrr": args.mrr,
+        "customers": args.customers,
+        "churned_customers": args.churned_customers,
+        "churn_pct": args.churn_pct,
+        "expansion": args.expansion,
+        "contraction": args.contraction,
+        "churned_mrr": args.churned_mrr,
+        "growth_pct": args.growth_pct,
+        "margin_pct": args.margin_pct,
+    }
+    return {"tool": "saas-metrics.py", "inputs": inputs, "metrics": metrics}
+
+
+def format_money(value):
+    return f"${value:,.2f}"
+
+
+def print_human(report):
+    metrics = report["metrics"]
+    print(f"ARR (annualized recurring revenue): {format_money(metrics['arr'])}")
+    print(f"Monthly logo churn: {metrics['monthly_logo_churn_pct']:.2f}%")
+    print(f"Annualized logo churn: {metrics['annualized_logo_churn_pct']:.2f}%")
+    if "ndr_pct" in metrics:
+        print(f"NDR (net dollar retention): {metrics['ndr_pct']:.2f}%")
+    if "rule_of_40" in metrics:
+        print(f"Rule of 40 (growth + margin): {metrics['rule_of_40']:.2f}")
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    error = validate_inputs(args)
+    if error is not None:
+        parser.error(error)
+
+    metrics = compute_metrics(
+        mrr=args.mrr,
+        customers=args.customers,
+        churned_customers=args.churned_customers,
+        churn_pct=args.churn_pct,
+        expansion=args.expansion,
+        contraction=args.contraction,
+        churned_mrr=args.churned_mrr,
+        growth_pct=args.growth_pct,
+        margin_pct=args.margin_pct,
+    )
+    report = build_report(args, metrics)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print_human(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/financial-modeling/scripts/test_saas_metrics.py
+++ b/financial-modeling/scripts/test_saas_metrics.py
@@ -1,0 +1,174 @@
+"""Tests for saas-metrics.py.
+
+Covers: ARR derivation from MRR, monthly and annualized logo churn from
+customers, churn from a direct percentage, NDR computation, Rule of 40,
+JSON report shape, churn/NDR omitted when inputs are absent, validation
+errors (exit 2), and --help.
+
+Discoverable by both pytest and unittest (unittest.TestCase classes) and
+runnable standalone: python3 financial-modeling/scripts/test_saas_metrics.py
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(SCRIPTS_DIR, "saas-metrics.py")
+
+
+def load_module():
+    """Load saas-metrics.py (hyphenated name is not importable directly)."""
+    spec = importlib.util.spec_from_file_location("saas_metrics_under_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+saas_metrics = load_module()
+
+
+def run_script(args):
+    proc = subprocess.run(
+        [sys.executable, SCRIPT, *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+class TestCliBasics(unittest.TestCase):
+    def test_help_exits_zero_and_covers_metrics(self):
+        rc, stdout, _ = run_script(["--help"])
+        self.assertEqual(rc, 0)
+        lowered = stdout.lower()
+        for term in ("arr", "churn", "ndr", "rule of 40"):
+            self.assertIn(term, lowered, f"--help must mention {term}")
+
+    def test_mrr_is_required(self):
+        rc, _, stderr = run_script([])
+        self.assertEqual(rc, 2)
+        self.assertIn("--mrr", stderr)
+
+    def test_full_report_human_readable(self):
+        rc, stdout, _ = run_script(
+            [
+                "--mrr", "120000",
+                "--customers", "480",
+                "--churned-customers", "10",
+                "--expansion", "9000",
+                "--contraction", "3000",
+                "--churned-mrr", "4200",
+                "--growth-pct", "38",
+                "--margin-pct", "6",
+            ]
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("ARR (annualized recurring revenue): $1,440,000.00", stdout)
+        self.assertIn("Monthly logo churn: 2.08%", stdout)
+        self.assertIn("NDR (net dollar retention): 101.50%", stdout)
+        self.assertIn("Rule of 40 (growth + margin): 44.00", stdout)
+
+
+class TestComputeMetrics(unittest.TestCase):
+    def test_arr_is_mrr_times_twelve(self):
+        metrics = saas_metrics.compute_metrics(mrr=100000)
+        self.assertEqual(metrics["arr"], 1200000)
+        self.assertEqual(metrics["mrr"], 100000)
+
+    def test_churn_from_customers(self):
+        metrics = saas_metrics.compute_metrics(
+            mrr=100000, customers=400, churned_customers=20
+        )
+        self.assertAlmostEqual(metrics["monthly_logo_churn_pct"], 5.0, places=4)
+
+    def test_annualized_churn_matches_compounding(self):
+        metrics = saas_metrics.compute_metrics(
+            mrr=100000, customers=1000, churned_customers=10
+        )
+        expected = (1 - (1 - 0.01) ** 12) * 100
+        self.assertAlmostEqual(metrics["annualized_logo_churn_pct"], expected, places=4)
+
+    def test_churn_from_direct_percentage(self):
+        metrics = saas_metrics.compute_metrics(mrr=100000, churn_pct=2.1)
+        self.assertAlmostEqual(metrics["monthly_logo_churn_pct"], 2.1, places=4)
+
+    def test_ndr_uses_expansion_contraction_churn(self):
+        metrics = saas_metrics.compute_metrics(
+            mrr=120000, expansion=9000, contraction=3000, churned_mrr=4200
+        )
+        self.assertAlmostEqual(metrics["ndr_pct"], 101.5, places=4)
+
+    def test_rule_of_40_sums_growth_and_margin(self):
+        metrics = saas_metrics.compute_metrics(mrr=100000, growth_pct=38, margin_pct=-4)
+        self.assertAlmostEqual(metrics["rule_of_40"], 34.0, places=4)
+
+    def test_churn_omitted_when_no_churn_inputs(self):
+        metrics = saas_metrics.compute_metrics(mrr=100000)
+        self.assertNotIn("monthly_logo_churn_pct", metrics)
+        self.assertNotIn("annualized_logo_churn_pct", metrics)
+
+    def test_ndr_omitted_when_no_ndr_inputs(self):
+        metrics = saas_metrics.compute_metrics(mrr=100000)
+        self.assertNotIn("ndr_pct", metrics)
+
+
+class TestJsonOutput(unittest.TestCase):
+    def test_json_report_shape(self):
+        rc, stdout, _ = run_script(
+            ["--mrr", "50000", "--churn-pct", "1", "--growth-pct", "30",
+             "--margin-pct", "10", "--json"]
+        )
+        self.assertEqual(rc, 0)
+        report = json.loads(stdout)
+        self.assertEqual(report["tool"], "saas-metrics.py")
+        self.assertEqual(report["inputs"]["mrr"], 50000.0)
+        self.assertEqual(report["metrics"]["arr"], 600000.0)
+        self.assertAlmostEqual(report["metrics"]["monthly_logo_churn_pct"], 1.0)
+        self.assertAlmostEqual(report["metrics"]["rule_of_40"], 40.0)
+        self.assertNotIn("ndr_pct", report["metrics"])
+
+
+class TestValidationErrors(unittest.TestCase):
+    def test_negative_mrr_rejected(self):
+        rc, _, stderr = run_script(["--mrr", "-1"])
+        self.assertEqual(rc, 2)
+        self.assertIn("--mrr", stderr)
+
+    def test_churned_exceeding_customers_rejected(self):
+        rc, _, stderr = run_script(
+            ["--mrr", "10000", "--customers", "10", "--churned-customers", "11"]
+        )
+        self.assertEqual(rc, 2)
+        self.assertIn("--churned-customers", stderr)
+
+    def test_partial_ndr_inputs_rejected(self):
+        rc, _, stderr = run_script(["--mrr", "10000", "--expansion", "500"])
+        self.assertEqual(rc, 2)
+        self.assertIn("--expansion", stderr)
+
+    def test_partial_rule_of_40_rejected(self):
+        rc, _, stderr = run_script(["--mrr", "10000", "--growth-pct", "30"])
+        self.assertEqual(rc, 2)
+        self.assertIn("--growth-pct", stderr)
+
+    def test_churned_mrr_above_mrr_rejected(self):
+        rc, _, stderr = run_script(
+            ["--mrr", "10000", "--expansion", "0", "--contraction", "0",
+             "--churned-mrr", "12000"]
+        )
+        self.assertEqual(rc, 2)
+        self.assertIn("--churned-mrr", stderr)
+
+    def test_customers_without_churned_rejected(self):
+        rc, _, stderr = run_script(["--mrr", "10000", "--customers", "100"])
+        self.assertEqual(rc, 2)
+        self.assertIn("--customers", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/financial-modeling/templates/fundraising-scenario.md
+++ b/financial-modeling/templates/fundraising-scenario.md
@@ -1,0 +1,72 @@
+# Fundraising Scenario
+
+Fill this scenario before starting a financing process. Size the raise from the
+cash model, show what it buys in each case, model the fully diluted cap-table
+impact, and list what must be prepared for diligence. This is not legal,
+securities, tax, or accounting advice; involve qualified counsel.
+
+## Business Case and Cash Model
+
+- Stage / round: `[fill: e.g. Series A]`
+- Currency: `[fill: e.g. USD]`
+- Prepared by / date: `[fill: name or handle, YYYY-MM-DD]`
+- Base-case net monthly cash burn: `[fill: amount; define cash basis, not P&L loss]`
+- Available cash today: `[fill: amount]`
+- Base-case cash-out date without financing: `[fill: date]`
+
+## Raise Size and Runway
+
+- Proposed raise size: `[fill: amount]`
+- Target runway after close (months): `[fill: count]`
+
+| Case | Net monthly burn | Runway from raise (months) | Cash-out date | Key drivers |
+|---|---|---|---|---|
+| Upside | `[fill: amount]` | `[fill: result]` | `[fill: date]` | `[fill: drivers]` |
+| Base | `[fill: amount]` | `[fill: result]` | `[fill: date]` | `[fill: drivers]` |
+| Downside | `[fill: amount]` | `[fill: result]` | `[fill: date]` | `[fill: drivers]` |
+
+- One-time costs and slower-collections sensitivity: `[fill: what else could move the burn]`
+- Contingency plan if terms change or timing slips: `[fill: description]`
+
+## Cap Table Impact (Fully Diluted)
+
+- Pre-money valuation: `[fill: amount]`
+- New money: `[fill: amount]`
+- Post-money valuation: `[fill: amount]`
+- Option-pool increase and who bears the dilution: `[fill: % and description]`
+- Existing convertibles, warrants, and preferences: `[fill: summary]`
+
+| Holder class | Pre-round ownership % | Post-round ownership % | Notes |
+|---|---|---|---|
+| Founders | `[fill: %]` | `[fill: %]` | `[fill: notes]` |
+| Employees (option pool) | `[fill: %]` | `[fill: %]` | `[fill: notes]` |
+| Existing investors | `[fill: %]` | `[fill: %]` | `[fill: notes]` |
+| New investors | n/a | `[fill: %]` | `[fill: notes]` |
+
+## Term-Sheet Modeling
+
+Model the economic result of key terms at several exit values, not just the
+headline valuation.
+
+| Term | Assumption to model | Result across exit values |
+|---|---|---|
+| Liquidation preference | `[fill: multiple and seniority]` | `[fill: who gets paid first and how much at each exit]` |
+| Participation | `[fill: participates or capped]` | `[fill: effect on common proceeds]` |
+| Anti-dilution | `[fill: down-round mechanics]` | `[fill: conversion impact]` |
+| Pro-rata / ROFR / drag-along | `[fill: rights]` | `[fill: effect on future rounds and transfers]` |
+
+## Diligence Preparation
+
+- [ ] Reconciled financial model (base/upside/downside, linked statements)
+- [ ] Current cap table with all instruments
+- [ ] Historical financial statements
+- [ ] Customer and retention analysis
+- [ ] Material contracts and corporate records
+- [ ] Risks and assumptions document
+- [ ] Access-control plan for sensitive records
+
+## Decisions & Follow-Ups
+
+- Decision this scenario supports: `[fill: e.g. raise now vs. extend runway first]`
+- Open questions for counsel / advisors: `[fill: questions]`
+- Next review date: `[fill: YYYY-MM-DD]`

--- a/financial-modeling/templates/model-sanity-checklist.md
+++ b/financial-modeling/templates/model-sanity-checklist.md
@@ -1,0 +1,51 @@
+# Model Sanity Checklist
+
+Run this checklist before a model is shared with a board, investor, or decision
+maker. The goal is to catch structural breaks, driver inconsistencies, and
+hidden assumptions — not to bless the forecast. Any unchecked item that is
+material must be resolved or explicitly accepted with a note.
+
+## Scope
+
+- Model name / version: `[fill: name and version or date]`
+- Currency and period convention: `[fill: e.g. USD, monthly]`
+- Accounting basis: `[fill: cash or accrual]`
+- Reviewer / date: `[fill: name or handle, YYYY-MM-DD]`
+
+## Structure and Linkage
+
+- [ ] Income statement, balance sheet, and cash-flow statement are present
+- [ ] Ending cash on the cash-flow statement reconciles to the balance sheet
+- [ ] One currency and one period convention used throughout
+- [ ] Supporting schedules (revenue build, headcount, capex/debt, equity) feed the statements
+- [ ] Bookings, recognized revenue, invoicing, and cash collections are kept distinct where timing differs
+
+## Driver Consistency
+
+- [ ] Revenue is built from operational drivers (customers x ARPU, expansion, usage, etc.), not a single growth-rate line
+- [ ] Churn and retention assumptions are explicit and consistent with the revenue build
+- [ ] Headcount, capacity, or COGS assumptions are consistent with the revenue trajectory
+- [ ] Gross margin is tested against cost drivers rather than accepted as a constant
+- [ ] Top-down market sizing is used only as a reasonableness check, not as the primary forecast
+- [ ] No automatic expansion or linear-growth assumptions hidden in formulas
+
+## Scenarios and Sensitivity
+
+- [ ] Base, upside, and downside cases exist and differ in observable drivers
+- [ ] Sensitivity analysis covers the inputs that most change ending cash or profitability
+- [ ] Runway (if used) is computed from a cash-flow forecast and a stated burn definition
+- [ ] One-time costs, slower collections, and delayed revenue are tested
+- [ ] Illustrative percentages and amounts are labeled as hypothetical
+
+## Documentation and Limits
+
+- [ ] Input sources and assumptions are listed separately from calculated outputs
+- [ ] Segment and channel differences are not hidden by blended averages
+- [ ] Limitations and items needing professional review are stated
+- [ ] Model outputs reconcile to the relevant statements where possible
+
+## Verdict
+
+- Result: `[fill: pass, pass with notes, or fail]`
+- Blocking items: `[fill: list any unchecked items that are material and why they matter]`
+- Recommended actions: `[fill: fixes to make before sharing]`

--- a/financial-modeling/templates/pricing-decision-record.md
+++ b/financial-modeling/templates/pricing-decision-record.md
@@ -1,0 +1,40 @@
+# Pricing Decision Record
+
+Fill this record for any pricing, packaging, or price-change decision. Treat the
+decision as a hypothesis to test: state the goal, show the unit-economics
+trade-off, define the test, and record what will be monitored after rollout.
+
+## Decision Under Consideration
+
+- Pricing question: `[fill: e.g. raise the $100/month tier to $120/month]`
+- Goal: `[fill: conversion, margin, expansion, cash collection, or a target segment]`
+- Currency and period convention: `[fill: e.g. USD, monthly]`
+- Prepared by / date: `[fill: name or handle, YYYY-MM-DD]`
+
+## Options and Unit Economics
+
+For each option, record the inputs and the resulting economics on one basis.
+
+| Option | Price | Gross margin % | Monthly churn % | Simple LTV | LTV/CAC | CAC payback (months) | Notes |
+|---|---|---|---|---|---|---|---|
+| Current | `[fill: amount]` | `[fill: %]` | `[fill: %]` | `[fill: result]` | `[fill: result]` | `[fill: result]` | `[fill: notes]` |
+| Proposed | `[fill: amount]` | `[fill: %]` | `[fill: %]` | `[fill: result]` | `[fill: result]` | `[fill: result]` | `[fill: notes]` |
+| Alternative | `[fill: amount or n/a]` | `[fill: %]` | `[fill: %]` | `[fill: result]` | `[fill: result]` | `[fill: result]` | `[fill: notes]` |
+
+- Trade-off summary: `[fill: which option wins on which metric and why]`
+- Revenue, contribution margin, retention, and cash timing effects: `[fill: assessment]`
+
+## Test Plan
+
+- Cohort definition (new customers, controlled segment, existing-customer treatment): `[fill: description]`
+- Contract obligations and grandfathering: `[fill: what existing contracts require]`
+- Observation period: `[fill: start and end dates]`
+- Metrics to track: `[fill: conversion, discounting, activation, retention, support demand, contribution margin, cash timing]`
+- Comparison baseline: `[fill: contemporaneous control or historical baseline with seasonality/channel adjustments]`
+
+## Decision and Monitoring
+
+- Decision: `[fill: proceed, revise, or hold; with the explicit trade-off accepted]`
+- Rollout plan: `[fill: phased or full; which segments]`
+- Post-rollout monitoring: `[fill: cohorts and metrics to watch, with dates]`
+- Rollback trigger: `[fill: what observed outcome would reverse the decision]`

--- a/financial-modeling/templates/unit-economics-record.md
+++ b/financial-modeling/templates/unit-economics-record.md
@@ -1,0 +1,45 @@
+# Unit Economics Record
+
+Fill one record per customer segment or acquisition channel. A unit-economics
+number without a stated segment, period, and definition is not comparable. If a
+field does not apply, write `n/a` — do not leave it blank.
+
+## Context
+
+- Segment / channel: `[fill: e.g. self-serve SMB via paid search]`
+- Currency: `[fill: e.g. USD]`
+- Measurement period: `[fill: e.g. trailing 3 months ending 2026-06-30]`
+- Accounting basis: `[fill: cash or accrual; revenue recognition convention]`
+- Prepared by / date: `[fill: name or handle, YYYY-MM-DD]`
+
+## Inputs
+
+| Input | Value | Source / definition |
+|---|---|---|
+| Monthly ARPU (or annual contract value) | `[fill: amount]` | `[fill: how revenue per customer is measured; what is excluded]` |
+| Gross margin % | `[fill: percent]` | `[fill: which costs are included in COGS]` |
+| CAC | `[fill: amount]` | `[fill: blended or channel-specific; which spend is included]` |
+| Monthly logo churn % | `[fill: percent]` | `[fill: population and period used]` |
+| Monthly revenue churn % (if different) | `[fill: percent or n/a]` | `[fill: contraction and churn treatment]` |
+| Expansion / upsell revenue | `[fill: amount per period or n/a]` | `[fill: what counts as expansion]` |
+| Contribution margin % (if used) | `[fill: percent or n/a]` | `[fill: variable costs included]` |
+
+## Calculations
+
+- Simple LTV = monthly ARPU x gross margin % / monthly churn rate = `[fill: result]`
+- LTV/CAC = `[fill: result]`
+- CAC payback (gross-margin basis, months) = CAC / (monthly ARPU x gross margin %) = `[fill: result]`
+- Contribution-margin payback (if used, months) = `[fill: result or n/a]`
+- Cohort LTV (if computed) = `[fill: result and method or n/a]`
+
+## Interpretation
+
+- Where this segment sits vs. context-dependent heuristics for its stage and model: `[fill: assessment]`
+- What the payback implies for financing needs: `[fill: assessment]`
+- Risks to the inputs (churn stability, margin drift, channel mix): `[fill: risks]`
+
+## Decisions & Follow-Ups
+
+- Decision this record supports: `[fill: e.g. continue spending on channel, change price]`
+- Next measurement date: `[fill: YYYY-MM-DD]`
+- Open questions: `[fill: what to validate next]`


### PR DESCRIPTION
## Summary

Beefs up `financial-modeling` per issue #241: adds a schema-valid eval manifest (6 cases), four fillable templates, and a stdlib SaaS-metrics calculator script with tests, documented in the README Quick Start.

- `financial-modeling/evals/evals.json` — schema v1, 6 cases: unit-economics review, pricing decision, fundraising scenario, SaaS metrics interpretation, model sanity check, runway and burn analysis (each with id/prompt/expected_output/assertions).
- `financial-modeling/templates/` — unit-economics record, pricing decision record, fundraising scenario, model sanity checklist (all with `[fill: ...]` markers).
- `financial-modeling/scripts/saas-metrics.py` — stdlib-only calculator for ARR, monthly and annualized logo churn, NDR, and Rule of 40; `--json` output; exit 2 on inconsistent inputs.
- `financial-modeling/scripts/test_saas_metrics.py` — 18 unittest cases, runnable standalone and pytest-discoverable.
- `SKILL.md` gains Templates/Scripts/Evals sections; `README.md` Quick Start documents a realistic invocation.

## Validation

- `ruby scripts/validate-skills.rb` — Validated 132 canonical skills.
- `python3 scripts/validate-evals.py` — Validated 44 eval manifests.
- `python3 scripts/eval-coverage.py --modified-from origin/main` — exit 0, warnings [] errors [], schema_valid 44/132 (33.3%).
- `ruby scripts/validate-skill-quality.rb --base origin/main` — 0 errors, 0 warnings.
- `make validate` — All checks passed (132 passed, 25 subtests, coverage 66.14%).
- `python3 financial-modeling/scripts/test_saas_metrics.py` — 18 tests OK.

## Documentation

- Updated `financial-modeling/SKILL.md` and `financial-modeling/README.md`.
- All links relative and resolve from a fresh clone.

## Community and security

- No credentials or private infrastructure details.
- AI assistance disclosed in the commit message.

Closes #241
