### PR TITLE
feat: enrich site reliability engineering skill from O'Reilly SRE books

### DIFF
--- a/site-reliability-engineering/README.md
+++ b/site-reliability-engineering/README.md
@@ -13,13 +13,13 @@ Use it when the work needs a repeatable process and an inspectable result. It is
 | Path | What it provides |
 |---|---|
 | `SKILL.md` | Trigger conditions, workflow, and guidance for loading deeper resources. |
-| `references/` | Reference material: `guiding-principles.md`, `incident-command-system.md`, `monitoring-alerting.md`, `oncall-best-practices.md`, `postmortem-culture.md`, `product-focused-reliability.md`, `release-engineering.md`, `senior-sre-blueprint.md`, `slo-sli-framework.md`, `sre-book-chapters.md`, `sre-communication-guide.md`, `sre-ecosystem-guide.md`, `toil-elimination.md`, `troubleshooting.md`, `twenty-years-lessons.md` |
-| `templates/` | Templates: `error-budget-policy.md`, `incident-command-checklist.md`, `incident-communication.md`, `oncall-rotation.md`, `postmortem-template.md`, `runbook-template.md`, `service-review-checklist.md`, `slo-declaration-template.md` |
+| `references/` | Reference material for SLOs, incidents, on-call, toil, troubleshooting, product engagement, adoption, reliability design, human systems, and the SRE learning ecosystem. |
+| `templates/` | Templates for SLOs, error budgets, incident response, runbooks, service reviews, reliability design reviews, and overload recovery. |
 | `scripts/` | Scripts: `slo-burn-rate.py` |
 
 ## Quick Start
 
-Start with the SLO/SLI, incident-command, or service-review template that matches the work at hand.
+Start with the SLO/SLI, incident-command, service-review, reliability-design-review, or operational-overload-recovery template that matches the work at hand.
 
 Install or expose this directory using your agent's standard Agent Skills loading mechanism, then ask for work that matches the triggers below.
 
@@ -28,6 +28,8 @@ Install or expose this directory using your agent's standard Agent Skills loadin
 - Design, operate, and improve reliable production systems with SLOs, incident command, observability, error budgets, and operational practices.
 - Requests involving the method, deliverables, or review process described in `SKILL.md`.
 - Work where a reusable template or reference from this skill would reduce avoidable mistakes.
+- Work that adopts SRE practices without assuming a dedicated SRE department.
+- Reliability design, capacity, overload, configuration, canary, dependency, durability, or operational-learning reviews.
 
 ## Requirements
 

--- a/site-reliability-engineering/SKILL.md
+++ b/site-reliability-engineering/SKILL.md
@@ -6,6 +6,7 @@ compatibility: Python 3.9+ is required only for the bundled calculation and summ
 metadata:
   source_repo: https://github.com/magnus919/hermes-profiles
   source_commit: 867a555
+  enrichment_sources: "Seeking SRE; The Site Reliability Workbook"
 ---
 
 
@@ -24,6 +25,10 @@ A comprehensive methodology for designing, operating, and improving reliable pro
 | "Do a reliability review" | Architecture review against SRE principles, risk assessment |
 | "I need an incident commander" | Incident command framework, role cards, communication templates |
 | "Automate this operational task" | Toil assessment, automation decision tree, runbook pattern |
+| "Adopt SRE in this organization" | Engagement boundaries, maturity, team model, and change adoption |
+| "Review this reliability design" | User journeys, dependencies, overload, configuration, canary, durability |
+| "Our SRE team is overloaded" | Operational-load diagnosis, protected engineering time, recovery plan |
+| "Improve incident learning or sustainable on-call" | Cognitive load, psychological safety, documentation, exercises |
 ## When not to use
 
 Use [release-engineering](../release-engineering/SKILL.md) to plan releases, compose promotion and rollback gates, or coordinate a release train. Use [systematic-debugging](../systematic-debugging/SKILL.md) to find the cause of a specific failure. Operating the telemetry stack itself — Prometheus scrape configs, OpenTelemetry Collector pipelines, Loki ingest and retention, Prometheus rules files — belongs to [telemetry](../telemetry/SKILL.md); this skill owns the SLI/SLO and alert *design* those rules implement. Grafana product work — dashboards, panels, Grafana-side alert rules, contact points, notification policies — belongs to [grafana](../grafana/SKILL.md).
@@ -34,7 +39,8 @@ Use [release-engineering](../release-engineering/SKILL.md) to plan releases, com
 |---|---|---|
 | SRE Book Chapter Summaries | `references/sre-book-chapters.md` | Design engagement, first principles review |
 | SLO/SLI Framework | `references/slo-sli-framework.md` | Defining reliability targets |
-| Error Budget Governance | `references/error-budget-governance.md` | Policy design, burn rate alerts |
+| SLO Implementation Recipe | `references/slo-implementation-recipe.md` | Agent-executable SLO adoption sequence and stakeholder review |
+| Error Budget Governance | `templates/error-budget-policy.md` and `references/slo-sli-framework.md` | Policy design, burn rate alerts |
 | Incident Command System | `references/incident-command-system.md` | During/after incident, training |
 | Blameless Postmortems | `references/postmortem-culture.md` | After incident, process design |
 | Monitoring & Alerting | `references/monitoring-alerting.md` | Observability design, alert rules |
@@ -48,6 +54,11 @@ Use [release-engineering](../release-engineering/SKILL.md) to plan releases, com
 | Product-Focused Reliability | `references/product-focused-reliability.md` | Product-centric SRE, CUJ-based SLOs, JTBD model |
 | Twenty Years of Lessons | `references/twenty-years-lessons.md` | Incident-derived tactical lessons, Prodverbs |
 | SRE Ecosystem Guide | `references/sre-ecosystem-guide.md` | Curated guide to all SRE resources (Workbook, Secure Systems, Classroom, Prodcast, STPA, Video Gallery, Mobaa, fundamentals, AI ops) |
+| Adoption and Engagement | `references/sre-adoption-and-engagement.md` | Starting SRE, dedicated and non-dedicated team models, maturity, change adoption |
+| Reliability Design and Change | `references/reliability-design-and-change.md` | Capacity, overload, configuration, canaries, data durability, dependencies, design review |
+| Human Systems and Learning | `references/human-systems-and-learning.md` | Cognitive work, sustainable on-call, psychological safety, documentation, exercises |
+| Third-Party Dependency Reliability | `references/third-party-dependency-reliability.md` | Vendor boundaries, failure modes, fallbacks, and provider evidence |
+| Operational Documentation | `references/operational-documentation.md` | Functional quality, ownership, testing, and staleness lifecycle |
 
 ## Templates
 
