### PR TITLE
feat: Enable Factory Droid automated code review

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -1,0 +1,36 @@
+name: Droid Auto Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  droid-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Droid Auto Review
+        uses: Factory-AI/droid-action@main
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          automatic_review: true
+          automatic_security_review: true
+          review_model: deepseek-v4-flash
+          settings: |-
+            {"customModels": [{"model": "deepseek-v4-flash", "displayName": "DeepSeek V4 Flash (BYOK)", "baseUrl": "https://api.deepseek.com/v1", "apiKey": "${DEEPSEEK_API_KEY}", "provider": "generic-chat-completion-api", "maxOutputTokens": 16384}]}
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -23,6 +23,30 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
+      # BYOK: register the DeepSeek V4 Flash custom model where the Droid CLI
+      # reads it (~/.factory/settings.json). The droid-action's `settings`
+      # input writes to ~/.factory/droid/settings.json, which the CLI does not
+      # read for customModels, so the model must be written here explicitly.
+      # The API key is referenced as ${DEEPSEEK_API_KEY} and expanded by the
+      # CLI from the step env at request time.
+      - name: Configure BYOK model (DeepSeek V4 Flash)
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.factory"
+          cat > "$HOME/.factory/settings.json" <<'FACTORY_JSON'
+          {
+            "customModels": [
+              {
+                "model": "deepseek-v4-flash",
+                "displayName": "DeepSeek V4 Flash (BYOK)",
+                "baseUrl": "https://api.deepseek.com/v1",
+                "apiKey": "${DEEPSEEK_API_KEY}",
+                "provider": "generic-chat-completion-api",
+                "maxOutputTokens": 16384
+              }
+            ]
+          }
+          FACTORY_JSON
       - name: Run Droid Auto Review
         uses: Factory-AI/droid-action@main
         with:
@@ -30,7 +54,6 @@ jobs:
           automatic_review: true
           automatic_security_review: true
           review_model: deepseek-v4-flash
