### PR TITLE
fix: SkillOpt 3-epoch optimization of forward-deployed-engineering bundle

### DIFF
--- a/bundles/forward-deployed-engineering/SKILL.md
+++ b/bundles/forward-deployed-engineering/SKILL.md
@@ -29,8 +29,22 @@ methods; the nine-stage sequence is not an externally standardized methodology.
 
 `Discover → Frame → Hypothesize → Build → Evaluate → Deploy → Adopt → Measure → Generalize`
 
-At every stage, maintain one [engagement charter](templates/engagement-charter.md),
-one [stakeholder/workflow map](templates/stakeholder-workflow-map.md), and one
+| Stage | Required question | Minimum output | Stop condition |
+|---|---|---|---|
+| Discover | What user workflow and problem are real? | [Stakeholder/workflow map](templates/stakeholder-workflow-map.md) and unknowns | No recognizable problem or access to the relevant workflow |
+| Frame | What is in scope, who decides, and what outcome matters? | [Engagement charter](templates/engagement-charter.md) and [assumptions/decisions/risks ledger](templates/assumptions-decisions-risks-ledger.md) | Authority, constraints, or outcome cannot be named |
+| Hypothesize | What smallest intervention could change the workflow? | Testable hypothesis and decision rule | No falsifiable hypothesis or unsafe test |
+| Build | What operationally complete slice can be built? | Thin-slice implementation plan and owner | Dependencies or permissions are infeasible |
+| Evaluate | What evidence supports quality, safety, and usefulness? | [Evaluation and release decision](templates/evaluation-and-release-decision.md) | Baseline, representative evidence, or risk constraints missing |
+| Deploy | Can it be released, recovered, and verified in the authorized environment? | Readiness, rollout, rollback, and verification record | No authorized access, rollback, or release decision |
+| Adopt | Do intended users activate and use it in the target workflow? | [Adoption scorecard](templates/adoption-scorecard.md) and intervention record | Adoption failure is unexplained or ownership/support is absent |
+| Measure | Did the capability change the agreed outcome? | [Outcome measurement record](templates/outcome-measurement-record.md) | Instrumentation cannot distinguish expected from observed |
+| Generalize | What should happen to the local learning? | [Productization record](templates/productization-record.md) and [field-learning record](templates/field-learning-record.md) | No evidence or receiving owner for the proposed next step |
+
+At every stage, read the current charter, workflow map, and ledger and add
+evidence rather than re-deriving prior decisions. Maintain one [engagement
+charter](templates/engagement-charter.md), one [stakeholder/workflow
+map](templates/stakeholder-workflow-map.md), and one
 [assumptions-decisions-risks ledger](templates/assumptions-decisions-risks-ledger.md).
 Each stage records entry evidence, the artifact produced, the accountable
 decision maker, unresolved unknowns, and the next handoff. Never silently turn
@@ -50,9 +64,11 @@ local success into a reusable product capability.
    [authority and escalation](references/authority-and-escalation.md) and route
    access, security, privacy, irreversible, cost, and external-commitment
    decisions to their authorized owner.