@@ -61,13 +72,15 @@ Use [release-engineering](../release-engineering/SKILL.md) to plan releases, com
 | On-Call Rotation Template | `templates/oncall-rotation.md` | Rotation schedule and escalation |
 | Service Review Checklist | `templates/service-review-checklist.md` | Pre-launch reliability review |
 | Incident Communication Template | `templates/incident-communication.md` | Status updates during incidents |
+| Reliability Design Review | `templates/reliability-design-review.md` | Evidence-based review of user impact, failure modes, capacity, change, and operations |
+| Operational Overload Recovery | `templates/operational-overload-recovery.md` | Declare, protect, reduce, and verify recovery from unsustainable operational load |
+| Reliability Ownership Charter | `templates/reliability-ownership-charter.md` | Make service, pager, dependency, and engagement boundaries explicit |
 
 ## Scripts
 
 | Script | Purpose |
 |---|---|
 | `scripts/slo-burn-rate.py` | Calculate error budget burn rate from SLI data |
-| `scripts/postmortem-summary.py` | Generate a postmortem summary from structured data |
 
 ## Portability
 

--- a/site-reliability-engineering/evals/evals.json
+++ b/site-reliability-engineering/evals/evals.json
@@ -61,6 +61,42 @@
         "The dependency causing the burn gets an owner and timeline",
         "One-off exceptions with stated owners are distinguished from policy-ignoring patterns"
       ]
+    },
+    {
+      "id": "reliability-design-review",
+      "prompt": "Review this proposed event-processing service before launch. It has a REST API, a queue, a database, and two external providers. Traffic may grow 20x during campaigns. What evidence and design decisions must be explicit before approval?",
+      "expected_output": "A concrete reliability design review that starts from user journeys and SLOs, maps synchronous and asynchronous dependencies, quantifies demand and capacity, covers retries and overload, distinguishes availability from data correctness and durability, defines canary and rollback evidence, and assigns owners and verification criteria for unresolved risks.",
+      "assertions": [
+        "The review begins with user journeys and user-facing SLOs rather than infrastructure labels",
+        "Capacity, queues, retries, timeouts, and dependency failure modes are quantified or explicitly marked unknown",
+        "Overload behavior includes admission control, degradation, shedding, or bounded backlog decisions",
+        "Data correctness, durability, recovery, and privacy are treated separately from availability",
+        "Canary, rollback, ownership, and live-boundary verification criteria are explicit"
+      ]
+    },
+    {
+      "id": "sre-adoption-without-team",
+      "prompt": "We are a 30-person engineering organization with no SRE team. Engineers own services but pages are noisy and incidents depend on two people. How can we adopt SRE without creating a central gatekeeping department?",
+      "expected_output": "A bounded adoption plan that starts with one service and user-facing SLOs, measures toil and incident load, assigns service ownership, uses a hybrid or working-group model deliberately, provides context rather than opaque approvals, includes training and review cadence, and defines evidence-based exit or expansion criteria.",
+      "assertions": [
+        "The plan does not assume a dedicated SRE department is required",
+        "A bounded pilot has measurable SLO, incident, toil, and ownership evidence",
+        "The proposed operating model preserves service-team accountability and avoids central gatekeeping",
+        "Adoption includes training, change-management, review cadence, and explicit exit or expansion criteria",
+        "Noisy alerts and two-person dependency are treated as system risks with engineering remedies"
+      ]
+    },
+    {
+      "id": "operational-overload-and-human-factors",
+      "prompt": "Our SRE team is spending 80% of its time on pages and manual changes, and people are afraid to challenge risky mitigations during incidents. What should the recovery plan contain?",
+      "expected_output": "An overload recovery plan that declares the condition with evidence, protects engineering time, inventories and reduces recurring work, renegotiates scope, improves alert and configuration safety, establishes escalation and psychological safety, and verifies recovery through operational-load and reliability trends rather than asking people to work harder.",
+      "assertions": [
+        "Operational overload is declared using a measurable threshold and evidence",
+        "The plan protects engineering time and explicitly renegotiates scope or commitments",
+        "Pages and manual changes are inventoried with owners and verification criteria for reduction",
+        "Incident roles and psychological safety make it safe to challenge unsafe actions and escalate",
+        "Exit criteria include sustainable workload and verified reduction of recurring load"
+      ]
     }
   ]
 }

