### PR TITLE
fix(anydoc): clarify rendered-layout inspection route

### DIFF
--- a/anydoc/SKILL.md
+++ b/anydoc/SKILL.md
@@ -138,7 +138,7 @@ Use this routing table before reaching for a conversion command:
 
 | User's request | Reach for | Why |
 | --- | --- | --- |
-| Generate, edit, inspect, or validate a PDF/Word/Excel/PowerPoint artifact | `documents` skill | anydoc converts existing documents to Markdown; it does not author or validate them. |
+| Generate, edit, inspect rendered layout, or validate a PDF/Word/Excel/PowerPoint artifact | `documents` skill | anydoc extracts existing document contents to Markdown; it does not author, preserve rendered layout, or validate artifacts. |
 | Package or author an EPUB | `epub` skill | anydoc reads an existing EPUB to Markdown but never writes or validates an EPUB container. |
 | OCR a scanned or image-only PDF | OCR tooling or the hosted Firecrawl Parse API | anydoc has no OCR path; report the documented unsupported error and do not retry locally. |
 | Scrape HTML or other web content | A web-scraping skill | HTML is not a supported anydoc input. |


### PR DESCRIPTION
## Summary

- Clarify the Any Doc negative-routing table so that `documents` is selected for rendered-layout inspection, not generic content inspection.
- Preserve Any Doc as the route for extracting contents from existing supported documents into Markdown.

This is a post-merge follow-up to #296, prompted by review of the merged documentation.

## Verification

- `python3 -m pytest -c /dev/null anydoc/tests/test_anydoc.py -q` — 52 passed, 19 subtests passed.
- `ruby scripts/validate-skills.rb` — 147 canonical skills validated.
- `ruby scripts/validate-skill-quality.rb --base origin/main` — 0 errors, 0 warnings.
- `python3 scripts/validate-evals.py` — 90 eval manifests validated.
- `git diff --check` — clean.

## Review finding addressed

The merged table previously said generic document “inspection” should route to `documents`, which could incorrectly divert a request to extract readable document contents. The wording now specifically says “inspect rendered layout.”