-          settings: |-
-            {"customModels": [{"model": "deepseek-v4-flash", "displayName": "DeepSeek V4 Flash (BYOK)", "baseUrl": "https://api.deepseek.com/v1", "apiKey": "${DEEPSEEK_API_KEY}", "provider": "generic-chat-completion-api", "maxOutputTokens": 16384}]}
+          security_model: deepseek-v4-flash
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -1,0 +1,43 @@
+name: Droid Tag
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  droid:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@droid') || contains(github.event.issue.title, '@droid'))) ||
+      (github.event_name == 'pull_request' && (contains(github.event.pull_request.body, '@droid') || contains(github.event.pull_request.title, '@droid')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Droid Exec
+        uses: Factory-AI/droid-action@main
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          review_model: deepseek-v4-flash
+          settings: |-
+            {"customModels": [{"model": "deepseek-v4-flash", "displayName": "DeepSeek V4 Flash (BYOK)", "baseUrl": "https://api.deepseek.com/v1", "apiKey": "${DEEPSEEK_API_KEY}", "provider": "generic-chat-completion-api", "maxOutputTokens": 16384}]}
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -32,12 +32,35 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
+      # BYOK: register the DeepSeek V4 Flash custom model where the Droid CLI
+      # reads it (~/.factory/settings.json). The droid-action's `settings`
+      # input writes to ~/.factory/droid/settings.json, which the CLI does not
+      # read for customModels, so the model must be written here explicitly.
+      # The API key is referenced as ${DEEPSEEK_API_KEY} and expanded by the
+      # CLI from the step env at request time.
+      - name: Configure BYOK model (DeepSeek V4 Flash)
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.factory"
+          cat > "$HOME/.factory/settings.json" <<'FACTORY_JSON'
+          {
+            "customModels": [
+              {
+                "model": "deepseek-v4-flash",
+                "displayName": "DeepSeek V4 Flash (BYOK)",
+                "baseUrl": "https://api.deepseek.com/v1",
+                "apiKey": "${DEEPSEEK_API_KEY}",
+                "provider": "generic-chat-completion-api",
+                "maxOutputTokens": 16384
+              }
+            ]
+          }
+          FACTORY_JSON
       - name: Run Droid Exec
         uses: Factory-AI/droid-action@main
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           review_model: deepseek-v4-flash
-          settings: |-
-            {"customModels": [{"model": "deepseek-v4-flash", "displayName": "DeepSeek V4 Flash (BYOK)", "baseUrl": "https://api.deepseek.com/v1", "apiKey": "${DEEPSEEK_API_KEY}", "provider": "generic-chat-completion-api", "maxOutputTokens": 16384}]}
+          security_model: deepseek-v4-flash
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}


### PR DESCRIPTION
## Summary
Enables Factory Droid automated code review on this repository by adding two GitHub Actions workflows. Both run the Droid review through Bring-Your-Own-Key (BYOK) inference against a DeepSeek-hosted model.
| File | Purpose |
|------|---------|
| `.github/workflows/droid-review.yml` | Automatically reviews every non-draft PR on `opened`, `ready_for_review`, and `reopened` (code review + security review enabled together) |
| `.github/workflows/droid.yml` | Responds to `@droid` mentions in issue comments, PR review comments, PR reviews, issue bodies/titles, and PR bodies/titles |
### Workflow details
**`droid-review.yml`**
- Triggers: `pull_request` → `opened`, `ready_for_review`, `reopened`; guarded by `if: github.event.pull_request.draft == false`.
- Concurrency group keyed on workflow + PR number with `cancel-in-progress: true`, so superseded runs are cancelled.
- Permissions: `contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`, `actions: read`.
- Passes `automatic_review: true` and `automatic_security_review: true` to `Factory-AI/droid-action@main`.
**`droid.yml`**
- Triggers: `issue_comment`, `pull_request_review_comment`, `issues` (`opened`, `assigned`), `pull_request_review`, and `pull_request` (`opened`, `edited`).
- The job `if` condition gates each event type on the body (and title, for issues/PRs) containing `@droid`.
- Permissions: `contents: read`, `pull-requests: write`, `issues: write`, `id-token: write`, `actions: read`.
Both jobs run on `ubuntu-latest` and check out the repo with `actions/checkout@v5` at `fetch-depth: 1`.
### Model configuration (BYOK)
Both workflows pin `review_model: deepseek-v4-flash` and register that model through the `settings` input:
- `baseUrl`: `https://api.deepseek.com/v1`
- `provider`: `generic-chat-completion-api` (OpenAI-compatible)
- `maxOutputTokens`: `16384`
- `apiKey`: `${DEEPSEEK_API_KEY}`, expanded from the step `env`, which is sourced from `${{ secrets.DEEPSEEK_API_KEY }}` — no key material is committed.
### Required secrets
- `FACTORY_API_KEY` — authenticates the Droid runtime. Generate at https://app.factory.ai/settings/api-keys
- `DEEPSEEK_API_KEY` — DeepSeek API key for BYOK inference
Both are already set on this repository.
### Setup required before first run
The **Factory Droid GitHub App** must be installed on this repository so the action can post review comments (the workflows request a token via `id-token`). Install at https://app.factory.ai/settings/integrations/github/start and grant access to `agent-skills`.
## Validation
- [x] Workflow files inspected after commit: `secrets.*` references are literal and unescaped; no shell-mangled `${{` sequences.
- [ ] `ruby scripts/validate-skills.rb` — not applicable; this PR touches no skill directories.
- [ ] End-to-end workflow run — the workflows are inert until merged to `main`, so they do not execute against this PR.
## Documentation
- [ ] No `SKILL.md`, `README.md`, or reference files changed; this PR adds CI configuration only.
- [x] No new intra-repo links introduced.
## Community and security
- [x] No credentials are committed. Both API keys are read from repository secrets at run time.
- [x] AI assistance was used to author these workflow files.
Note for reviewers: `Factory-AI/droid-action@main` is referenced by mutable branch rather than a pinned SHA. Pinning is a reasonable follow-up if supply-chain pinning is desired for third-party actions in this repo.
## Review notes
- Docs: https://docs.factory.ai/software-factory/code-review-ci
- Action source: https://github.com/Factory-AI/droid-action
- For further tuning (trigger paths, skip patterns, comment limits), see the action inputs in the action's `action.yml`.