--- a/site-reliability-engineering/references/human-systems-and-learning.md
+++ b/site-reliability-engineering/references/human-systems-and-learning.md
@@ -1,0 +1,111 @@
+# Human Systems, Learning, and Sustainable SRE
+
+Reliability work is cognitive and social work as well as technical work. Use this reference when designing on-call, incident training, postmortem learning, documentation, team health, or operational policies that affect people.
+
+## Source anchors
+
+This reference synthesizes *Seeking SRE*, “Do Docs Better,” “Active Teaching and Learning,” “Psychological Safety in SRE,” “SRE Cognitive Work,” “Beyond Burnout,” and “Against On-Call: A Polemic,” with the practical on-call, incident, and postmortem chapters of *The Site Reliability Workbook*. These sources include opinion and experience as well as general practice. Treat claims about health, accommodation, and employment as context for humane design, not medical or legal advice.
+
+## Design for cognitive work
+
+During an incident, operators are not interchangeable sensors. They interpret incomplete signals, form and revise hypotheses, coordinate across boundaries, and choose actions under time pressure. Reduce avoidable cognitive load:
+
+- provide a small set of trusted dashboards and a current service map;
+- make dependencies, recent changes, and rollback paths easy to find;
+- separate incident command from deep technical investigation;
+- record decisions and hypotheses so responders do not repeatedly reconstruct context;
+- prefer reversible actions and observe their effects;
+- make escalation normal and fast;
+- preserve a quiet channel for coordination when the main channel is noisy.
+
+Automation should remove repetitive work while keeping the operator's decision boundary visible. A system that acts automatically must expose what it observed, what it changed, and how to stop or reverse it.
+
+## On-call is a system property
+
+Do not judge an on-call rotation only by whether pages are answered. Review:
+
+- page volume, actionability, urgency, and repeat rate;
+- time spent on pages, tickets, handoffs, and recovery;
+- interruptions outside shifts and the quality of escalation;
+- whether responders have current runbooks, access, context, and training;
+- whether the service can be operated without heroic individual knowledge;
+- recovery time and post-incident cognitive load;
+- whether the rotation leaves time for engineering that reduces future load.
+
+A rotation that relies on exhausted people, undocumented exceptions, or constant escalation is not reliable even when uptime looks acceptable. If the service cannot support a sustainable rotation, reduce scope, improve automation, change the service, or stop carrying the pager until the risk is acknowledged.
+
+## Psychological safety in reliability work
+
+Effective teams make it safe to report uncertainty, challenge a plan, ask for help, and surface a risk raised by a junior responder. Psychological safety is not permission to skip accountability. It is a condition for receiving the information needed for accountability.
+
+Make it observable:
+
+- the incident commander explicitly invites dissent and clarifying questions;
+- a responder can pause a rollout or mitigation when a stated safety condition is violated;
+- postmortems analyze system conditions rather than assign personal fault;
+- leaders respond to bad news with investigation and support, not punishment;
+- action items improve interfaces, defaults, tests, access, or training rather than merely reminding people to be careful.
+
+A blameless culture still names decisions, conditions, and owners. “No blame” must not become “no learning” or “no follow-through.”
+
+## Documentation as an operational control
+
+Documentation is part of the service's reliability surface. A document should have:
+
+- a named audience and task;
+- prerequisites and access requirements;
+- observable symptoms and scope boundaries;
+- safe first actions and explicit stop conditions;
+- verification after each consequential action;
+- escalation path and rollback or recovery path;
+- owner, review date, and links to source configuration or dashboards.
+
+Keep documentation in the engineering workflow. Update it when a runbook is used, an incident exposes a gap, a configuration changes, or a new operator is trained. Stale documentation should be treated as an operational defect, not as a writing problem deferred indefinitely.
+
+## Practice before production
+
+Incident command and mitigation are skills. Use bounded, low-risk practice:
+
+- scenario exercises with realistic but synthetic failures;
+- game days and disaster-recovery drills;
+- tabletop exercises for third-party and communication failures;
+- shadow shifts and graduated on-call access;
+- short drills that rehearse one capability, such as rollback or traffic shedding.
+
+After an exercise, record what participants could and could not find, decide, or execute. The learning objective is not theatrical realism. It is to expose missing context, unsafe defaults, confusing roles, and untested recovery paths before a real incident.
+
+## Learning loops
+
+A postmortem is useful only when it changes future capability. Link each action to:
+
+- the failure condition it addresses;
+- an owner with authority and time;
+- a due date or review checkpoint;
+- an observable completion criterion;
+- a later verification that the change reduced risk or toil.
+
+Track recurring triggers across incidents. A single incident may be local; a pattern across services may justify a platform, design, training, or organizational intervention. Do not optimize for a rising closure count if the actions are vague or unverified.
+
+## Inclusion and sustainable work
+
+Design for different working styles and access needs without requiring people to disclose private medical information to participate safely. Practical safeguards include written incident roles, asynchronous handoff records, predictable escalation paths, quiet channels, clear interruption expectations, and multiple ways to contribute during reviews and exercises.
+
+Do not diagnose, infer, or prescribe. Ask what working arrangement or interface makes the task safe and effective, follow applicable organizational processes, and keep private information out of operational artifacts.
+
+## When on-call should be redesigned
+
+Treat these as design signals, not individual failure:
+
+- persistent high page volume or repeated non-actionable pages;
+- responders cannot complete engineering work;
+- incidents depend on one person or one undocumented procedure;
+- escalation is delayed because people fear being judged;
+- frequent sleep disruption, burnout, or unsafe fatigue;
+- the service has no credible degraded mode or recovery test;
+- the team cannot staff the rotation without coercion.
+
+The response may be alert reduction, service simplification, ownership change, scope reduction, a dedicated operations function, or retiring the service. “Try harder” is not a reliability strategy.
+
+## Agent procedure
+
+When asked to improve on-call or incident learning, load this reference with `oncall-best-practices.md`, `incident-command-system.md`, and `postmortem-culture.md`. Include both service metrics and human-work metrics. Distinguish observed evidence, team-reported experience, and proposed safeguards.

--- a/site-reliability-engineering/references/operational-documentation.md
+++ b/site-reliability-engineering/references/operational-documentation.md
@@ -1,0 +1,39 @@
+# Operational Documentation Lifecycle
+
+Use this reference when runbooks, alerts, service maps, configuration guidance, or incident procedures are stale, hard to find, or not trusted by responders.
+
+## Source anchors
+
+Synthesized from *Seeking SRE*, “Do Docs Better: Integrating Documentation into the Engineering Workflow,” “Active Teaching and Learning,” “SRE Cognitive Work,” and “Psychological Safety in SRE.”
+
+## Functional quality
+
+A document is good when it helps its intended reader complete a real task safely. Check more than spelling and structure:
+
+- Can the reader identify the symptom and scope?
+- Does the document state prerequisites, access, and assumptions?
+- Are the first actions safe, bounded, and reversible?
+- Does every consequential action have an observable verification?
+- Does it say when to stop, escalate, or hand off?
+- Are dashboards, configuration, owners, and dependencies linked to authoritative sources?
+- Can a new responder follow it without relying on private memory?
+
+## Lifecycle
+
+1. Create the smallest document for a named task and audience.
+2. Store it beside the service or in a discoverable source-controlled location.
+3. Link alerts and service reviews to it.
+4. Test it during onboarding, game days, and real incidents.
+5. Update it when the service, alert, configuration, dependency, or recovery path changes.
+6. Record owner and review trigger, not only a calendar date.
+7. Prune documents that no longer describe a supported path.
+
+Documentation work belongs in the engineering workflow. A stale runbook is an operational defect that can prolong an incident.
+
+## Coverage signals
+
+Useful signals include alert-to-playbook coverage, broken-link count, age of last successful exercise, time for a new responder to complete a task, and incidents where missing or misleading documentation delayed mitigation. Do not optimize for document count or word count.
+
+## Agent procedure
+
+Use this reference with `templates/runbook-template.md`, `monitoring-alerting.md`, and `human-systems-and-learning.md`. When editing a runbook, verify every command's scope, prerequisite, expected result, and rollback. If the source of truth is unavailable, mark the link and assumption instead of fabricating it.