-5. Before calling applied AI or any risky capability production-ready, load the
-   evaluation specialist and require baseline, representative and adversarial
-   evidence, constraints, and a release decision.
+5. Before calling applied AI or any risky capability production-ready, load
+   [agent-evals-and-observability](../../agent-evals-and-observability/SKILL.md)
+   and [production-readiness](../../production-readiness/SKILL.md), and require
+   baseline, representative and adversarial evidence, constraints, and a
+   release decision.
 6. Treat adoption and measured workflow impact as completion conditions, not
    postscript communications. Use [adoption and measurement](references/adoption-and-measurement.md).
 7. Apply the classification rules in [generalization and

--- a/bundles/forward-deployed-engineering/SKILL.md
+++ b/bundles/forward-deployed-engineering/SKILL.md
@@ -51,6 +51,26 @@ decision maker, unresolved unknowns, and the next handoff. Never silently turn
 an observation into a requirement, a prototype into a production claim, or a
 local success into a reusable product capability.
 
+### Where to enter the lifecycle
+
+Enter at the stage that matches what already exists. Do not restart earlier
+stages unless the current charter's stop conditions require it.
+
+| What you already have | Enter at |
+|---|---|
+| A stakeholder request or observed workflow opportunity, no validated problem | Discover |
+| Validated problem and stakeholders, no charter | Frame (establish the charter first) |
+| Charter, workflow map, and ledger; no approved requirement | Hypothesize |
+| Approved requirement; thin slice in progress | Build |
+| Built and tested slice; no release decision | Evaluate |
+| Released within the authorized boundary | Adopt |
+| Adopted and measuring against the decision rule | Measure |
+| Post-launch evidence and a generalization question | Generalize |
+| A well-specified bounded change with no continuity need | Route to [neckbeard](../../bundles/neckbeard/SKILL.md) instead |
+
+Before acting at any entry point, review the current charter, workflow map,
+ledger, and preceding stage-handoff record as entry evidence.
+
 ## Loading protocol
 
 1. Establish the charter before solution design: problem, users, workflow,
@@ -110,12 +130,14 @@ specialist instead of invoking this lifecycle.
 
 ## When not to use
 
-- Use [neckbeard](../../bundles/neckbeard/SKILL.md) for a well-bounded repository change.
-- Use [product-lifecycle](../../bundles/product-lifecycle/SKILL.md) for product investment and lifecycle governance.
-- Use [site-reliability-engineering](../../site-reliability-engineering/SKILL.md) for ongoing reliability ownership.
-- Use [platform-engineering](../../platform-engineering/SKILL.md) for internal platform design or operation.
-- Load a single specialist directly when one discipline fully owns the task.
-- Do not use for advisory analysis that ends before implementation, adoption, and outcome continuity.
+| Scenario | Reach for | Why |
+|---|---|---|
+| Well-bounded repository change | [neckbeard](../../bundles/neckbeard/SKILL.md) | Owns intake through verified PR and authorized release for a bounded change |
+| Product investment, portfolio, or lifecycle governance | [product-lifecycle](../../bundles/product-lifecycle/SKILL.md) | Owns investment and lifecycle governance, not delivery continuity |
+| Ongoing reliability ownership (SLOs, alerts, incidents) | [site-reliability-engineering](../../site-reliability-engineering/SKILL.md) | Standing operational ownership, not an embedded engagement |
+| Internal platform design or operation | [platform-engineering](../../platform-engineering/SKILL.md) | Platform ownership, not customer delivery |
+| One discipline fully owns the task | That specialist directly | FDE stops routing when one specialist owns the request |
+| Advisory analysis ending before implementation and adoption | The relevant architecture or decision specialist | FDE completion requires adoption and outcome continuity |
 
 ## File map
 

--- a/bundles/forward-deployed-engineering/SKILL.md
+++ b/bundles/forward-deployed-engineering/SKILL.md
@@ -49,7 +49,9 @@ map](templates/stakeholder-workflow-map.md), and one
 Each stage records entry evidence, the artifact produced, the accountable
 decision maker, unresolved unknowns, and the next handoff. Never silently turn
 an observation into a requirement, a prototype into a production claim, or a
-local success into a reusable product capability.
+local success into a reusable product capability. For the expected depth and
+evidence labeling of these artifacts, see the
+[worked example engagement](references/worked-example-engagement.md).
 
 ### Where to enter the lifecycle
 
@@ -151,5 +153,6 @@ specialist instead of invoking this lifecycle.
 | [references/adoption-and-measurement.md](references/adoption-and-measurement.md) | Evaluating activation, workflow adoption, and measurable impact |
 | [references/generalization-and-productization.md](references/generalization-and-productization.md) | Deciding what field work becomes or does not become reusable |
 | [references/communication.md](references/communication.md) | Writing status, decision, escalation, or handoff communication |
