### PR TITLE
docs(skill): attribute supabase/evals harness reference (Apache-2.0)

### DIFF
--- a/supabase/references/agent-evals.md
+++ b/supabase/references/agent-evals.md
@@ -83,3 +83,7 @@ Use the scenario set that matches the workflow under evaluation, and prefer scen
 
 - Do not use this reference to design evaluation methodology, datasets, or graders — that is [agent-evals-and-observability](../../agent-evals-and-observability/SKILL.md).
 - Do not confuse supabase/evals with this skill's own `evals/evals.json`: the former runs agents against scored scenarios, the latter is a static output-quality contract validated by this repository.
+
+## Attribution
+
+Concepts, runtime descriptions, and commands in this reference are derived from the [supabase/evals README](https://github.com/supabase/evals), Copyright Supabase, licensed under [Apache-2.0](https://github.com/supabase/evals/blob/main/LICENSE). Definitions are paraphrased or quoted for documentation; the harness and its skills submodule remain external to this repository.

--- a/supabase/references/source-index.md
+++ b/supabase/references/source-index.md
@@ -40,6 +40,7 @@ Use current official documentation and source before making version-sensitive cl
 - Supavisor: https://github.com/supabase/supavisor
 - Supabase Postgres: https://github.com/supabase/postgres
 - PostgREST: https://github.com/PostgREST/postgrest
+- Agent evals harness: https://github.com/supabase/evals (Apache-2.0; concepts/commands checked 2026-08-09)
 
 Within the official Docker directory, read `README.md`, `CONFIG.md`, `CHANGELOG.md`, `versions.md`, `.env.example`, `docker-compose.yml`, `run.sh`, and the relevant `tests/` file together. `CONFIG.md` explicitly distinguishes source-derived facts from interpretive descriptions; use each service's own documentation or source when intent matters.
 


### PR DESCRIPTION
## What this adds

Follow-up to #306 (issue #271). The `supabase/references/agent-evals.md` reference derives its concepts, runtime descriptions, and commands from the [supabase/evals](https://github.com/supabase/evals) README, which is licensed **Apache-2.0** (our skill is MIT; the two are compatible). To satisfy Apache-2.0 notice requirements and this repository's attribution convention (AGENTS.md: attribution is maintained in the source field), this PR:

1. Adds an **Attribution** section to `supabase/references/agent-evals.md` naming the source repository, copyright holder (Supabase), and Apache-2.0 license link.
2. Adds the harness repository to the canonical source repositories list in `supabase/references/source-index.md` with its license and check date.

No skill descriptions changed, so no catalog artifacts were regenerated.

## Validation

- `ruby scripts/validate-skills.rb` — 150 skills validated, no errors
- `python3 scripts/validate-evals.py` — OK
- `python3 scripts/eval-coverage.py --modified-from origin/main` — ratchet exit 0
- Generated artifacts verified current (gen-claude-marketplace.rb, gen-codex-plugin.rb, gen-llms-txt.rb check mode)