--- a/site-reliability-engineering/references/reliability-design-and-change.md
+++ b/site-reliability-engineering/references/reliability-design-and-change.md
@@ -1,0 +1,133 @@
+# Reliability Design, Change Safety, and Overload
+
+Use this reference for design reviews, capacity and overload planning, production configuration, canary releases, data pipelines, and services whose reliability depends on more than availability alone.
+
+## Source anchors
+
+This reference synthesizes *The Site Reliability Workbook*, “Managing Load,” “Introducing Non-Abstract Large System Design,” “Data Processing Pipelines,” “Configuration Design and Best Practices,” “Configuration Specifics,” “Canarying Releases,” and “Identifying and Recovering from Overload,” plus *Seeking SRE*, “In the Beginning, There Was Chaos,” “Database Reliability Engineering,” “Engineering for Data Durability,” “Immutable Infrastructure and SRE,” “Scriptable Load Balancers,” and “The Service Mesh: Wrangler of Your Microservices?” The source books contain organization-specific examples; the procedures below generalize the engineering decisions without copying those examples.
+
+## Design for the whole system
+
+A reliability design review must include the user journey, not just the service under review. For each proposed system:
+
+1. State the user-visible objectives and the SLOs they imply.
+2. Draw the request and data paths, including asynchronous work and third parties.
+3. Identify capacity limits, queues, retries, timeouts, rate limits, and shared resources.
+4. Describe normal, degraded, overloaded, and recovery states.
+5. Define what can be shed, delayed, cached, degraded, or served read-only.
+6. Identify data-loss, corruption, privacy, and security consequences separately from downtime.
+7. Specify observability, operator actions, rollback, restore, and verification.
+8. Estimate operational work and cognitive load before approving the design.
+
+A design that meets an availability target by silently corrupting data or violating privacy is not reliable.
+
+## Non-Abstract Large System Design (NALSD-style review)
+
+Use concrete boundaries and numbers rather than “high scale” or “resilient.” Record:
+
+- expected request, event, and data rates, including peak and burst shape;
+- storage growth, retention, replication, and recovery-point objectives;
+- latency budgets across each dependency hop;
+- failure domains and blast radius;
+- consistency, ordering, idempotency, and replay behavior;
+- quotas, backpressure, retry limits, and queue bounds;
+- deployment and migration strategy;
+- cost and operational ownership.
+
+Iterate the design against the SLO and error budget. If a proposed feature consumes more reliability, capacity, or operator attention than the budget allows, record the trade-off and decision owner instead of hiding it in implementation detail.
+
+## Load and overload management
+
+Capacity planning is not only “add more machines.” Build a demand model from historical traffic, expected growth, scheduled events, and worst credible bursts. Test the model before the event and identify the manual fallback if automation fails.
+
+When overload begins:
+
+1. Confirm whether demand, capacity, dependency latency, or a control-plane failure is the limiting factor.
+2. Stop amplification: bound retries, disable nonessential fan-out, and prevent queue growth from becoming unbounded.
+3. Protect the critical user journey with admission control, prioritization, rate limits, caching, or graceful degradation.
+4. Shed or defer work deliberately. Prefer a known reduced mode over random timeouts.
+5. Watch saturation, queue depth, latency, errors, and dependency health for recovery evidence.
+6. Restore normal traffic gradually and verify that backlog, data integrity, and downstream systems recover.
+7. Record the capacity assumption that failed and create an owned repair.
+
+A service that responds slowly under overload can consume more shared capacity through timeouts and retries, creating a cascade. Fast rejection with a clear degraded path can be more reliable than accepting work that cannot complete.
+
+## Operational overload of the team
+
+A team is operationally overloaded when urgent work continually preempts the engineering needed to reduce future load. Track operational work as a proportion of available engineering time, including pages, tickets, manual changes, support interruptions, and incident follow-up.
+
+Recovery requires an explicit cutover:
+
+- declare the team overloaded using a stated threshold or sustained trend;
+- protect a fixed block of engineering time;
+- reduce or renegotiate service scope and nonessential commitments;
+- suppress, route, or retire non-actionable alerts;
+- prioritize the smallest changes that remove recurring interruption;
+- assign leadership support for deferred product work and staffing gaps;
+- review the load trend weekly until the team returns below the threshold.
+
+Do not respond to operational overload by asking the team to work longer hours. That hides the capacity failure and increases incident risk.
+
+## Configuration safety
+
+Treat configuration as production code with an explicit lifecycle:
+
+- one authoritative source and a discoverable ownership path;
+- schema, type, range, dependency, and compatibility validation;
+- safe defaults and explicit units;
+- version control, review, audit trail, and rollback;
+- staged rollout or canary for high-impact changes;
+- dry-run or preview where possible;
+- clear distinction between static configuration and runtime state;
+- emergency path that is fast but still logged and reconciled into source control.
+
+Configuration should be easy to inspect during an incident. Avoid hidden inheritance, ambiguous names, duplicated values, unbounded lists, and emergency-only interfaces. A configuration change needs a stated expected effect and a way to observe whether that effect occurred.
+
+## Canarying changes
+
+A canary is a partial, time-limited deployment evaluated against a control. It is not merely “deploy to one host.” Define before rollout:
+
+- canary population and selection method;
+- control population and whether traffic is comparable;
+- observation window and minimum sample size;
+- success metrics tied to SLOs, user journeys, saturation, and dependency health;
+- abort thresholds and who or what can stop the rollout;
+- rollback or roll-forward action;
+- criteria for expanding, pausing, or declaring success.
+
+Compare canary and control, and account for traffic mix, time-of-day, cold starts, and unrelated changes. A canary with no control, no minimum sample, or no abort authority creates the appearance of safety without the decision evidence.
+
+## Data processing and durability
+
+For pipelines and data stores, define reliability beyond service uptime:
+
+- freshness and completeness of output;
+- correctness and reconciliation checks;
+- ordering, duplication, replay, and late-arriving data behavior;
+- checkpointing, retention, backfill, and recovery-point objectives;
+- schema evolution and compatibility;
+- access control and privacy boundaries;
+- restore tests and corruption detection.
+
+Availability and durability are different SLO dimensions. A pipeline can be “up” while producing stale, incomplete, duplicated, or wrong data. A database can answer requests while losing writes. Measure the property users and downstream decisions depend on.
+
+## Third-party dependencies
+
+Apply SRE discipline to vendors and managed services:
+
+1. Classify the dependency by user impact, substitutability, and failure mode.
+2. Record the dependency's SLO or service limits, support path, status signal, and contractual boundaries.
+3. Measure the dependency from your service's perspective, not only from the vendor dashboard.
+4. Design timeout, retry, fallback, queue, cache, and degraded-mode behavior.
+5. Test provider failure and credential, quota, region, and API-version failure modes.
+6. Track unresolved vendor repairs and review whether the dependency remains acceptable.
+
+“External” is not the same as “unowned.” If a dependency failure is excluded from your SLO, document what users experience and what mitigation you actually provide.
+
+## Complexity and service mesh caution
+
+Prefer the simplest architecture that meets the objectives. Every proxy, control plane, configuration layer, retry policy, and telemetry path adds failure modes and cognitive load. Adopt a service mesh or similar platform only when the operational capability it provides outweighs its new blast radius and the team can observe and operate it.
+
+## Agent procedure
+
+Use this reference with `slo-sli-framework.md`, `monitoring-alerting.md`, `release-engineering.md`, and `troubleshooting.md`. Use the `templates/reliability-design-review.md` template. Reject vague claims such as “handles scale” or “has rollback” until the owner, evidence, thresholds, and verification path are explicit.

