### PR TITLE
fix: correct vllm models-check test name and stripe cancel boolean

### DIFF
--- a/stripe/scripts/stripe-cli
+++ b/stripe/scripts/stripe-cli
@@ -48,8 +48,17 @@ def get_api_key() -> str:
     return key
 
 
+def _encode_form_fields(fields: Dict[str, Any]) -> bytes:
+    """Encode form fields, mapping booleans to Stripe's lowercase true/false."""
+    normalized = {
+        key: "true" if value is True else "false" if value is False else value
+        for key, value in fields.items()
+    }
+    return urllib.parse.urlencode(normalized).encode("utf-8")
+
+
 def api_request(method: str, path: str, api_key: str,
-                fields: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+                fields: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     base = f"{API_BASE}/{path.lstrip('/')}"
     if fields and method == "GET":
         query = "&".join(f"{key}={urllib.parse.quote(str(value))}" for key, value in fields.items())
@@ -57,7 +66,7 @@ def api_request(method: str, path: str, api_key: str,
         data = None
     elif fields:
         url = base
-        data = urllib.parse.urlencode(fields).encode("utf-8")
+        data = _encode_form_fields(fields)
     else:
         url = base
         data = None
@@ -168,7 +177,7 @@ def cmd_subscriptions_cancel(args: argparse.Namespace, api_key: str) -> Dict[str
     # setting cancel_at_period_end back to false) rather than cancelling
     # immediately.
     payload = api_request("POST", f"subscriptions/{args.subscription_id}", api_key,
-                          {"cancel_at_period_end": "true"})
+                          {"cancel_at_period_end": True})
     if payload.get("cancel_at_period_end") is not True:
         raise StripeError(
             "Stripe did not confirm the cancellation (cancel_at_period_end is "

--- a/vllm/tests/test_vllm_health.py
+++ b/vllm/tests/test_vllm_health.py
@@ -220,14 +220,12 @@ class ProbeTests(unittest.TestCase):
         finally:
             large.stop()
 
-    def test_empty_models_is_a_failure(self):
-        # A server that responds 200 but lists no models must fail the models check.
+    def test_models_check_parses_from_stub(self):
+        """The models check parses the stub's served model list (positive path)."""
         proc = run_script(
             "--url", f"http://127.0.0.1:{self.server.port}", "--check", "models", "--json"
         )
         payload = load_json(proc)
-        # Stub lists test-model, so this is a sanity assertion on parsing, not a
-        # negative-path test; the negative path is covered by test_unreachable_server.
         self.assertEqual(payload["checks"][0]["ok"], True)
 
 


### PR DESCRIPTION
## Summary

Follow-up cleanup from the M8 scrutiny review of the shipped vllm and Stripe tool scripts (the underlying features for #247/#249 are already merged and #249 is closed).

- `vllm/tests/test_vllm_health.py`: renamed the misleadingly-named `test_empty_models_is_a_failure` to `test_models_check_parses_from_stub` and corrected its docstring, which claimed it tested an empty-models failure when it actually asserts positive-path parsing against the stub server (which serves `test-model`).
- `stripe/scripts/stripe-cli`: `cancel_at_period_end` is now passed as the boolean `True` instead of the string `'true'`. Form encoding now maps booleans to Stripe's lowercase `true`/`false`, so the wire payload is unchanged and Stripe-compatible; the existing test asserting `cancel_at_period_end=true` in the POST body still passes.

No new assertions needed; the existing test suites cover this behavior.

## Validation

- [x] `ruby scripts/validate-skills.rb` — `Validated 144 canonical skills.`
- [x] `.venv/bin/python scripts/validate-evals.py` — `Validated 83 eval manifests ...`
- [x] `ruby scripts/validate-skill-quality.rb --base origin/main` — no changed SKILL.md files
- [x] `.venv/bin/python scripts/eval-coverage.py --modified-from origin/main` — ratchet green
- [x] `.venv/bin/python scripts/check-artifacts.py` — pass
- [x] `.venv/bin/python vllm/tests/test_vllm_health.py` — 12 tests OK
- [x] `.venv/bin/python stripe/tests/test_stripe_cli.py` — 12 tests OK
- [x] `make validate` — all checks passed

## Documentation

- [x] No `SKILL.md`, `README.md`, or reference files changed by this cleanup; no catalog regeneration required.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] I have disclosed meaningful AI assistance in the description or commit message.

## Review notes

- [ ] Final-head review evidence is tied to commit SHA `401d536`, and all actionable findings are resolved.