-| [templates/](templates/) | Creating the charter, maps, ledgers, scorecards, status, or productization record |
+| [references/worked-example-engagement.md](references/worked-example-engagement.md) | Calibrating expected artifact depth or evidence labeling at any stage |
+| [templates/](templates/) | Creating the charter, workflow map, ledger, stage handoff, engagement status, evaluation and release decision, adoption scorecard, outcome measurement record, productization record, or field learning record |
 | [manifest.yaml](manifest.yaml) | Reading machine-readable stages, routes, outputs, and conflicts |

--- a/bundles/forward-deployed-engineering/references/lifecycle-and-artifacts.md
+++ b/bundles/forward-deployed-engineering/references/lifecycle-and-artifacts.md
@@ -1,20 +1,13 @@
 # Lifecycle and Artifacts
 
 The lifecycle is a continuity contract, not a claim about industry standard
-practice. Every stage reads the current charter, workflow map, and ledger; it
-adds evidence rather than re-deriving prior decisions.
+practice. The nine-stage contract — required question, minimum output, and
+stop condition per stage — lives in [SKILL.md](../SKILL.md#lifecycle) and is
+the single source of truth for stage expectations.
 
-| Stage | Required question | Minimum output | Stop condition |
-|---|---|---|---|
-| Discover | What user workflow and problem are real? | [Stakeholder/workflow map](../templates/stakeholder-workflow-map.md) and unknowns | No recognizable problem or access to the relevant workflow |
-| Frame | What is in scope, who decides, and what outcome matters? | [Engagement charter](../templates/engagement-charter.md) and [assumptions/decisions/risks ledger](../templates/assumptions-decisions-risks-ledger.md) | Authority, constraints, or outcome cannot be named |
-| Hypothesize | What smallest intervention could change the workflow? | Testable hypothesis and decision rule | No falsifiable hypothesis or unsafe test |
-| Build | What operationally complete slice can be built? | Thin-slice implementation plan and owner | Dependencies or permissions are infeasible |
-| Evaluate | What evidence supports quality, safety, and usefulness? | [Evaluation and release decision](../templates/evaluation-and-release-decision.md) | Baseline, representative evidence, or risk constraints missing |
-| Deploy | Can it be released, recovered, and verified in the authorized environment? | Readiness, rollout, rollback, and verification record | No authorized access, rollback, or release decision |
-| Adopt | Do intended users activate and use it in the target workflow? | Adoption scorecard and intervention record | Adoption failure is unexplained or ownership/support is absent |
-| Measure | Did the capability change the agreed outcome? | [Outcome measurement record](../templates/outcome-measurement-record.md) | Instrumentation cannot distinguish expected from observed |
-| Generalize | What should happen to the local learning? | [Productization record](../templates/productization-record.md) and [field-learning record](../templates/field-learning-record.md) | No evidence or receiving owner for the proposed next step |
+Every stage records entry evidence, the artifact produced, the accountable
+decision maker, unresolved unknowns, and the next handoff in the shared
+records below.
 
 ## Shared record fields
 

--- a/bundles/forward-deployed-engineering/references/worked-example-engagement.md
+++ b/bundles/forward-deployed-engineering/references/worked-example-engagement.md
@@ -1,0 +1,124 @@
+# Worked Example — Claims-Processing Cycle-Time Reduction
+
+A synthetic engagement that calibrates the expected depth and evidence
+labeling of the continuity artifacts. All people, numbers, and workflows are
+illustrative; none reference a real customer, system, or deployment. Use this
+to calibrate depth, not as a template substitute.
+
+## Engagement charter (excerpt)
+
+- **Engagement:** Claims-processing cycle-time reduction
+- **Accountable technical lead:** Assigned engagement lead
+- **Sponsor and decision authority:** Operations sponsor; privacy and security
+  owners gate data access; service owner approves production change
+- **Stakeholders and intended users:** Claims processors, workflow
+  supervisors, downstream payment roles
+- **Workflow and problem statement:** Elapsed time from claim submission to
+  decision is the target workflow. The bottleneck is unvalidated; no
+  particular stage is assumed to be the cause.
+- **Desired outcome and baseline:** Reduce median cycle time by at least 10%
+  against a recorded 30-day baseline, without breaching agreed quality,
+  privacy, or compliance guardrails.
+- **In scope:** Read-only workflow observation; baseline measurement; one
+  bounded intervention with a tested hypothesis.
+- **Out of scope:** Claims policy changes; unapproved production changes;
+  external commitments.
+- **Constraints:** Least-privilege access; approved change windows; retention
+  and deletion rules for claims data.
+- **Success measure and decision rule:** Proceed to the next stage only when
+  the sponsor approves the metric definition, baseline, target, and guardrails
+  with named evidence.
+- **Stop conditions:** No recognizable problem; no workflow access; authority
+  or constraints cannot be named; evidence fails; next action exceeds charter.
+- **Sharing classification:** Private by default; reviewer and review date
+  recorded before any external sharing.
+
+## Ledger entries (excerpt)
+
+| ID | Type | Statement | Evidence / source | Confidence | Owner | Due / review | Status |
+|---|---|---|---|---|---|---|---|
+| A-001 | Assumption | Median cycle time is a material outcome for the engagement. | Source fact: engagement request names cycle-time reduction as the objective | High | Sponsor | Before solution design | Open |
+| D-001 | Decision | No solution design until the charter establishes problem, users, workflow, outcome, scope, authority, constraints, success measure, and stop conditions. | Decision: engagement design gate | High | Sponsor and lead | Ratified | Active |
+| R-001 | Risk | Optimizing cycle time could degrade claim quality if guardrails are not explicit. | Inference: guardrails not yet defined | Medium | Operational risk owner | Before hypothesis approval | Open |
+
+## Stage handoff — Build to Evaluate (excerpt)
+
+- **Entry evidence:** Approved requirement; thin-slice implementation plan with
+  owner; charter and ledger current.
+- **Work performed:** Thin slice built and tested against acceptance criteria.
+- **Source / evidence labels:** Each test result labeled engagement observation;
+  design choices labeled decisions.
+- **Observed result:** Slice passes technical acceptance; no production claim.
+- **Unknowns:** Production data behavior; operator workflow interaction.
+- **Decision rule:** Advance to Evaluate when representative evidence exists.
+- **Decision:** Advance to Evaluate.
+- **Receiving owner / acceptance condition:** Evaluation owner accepts the
+  slice and baseline evidence.
+
+## Evaluation and release decision (excerpt)
+
+- **Baseline and decision thresholds:** Median 30-day cycle time; 10%
+  reduction rule; quality guardrails.
+- **Representative evidence:** Workflow sample spanning claim types, channels,
+  and processor experience levels.
+- **Adversarial or misuse evidence:** Boundary inputs, partial data, and
+  worst-case queue conditions.
+- **Known constraints and residual risks:** One segment shows 8% adoption;
+  support owner not yet named.
+- **Rollout / rollback prerequisites:** Authorized change window; recovery
+  path tested; verification method named.
+- **Release decision:** Conditional — approve with the adoption plan and
+  support owner recorded as conditions.
+
+## Adoption scorecard (excerpt)
+
+- **Target workflow and users:** Claims processors in the two busiest teams.
+- **Activation event:** First claim completed with the new path.
+- **Adoption metric and decision rule:** 60% of eligible processors active
+  within 30 days.
+- **Outcome metric and decision rule:** Median cycle-time reduction >= 10%
+  with quality guardrails intact.
+- **Observed:** Team A 64% active; Team B 8% active.
+- **Blockers recorded:** Team B workflow-fit and support evidence missing;
+  incentive alignment unexamined.
+- **Interpretation:** Adoption gap is unexplained; more training or features
+  are not prescribed until access, fit, trust, support, and incentives are
+  distinguished.
+
+## Outcome measurement record (excerpt)
+
+- **Observed result:** 12% median reduction against the 10% rule.
+- **Uncertainty and confounders:** Two-week window; concurrent process
+  changes; segment imbalance.
+- **Decision:** Continue with the adoption intervention; re-measure at 60
+  days.
+
+## Productization record (excerpt)
+
+- **Observed local result:** 12% reduction; adoption strong in one segment,
+  weak in another.
+- **Reuse hypothesis:** The intervention may transfer to similar
+  intake-to-decision workflows.
+- **Classification:** Configuration — provisional, local-only. A single
+  positive outcome, weak adoption in one segment, and no willing receiving
+  owner are insufficient evidence for a reusable-pattern or product-capability
+  classification.
+- **Reuse boundary:** Restricted to the current authorized context until
+  repeated need, transferable constraints, support economics, and a receiving
+  owner are evidenced.
+- **Recommendation:** Candidate pattern for a pilot transfer; the receiving
+  product owner must approve a requirement before implementation-planning is
+  routed.
+- **Decision authority and decision:** Pending; recommendation is not a
+  decision.
+- **Field learning returned to:** Internal platform and product owners, with
+  the external-sharing gate applied.
+
+## What this example is for
+
+Calibrate the depth and evidence discipline expected of each artifact:
+separate observations from inferences, apply the declared decision rule,
+record missing evidence as bounded uncertainty, label every material entry,
+and keep the classification and recommendation separate from any authorized
+decision. Do not copy the illustrative numbers or the synthetic workflow into
+a real engagement.


### PR DESCRIPTION
## SkillOpt: three-epoch optimization of forward-deployed-engineering

Fully autonomous greenfield SkillOpt run (3 epochs) on the
`forward-deployed-engineering` bundle, following the SkillOpt methodology
(Controllable Text-Space Optimization for Agent Skills, arXiv 2605.23904).
Epoch 0 baseline: the original merge commit `a4db8e7`. All epochs ran
rollout → reflect → propose → validate → merge with distinct training and
held-out validation task sets; every edit was validated against a candidate
copy before merging. All-pass baselines throughout, so validation measured
regression plus manual verification of each exact diff.

### What changed

**Epoch 1 — prominence (c401f29)**
- Inlined the nine-stage contract table (required question, minimum output,
  stop condition) into `SKILL.md` with template links, plus the
  entry-evidence rule; deduplicated the stage table out of
  `references/lifecycle-and-artifacts.md` into a pointer (single source of
  truth).
- Named `agent-evals-and-observability` and `production-readiness` inline in
  the applied-AI release gate (loading protocol step 5).

**Epoch 2 — decision guidance (0ad03b0)**
- Added a "Where to enter the lifecycle" table mapping existing state to the
  correct entry stage (with the neckbeard route for bounded changes) and the
  entry-evidence rule for mid-stream joins.
- Replaced the flat "When not to use" list with a proactive
  Scenario | Reach for | Why routing table covering all six boundary routes.

**Epoch 3 — pattern expansion (095421c)**
- Added `references/worked-example-engagement.md`: a fully synthetic,
  sanitized depth-calibration artifact showing the complete artifact chain
  (charter excerpt, evidence-labeled ledger, stage handoff, evaluation and
  release decision, adoption scorecard, outcome measurement record,
  productization record) for one engagement.
- Added the File map row, enumerated the templates row (surfacing
  `engagement-status`), and added a depth-calibration pointer in the
  Lifecycle section.

### Validation evidence

- 15 rollout trajectories across the three epochs (structural probes,
  decision probes, pattern probes), all scored against rubrics by the
  orchestrator from raw worker output.
- 18 held-out validation trajectories (baseline + candidate, paired and
  byte-identical except the candidate copy path): 18/18 pass, 0 regressions.
- Epoch 2's decision tables measurably changed behavior: mid-stream entry
  workers echo the entry-points rule verbatim after the edit.
- Repo validators green on the final head: validate-skills, validate-bundles,
  validate-skill-quality, validate-evals, eval-coverage ratchet.

### Public-safety check

The diff was scanned for private identifiers (internal hostnames, personal
names, paths, credentials, domain names): clean. The worked example is fully
synthetic with illustrative numbers only.

Full run artifacts (dossiers, rollouts, reflection, proposals, validation)
live in the local SkillOpt state directory; the kanban board slug
`skillopt-forward-deployed-engineering` is registered for provenance.