--- a/site-reliability-engineering/references/slo-implementation-recipe.md
+++ b/site-reliability-engineering/references/slo-implementation-recipe.md
@@ -1,0 +1,51 @@
+# SLO Implementation Recipe
+
+Use this reference when a team has no SLOs, has metrics but no shared objectives, or needs to turn an SLO discussion into an operating agreement. It complements `references/slo-sli-framework.md`; it does not replace its definitions or formulas.
+
+## Source anchors
+
+Synthesized from *The Site Reliability Workbook*, “Implementing SLOs,” “SLO Engineering Case Studies,” “Alerting on SLOs,” and “Example SLO Document,” and *Seeking SRE*, “The Art and Science of the Service-Level Objective,” “SRE as a Success Culture,” and “Using Incident Metrics to Improve SRE at Scale.”
+
+## The bounded sequence
+
+1. **Choose one service and identify its users.** Include direct users, downstream services, operators, and business processes. State what failure means to each.
+2. **Map the important journeys.** Describe the request path, asynchronous path, data path, dependencies, and the point at which users experience success or failure.
+3. **Select a small initial set of indicators.** Prefer a few customer-facing indicators for availability, latency, correctness, freshness, or durability. Do not begin by turning every metric into an SLO.
+4. **Define good and bad events.** State valid events, exclusions, aggregation, data source, sampling, and measurement boundary. A formula without a measurement boundary is not an SLI.
+5. **Measure the baseline.** Use a representative period and record gaps in instrumentation. A target should be feasible and meaningful, not an aspirational number copied from another service.
+6. **Propose targets and windows.** Explain the user impact and expected error budget for each target. Use rolling windows when the decision needs a current operating signal; use calendar or contractual windows only when that is the real agreement.
+7. **Review with stakeholders.** The product owner, service owner, support or customer-facing team, and reliability operator must be able to explain what the objective protects and what it will cause them to do.
+8. **Define the policy before the first breach.** Specify what healthy, at-risk, and exhausted budget states change: release pace, reliability work, incident review, escalation, or scope.
+9. **Alert on significant budget consumption.** Use multi-window burn-rate alerts and route pages only when the response is urgent and actionable. Use tickets or review queues for slower repair work.
+10. **Run a review cycle.** Revisit targets when user expectations, architecture, traffic, dependencies, or product criticality changes. Record why the target changed and what evidence supported it.
+
+## SLO review questions
+
+- Would a user notice the measured failure, or is it only an internal proxy?
+- Can the team take action when the SLO is violated or burning rapidly?
+- Does the measurement include dependency and client-side effects that matter to the journey?
+- Are exclusions hiding a failure the user still experiences?
+- Does the error budget create enough signal before the service becomes unacceptable?
+- Is the target tight enough to protect users but loose enough to permit justified change?
+- What happens when the team cannot operate within the target and toil constraints?
+
+## What to record
+
+Every approved SLO should link to a declaration containing:
+
+- user journey and service owner;
+- SLI good-event definition and measurement boundary;
+- data source, query, aggregation, and known blind spots;
+- target, window, error budget, and review date;
+- alert and escalation behavior;
+- release and reliability-work policy;
+- dependency treatment and exception process;
+- evidence baseline and unresolved instrumentation gaps.
+
+## SLO failure is a decision signal
+
+Do not treat SLOs as a performance score or a punishment mechanism. A budget breach is evidence that the service needs reliability attention, reduced change risk, more capacity, a dependency intervention, an objective revision backed by new user evidence, or a scope decision. Repeatedly overriding the policy without recording the reason turns the SLO into decoration.
+
+## Agent procedure
+
+Load this recipe with `references/slo-sli-framework.md` and `templates/slo-declaration-template.md`. If the user has supplied no service, users, or measurement data, produce a discovery plan and mark assumptions rather than inventing targets.

--- a/site-reliability-engineering/references/source-index.md
+++ b/site-reliability-engineering/references/source-index.md
@@ -4,3 +4,10 @@
 - **Inspected commit:** `867a555`
 - **Imported source directory:** `site-reliability-engineering`
 - **Porting boundary:** Retained portable methodology, templates, scripts, and references. Removed or generalized Hermes profile, task-orchestration, memory, and rigid response-handoff assumptions.
+
+## Enrichment sources
+
+- *Seeking SRE*, edited by David N. Blank-Edelman, O'Reilly, 2018. Local source supplied by the user: `seekingsre.epub`.
+- *The Site Reliability Workbook*, Betsy Beyer, Niall Richard Murphy, David K. Rensin, Kent Kawahara, and Stephen Thorne, O'Reilly, 2018. Local source supplied by the user: `thesitereliabilityworkbook.epub`.
+
+The enrichment references paraphrase and synthesize the supplied books' implementation lessons. They do not reproduce chapter text. Chapter-level source anchors are recorded in each new reference so an agent can distinguish book-derived practice from the skill's own synthesis.

--- a/site-reliability-engineering/references/sre-adoption-and-engagement.md
+++ b/site-reliability-engineering/references/sre-adoption-and-engagement.md
@@ -1,0 +1,126 @@
+# SRE Adoption, Engagement, and Team Design
+
+This reference turns SRE from a named team into a set of adoptable operating practices. Use it when an organization is starting SRE, lacks a dedicated SRE team, is introducing SRE into an enterprise, or needs to decide how a reliability engagement should begin and end.
+
+## Source anchors
+
+This guidance is a synthesis of *The Site Reliability Workbook*, especially “How SRE Relates to DevOps,” “SRE Engagement Model,” “SRE Team Lifecycles,” and “Organizational Change Management in SRE,” and *Seeking SRE*, especially “Context Versus Control in SRE,” “So, You Want to Build an SRE Team?,” “How to Apply SRE Principles Without Dedicated SRE Teams,” “SRE Without SRE: The Spotify Case Study,” “Introducing SRE in Large Enterprises,” “Clearing the Way for SRE in the Enterprise,” and “Using Incident Metrics to Improve SRE at Scale.” These are paraphrased implementation lessons, not a replacement for the books.
+
+## First decision: adopt practices or create a team?
+
+Do not begin by renaming an operations team. Establish the problem and the smallest useful intervention:
+
+1. Name the user and business consequence of unreliable behavior.
+2. Establish one or two user-facing SLIs and an initial SLO, even if measurement is imperfect.
+3. Make the current operational load visible: pages, tickets, manual changes, support escalations, and repair work.
+4. Pick one service or user journey with an owner who can act on the measurements.
+5. Run a short review cycle, then decide whether the evidence justifies a standing SRE engagement, embedded reliability role, platform work, or continued team-owned practice.
+
+An SRE title without engineering authority, time for automation, or a way to change the service creates a rebranded operations queue. The intervention must have a path from operational evidence to engineering change.
+
+## Engagement lifecycle
+
+Treat reliability work as a lifecycle rather than an indefinite support commitment.
+
+### 1. Discovery
+
+Capture the product's critical user journeys, dependencies, current failure modes, operational work, ownership boundaries, and existing telemetry. Ask the product team what users must be able to do, not only which components are deployed.
+
+Output:
+- service and dependency map;
+- named service and product owners;
+- initial user journeys and candidate SLIs;
+- current incident, toil, and capacity evidence;
+- explicit risks and unknowns.
+
+### 2. Productionization
+
+Before general availability, address capacity, redundancy, overload behavior, monitoring, alerting, runbooks, rollback, data recovery, and escalation. Define SLOs before launch when possible. A service is not production-ready because it has a health endpoint or a green deployment; it is ready when the team can detect, mitigate, explain, and recover from plausible failures.
+
+### 3. Operate and improve
+
+Review SLO performance, error-budget consumption, operational load, incident repairs, dependency health, and user impact on a fixed cadence. Convert repeated incidents and manual work into owned engineering items. Keep the service team responsible for decisions that require product context; SRE supplies methods, evidence, and engineering leverage.
+
+### 4. Offboard or renew
+
+An engagement should have exit criteria. Offboard when the service team can operate the service sustainably, owns its SLOs and runbooks, and has a reliable path for escalation. Renew or deepen the engagement when evidence shows unresolved reliability risk, growing toil, or a cross-cutting failure pattern.
+
+## Context over control
+
+Prefer decision context to opaque permission gates. A release or operational decision should show:
+
+- the relevant SLO and current error-budget state;
+- the affected user journey and dependency path;
+- recent changes and known risks;
+- the expected blast radius and rollback or mitigation;
+- who owns the decision and when it will be revisited.
+
+Controls are still justified for irreversible, high-blast-radius, security-sensitive, or legally constrained actions. The improvement is to make the reason and evidence visible rather than asking people to obey an unexplained process. Context supports judgment; it does not mean removing guardrails.
+
+## Models when there is no dedicated SRE team
+
+A small organization can apply SRE without a central SRE department. Select a model deliberately:
+
+| Model | Strength | Risk to manage |
+|---|---|---|
+| Service-team ownership | Product context stays close to the people who build the service. | Reliability work loses to feature work unless SLOs, review time, and ownership are explicit. |
+| Embedded reliability engineer | Fast transfer of methods and context. | The engineer becomes permanent escalation coverage unless an exit plan exists. |
+| Central platform or enablement team | Reusable tooling, standards, and cross-service learning. | It becomes a ticket queue or a gatekeeper detached from user impact. |
+| Cross-team working group | Useful for incident practice, deployment safety, and shared standards. | Shared ownership can become no ownership. Assign accountable service owners. |
+| Hybrid | Central leverage plus local service ownership. | Interfaces must specify who decides, operates, and funds the work. |
+
+Never infer that one model is universally correct. Use incident, toil, dependency, and change data to choose and revisit the model.
+
+## Team lifecycle and maturity signals
+
+Assess maturity by observable capability, not team size or title. A useful progression is:
+
+1. **Aspirational:** reliability concerns are named, but user-facing objectives and ownership are unclear.
+2. **Measured:** critical journeys, initial SLIs/SLOs, incident records, and operational load are visible.
+3. **Managed:** error budgets influence change, alerts are actionable, and incident response is rehearsed.
+4. **Engineering-led:** toil and repair work are reduced through projects; service design includes reliability.
+5. **Scaled:** cross-service dependencies, capacity, change risk, and organizational load are managed as a system.
+
+A maturity claim needs evidence: current SLO reports, alert quality, incident learning, closed repairs, toil trend, recovery exercises, or review outputs.
+
+## Change-management sequence
+
+For organizational adoption:
+
+1. **Diagnose:** identify the failure in the current operating model and the people affected.
+2. **Frame:** connect SRE practices to user outcomes, engineering capacity, and business risk, not fashion.
+3. **Pilot:** choose a bounded service and a few practices that can produce visible evidence.
+4. **Teach:** give teams working examples, exercises, and time to practice, not only policy documents.
+5. **Measure:** compare incidents, toil, recovery, change outcomes, and user-facing reliability before and after.
+6. **Adapt:** preserve what works, remove ceremony that does not, and publish the reasoning.
+7. **Scale:** expand only after the pilot demonstrates a repeatable path and accountable ownership.
+
+Separate organizational change from change-control mechanics. A change-management program is not a justification for making every production change slow or centralized.
+
+## Incident and repair metrics at scale
+
+Use incident data to target investment, not to rank teams. Normalize where possible by service size, traffic, or exposure. Useful dimensions include:
+
+- user-impact duration and affected journeys;
+- detection and mitigation time;
+- trigger and contributing conditions;
+- repeat incidents and dependency involvement;
+- change-related incidents;
+- unresolved repair age and owner;
+- operational load and interruption rate.
+
+Log repairs as normal engineering work with owners, priority, due dates, and verification criteria. An initial increase in recorded repairs may mean the organization has made hidden debt visible, not that reliability has worsened.
+
+## Anti-patterns
+
+- Creating an SRE team before deciding what reliability problem it owns.
+- Rebranding sysadmins while leaving them with all operational work and no engineering time.
+- Centralizing every decision in SRE instead of giving service teams usable context.
+- Treating SLOs as a report card without connecting them to action.
+- Scaling a pilot by copying its ceremonies without copying its evidence and ownership.
+- Measuring incident counts alone, which rewards under-reporting and ignores impact.
+- Making a permanent support team from an engagement that has no exit criteria.
+
+## Agent procedure
+
+When asked to design or review an SRE operating model, load this reference with `slo-sli-framework.md`, `toil-elimination.md`, and `product-focused-reliability.md`. Produce an engagement boundary, accountable owners, evidence baseline, pilot scope, review cadence, and exit criteria. State which conclusions are observed, inferred, or still unknown.

--- a/site-reliability-engineering/references/third-party-dependency-reliability.md
+++ b/site-reliability-engineering/references/third-party-dependency-reliability.md
@@ -1,0 +1,57 @@
+# Third-Party Dependency Reliability
+
+Use this reference when a service relies on a vendor, managed platform, external API, identity provider, payment processor, DNS, CDN, messaging system, or other dependency outside the team's direct control.
+
+## Source anchors
+
+Synthesized from *Seeking SRE*, “Working with Third Parties Shouldn’t Suck,” “SRE as a Success Culture,” “Engineering for Data Durability,” and “Introduction to Machine Learning for SRE,” with dependency and overload practices from *The Site Reliability Workbook*, “Managing Load” and “Data Processing Pipelines.”
+
+## Dependency record
+
+For each important dependency, record:
+
+- user journeys and SLOs affected;
+- owner on both sides and escalation path;
+- vendor SLO, quotas, rate limits, maintenance model, and support boundaries;
+- observed latency, errors, freshness, correctness, and availability from your service boundary;
+- credential, quota, region, API-version, and account failure modes;
+- fallback, cache, queue, degraded mode, or alternate-provider plan;
+- data, privacy, and exit implications;
+- last failure exercise and unresolved repairs.
+
+A vendor dashboard is useful evidence but is not the service's user-visible boundary. Providers can report healthy while a regional route, credential, quota, integration version, or client-side timeout is failing.
+
+## Buy, build, or adopt
+
+Classify the dependency before debating implementation:
+
+1. How critical is it to a user journey?
+2. How likely and severe are its failure modes?
+3. Can the team mitigate or substitute it?
+4. What operational and security expertise does each option require?
+5. What is the cost of exit, migration, or data recovery?
+
+Criticality and substitutability determine how much redundancy, contract, testing, and internal expertise are justified. Do not build a replacement merely to avoid every external dependency, and do not accept a single provider as harmless because it is popular.
+
+## Failure behavior
+
+Design and test the client behavior explicitly:
+
+- bounded timeouts aligned with the user journey;
+- retries only for safe and retryable operations, with exponential backoff and a cap;
+- circuit breaking or admission control to prevent retry storms;
+- idempotency and deduplication for retried writes;
+- queueing or asynchronous completion when delay is acceptable;
+- cache or last-known-good behavior where correctness permits;
+- clear degraded response and support communication;
+- manual or alternate-provider path for critical operations.
+
+If no fallback is feasible, say so. An undocumented dependency with no mitigation is a reliability risk, not an “external limitation.”
+
+## Review and exercise
+
+Review dependency health on a fixed cadence and after incidents. Run failure exercises for the most consequential paths, including provider outage, partial outage, elevated latency, quota exhaustion, expired credentials, malformed responses, and loss of the provider's status API. Verify that alarms, escalation, user messaging, data reconciliation, and recovery actually work.
+
+## Agent procedure
+
+Use this reference with `slo-sli-framework.md`, `reliability-design-and-change.md`, and `templates/reliability-design-review.md`. Report provider claims separately from measurements taken at the service boundary. Treat “no alternative” as an explicit risk requiring an owner and review date.

--- a/site-reliability-engineering/templates/operational-overload-recovery.md
+++ b/site-reliability-engineering/templates/operational-overload-recovery.md
@@ -1,0 +1,74 @@
+---
+title: "Operational Overload Recovery: [Team / Service]"
+doc_id: OOR-[TEAM]-[YYYYMMDD]
+status: active | recovering | stable | escalated
+opened: [YYYY-MM-DD]
+owner: "[Manager / Team Lead]"
+---
+
+# Operational Overload Recovery — [Team / Service]
+
+## Trigger and evidence
+
+- **Overload threshold:** [e.g., operational work > 50% for two consecutive weeks]
+- **Observed period:** [ ]
+- **Evidence:** [pages, tickets, incidents, interruptions, toil sample]
+- **User or service risk:** [ ]
+- **What is unknown:** [ ]
+
+## Immediate protection
+
+- [ ] Declare the overload state to stakeholders.
+- [ ] Protect [X]% of engineering time for load reduction.
+- [ ] Freeze or renegotiate nonessential commitments.
+- [ ] Route, suppress, or retire non-actionable alerts.
+- [ ] Set an escalation path for unsafe fatigue or unstaffed coverage.
+- [ ] Identify the service scope that will be reduced if capacity is exceeded.
+
+## Load inventory
+
+| Work source | Count / hours | User impact | Repetition / trigger | Proposed action | Owner |
+|---|---:|---|---|---|---|
+| Pages | [ ] | [ ] | [ ] | [tune / automate / remove] | [ ] |
+| Manual changes | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Support / tickets | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Incident follow-up | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Other interruptions | [ ] | [ ] | [ ] | [ ] | [ ] |
+
+## Recovery queue
+
+Prioritize the smallest interventions that remove recurring load or reduce blast radius.
+
+| Item | Failure or toil condition | Expected reduction | Verification criterion | Owner | Due |
+|---|---|---:|---|---|---|
+| [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+
+## Scope and authority decisions
+
+- **Work deferred:** [ ]
+- **Work stopped:** [ ]
+- **Service scope renegotiated:** [ ]
+- **Staffing or leadership escalation:** [ ]
+- **Temporary exception and expiry:** [ ]
+
+## Weekly review
+
+| Week | Operational share | Pages / engineer | Engineering hours protected | Reliability / user signal | Decision |
+|---|---:|---:|---:|---|---|
+| [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+
+## Exit criteria
+
+- [ ] Operational work is below the stated threshold for [N] review periods.
+- [ ] The top recurring load sources have owners and verified reductions.
+- [ ] On-call coverage is sustainable without unsafe fatigue or coercion.
+- [ ] Deferred work and temporary exceptions have been reconciled.
+- [ ] The service's SLO, alerts, runbooks, and escalation paths are current.
+- [ ] A follow-up review is scheduled to detect relapse.
+
+## Closeout
+
+- **Closed by:** [ ]
+- **Date:** [ ]
+- **What changed:** [ ]
+- **What remains risky:** [ ]

--- a/site-reliability-engineering/templates/reliability-design-review.md
+++ b/site-reliability-engineering/templates/reliability-design-review.md
@@ -1,0 +1,97 @@
+---
+title: "Reliability Design Review: [System or Change]"
+doc_id: RDR-[SERVICE]-[VERSION]
+status: draft | reviewed | approved | rejected
+created: [YYYY-MM-DD]
+owner: "[Name / Team]"
+reviewers: "[Names / Teams]"
+---
+
+# Reliability Design Review — [System or Change]
+
+## Decision
+
+- **Decision:** [approve / approve with conditions / defer / reject]
+- **Decision owner:** [Name / role]
+- **Review date:** [YYYY-MM-DD]
+- **Next review trigger:** [date, SLO breach, traffic threshold, architecture change]
+
+## 1. User and business context
+
+- **Critical user journeys:** [What users need to accomplish]
+- **User impact if this fails:** [availability, latency, correctness, freshness, privacy, data loss]
+- **Existing or proposed SLOs:** [Link or concise statement]
+- **Error-budget trade-off:** [What budget is consumed or protected?]
+
+## 2. System and dependency boundaries
+
+- **Request path:** [Describe or link diagram]
+- **Async/data paths:** [Queues, pipelines, batch jobs, replay]
+- **Dependencies:** [Service, owner, failure mode, fallback]
+- **Shared resources:** [Databases, quotas, clusters, control planes]
+- **Failure domains:** [What can fail together?]
+
+## 3. Concrete assumptions
+
+| Dimension | Normal | Expected peak | Worst credible case | Evidence / owner |
+|---|---:|---:|---:|---|
+| Requests or events per second | [ ] | [ ] | [ ] | [ ] |
+| Payload or storage growth | [ ] | [ ] | [ ] | [ ] |
+| Latency budget | [ ] | [ ] | [ ] | [ ] |
+| Concurrent work / queue depth | [ ] | [ ] | [ ] | [ ] |
+| Recovery point / recovery time | [ ] | [ ] | [ ] | [ ] |
+
+## 4. Failure and degraded modes
+
+| Failure or saturation condition | User-visible effect | Detection | Mitigation / shed / defer | Recovery verification | Owner |
+|---|---|---|---|---|---|
+| [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+
+Include retry amplification, timeout behavior, dependency failure, quota exhaustion, bad configuration, partial rollout, data corruption, and loss of observability where relevant.
+
+## 5. Change and rollout safety
+
+- **Change units:** [small, reversible steps]
+- **Canary population and control:** [ ]
+- **Observation window and sample size:** [ ]
+- **Success metrics:** [SLO, user journey, saturation, dependency]
+- **Abort thresholds and authority:** [ ]
+- **Rollback or roll-forward:** [ ]
+- **Configuration validation and audit path:** [ ]
+
+## 6. Data, privacy, and security reliability
+
+- **Correctness and completeness checks:** [ ]
+- **Durability, backup, restore, and replay evidence:** [ ]
+- **Privacy or security failure modes:** [ ]
+- **Access and break-glass controls:** [ ]
+
+## 7. Operations and human work
+
+- **Dashboards and alerts:** [Links; each page has an action]
+- **Runbook:** [Link]
+- **On-call readiness:** [Access, training, escalation, handoff]
+- **Expected toil:** [Estimate and reduction plan]
+- **Cognitive-load risks:** [Ambiguous signals, hidden state, complex procedures]
+
+## 8. Verification plan
+
+- [ ] Unit and integration behavior verified
+- [ ] Load or capacity assumptions tested
+- [ ] Failure and degraded modes exercised
+- [ ] Canary and rollback exercised
+- [ ] Restore or replay verified where applicable
+- [ ] User-visible SLO and telemetry verified in the live boundary
+
+## 9. Open risks and conditions
+
+| Risk / unknown | Evidence needed | Owner | Due / trigger | Decision if unresolved |
+|---|---|---|---|---|
+| [ ] | [ ] | [ ] | [ ] | [ ] |
+
+## 10. Approval record
+
+- **Service owner:** [Name / date]
+- **Reliability reviewer:** [Name / date]
+- **Security / privacy reviewer (if applicable):** [Name / date]
+- **Product or business owner:** [Name / date]

--- a/site-reliability-engineering/templates/reliability-ownership-charter.md
+++ b/site-reliability-engineering/templates/reliability-ownership-charter.md
@@ -1,0 +1,62 @@
+---
+title: "Reliability Ownership Charter: [Service]"
+doc_id: ROC-[SERVICE]-[VERSION]
+status: draft | active | superseded
+created: [YYYY-MM-DD]
+owner: "[Service owner]"
+review_date: [YYYY-MM-DD]
+---
+
+# Reliability Ownership Charter — [Service]
+
+## Service and user journeys
+
+- **Service:** [ ]
+- **Critical user journeys:** [ ]
+- **SLOs and dashboards:** [ ]
+- **Supported scope:** [ ]
+- **Explicitly unsupported scope:** [ ]
+
+## Ownership boundaries
+
+| Responsibility | Accountable owner | Contributing teams | Escalation path |
+|---|---|---|---|
+| Product and user priority | [ ] | [ ] | [ ] |
+| Application code and deploy | [ ] | [ ] | [ ] |
+| Runtime and infrastructure | [ ] | [ ] | [ ] |
+| Monitoring and alert quality | [ ] | [ ] | [ ] |
+| Runbook and training | [ ] | [ ] | [ ] |
+| Dependency relationship | [ ] | [ ] | [ ] |
+| Backup, restore, and recovery | [ ] | [ ] | [ ] |
+| Incident command and communications | [ ] | [ ] | [ ] |
+
+## Pager and maintenance model
+
+- **Primary and secondary rotation:** [ ]
+- **Who must page and who may be consulted:** [ ]
+- **Expected maintenance / engineering allocation:** [ ]
+- **Escalation and handoff rules:** [ ]
+- **Conditions that make the rotation unsafe:** [ ]
+
+## Engagement agreement
+
+- **Engagement mode:** [service-owned / embedded / platform enablement / working group / hybrid]
+- **Reliability goals for this period:** [ ]
+- **Work the enabling team will do:** [ ]
+- **Work the service team must own:** [ ]
+- **Exit or transition criteria:** [ ]
+- **What happens if the service cannot operate within agreed SLO and toil limits:** [ ]
+
+## Evidence and review
+
+- **Baseline incident and toil evidence:** [ ]
+- **Success measures:** [ ]
+- **Review cadence:** [ ]
+- **Open risks and owners:** [ ]
+
+## Sign-off
+
+- Service owner: [name / date]
+- Reliability or enabling owner: [name / date]
+- Product owner: [name / date]
+- Platform / security / privacy owners as applicable: [name / date]


### PR DESCRIPTION
## Summary

Enriches `site-reliability-engineering` using a thorough read of the supplied EPUBs:

- *Seeking SRE* (44 spine chapters, ~233k extracted words)
- *The Site Reliability Workbook* (37 spine chapters, ~194k extracted words)

The book-derived guidance is paraphrased, source-anchored, and integrated with the existing skill rather than added as a book summary.

## What changed

- Added focused references for:
  - SLO adoption sequence and stakeholder review
  - SRE adoption, engagement boundaries, team models, maturity, and organizational change
  - reliability design, NALSD-style concrete assumptions, overload, configuration, canarying, durability, and dependencies
  - third-party dependency reliability
  - operational documentation lifecycle
  - cognitive work, sustainable on-call, psychological safety, and learning exercises
- Added templates for:
  - reliability design review
  - operational overload recovery
  - reliability ownership charter
- Updated the skill routing tables, README, and source index.
- Extended output-quality evals with design-review, adoption-without-a-dedicated-team, and overload/human-factors cases.
- Removed stale references to files that did not exist.
- Deliberately did not add another calculation script: the existing burn-rate script remains the right deterministic utility, while the new material is primarily decision and evidence guidance.

## Verification

- `ruby scripts/validate-skills.rb`
- `python3 -m json.tool site-reliability-engineering/evals/evals.json`
- `git diff --check`

All passed locally.
