### PR TITLE
docs(data-architect): complete README inventory

### DIFF
--- a/data-architect/README.md
+++ b/data-architect/README.md
@@ -17,10 +17,11 @@ When your agent loads this skill, it becomes a **senior data architect** who can
 
 | Directory | Purpose |
 |-----------|---------|
-| `SKILL.md` | Symptom recognition guide, QuickScan diagnostic, entry point table |
-| `references/` | Discovery framework, maturity model, architecture patterns, data mesh readiness, event-driven products, platform evaluation, governance, migration |
-| `templates/architecture-design-session.md` | Facilitated worksheet for current state, workloads, candidate patterns, decisions, experiments, and owners |
-| `evals/evals.json` | Output-quality cases for architecture reviews, mesh adoption, data products, and boundary routing |
+| `SKILL.md` | Symptom recognition guide, QuickScan diagnostic, consulting workflow, and resource routing |
+| `references/` | Discovery framework, maturity model, architecture patterns, data mesh readiness, event-driven products, platform evaluation, governance, compliance, anti-patterns, and case studies |
+| `scripts/` | Interactive governance maturity assessment |
+| `templates/` | Architecture decision record and data architecture design-session worksheets |
+| `evals/` | Output-quality cases for architecture reviews, mesh adoption, data products, governance, and boundary routing |
 
 ## Triggers
 
@@ -33,4 +34,10 @@ No special system requirements. Designed for agentic AI assistants. Platform ope
 
 ## Quick Start
 
-Start with the setup and first workflow in SKILL.md, then use the linked resources for the specific task you need to complete.
+From the skill directory, run the interactive governance assessment when the question is "How mature is our data governance?":
+
+```bash
+python3 scripts/governance-assessment.py
+```
+
+For architecture reviews, platform decisions, data mesh assessments, or design sessions, load `SKILL.md` and follow its task-specific reference routing.


### PR DESCRIPTION
## Summary

- make the data-architect README inventory the complete delivered skill by listing scripts, templates, references, and evals
- add the governance assessment as a concrete Quick Start command

Closes #351

## Validation

- [x] `ruby scripts/validate-skills.rb` — 158 canonical skills
- [x] `python3 scripts/validate-evals.py` — 113 valid manifests
- [x] `python3 scripts/eval-coverage.py --modified-from origin/main` — ratchet passed
- [x] `uvx --from skills-ref agentskills validate data-architect` — valid
- [x] `git diff --check`

## Documentation

- [x] The README now inventories every delivered artifact category.
- [x] Quick Start gives a concrete first command.

## Community and security

- [x] This pull request contains no credentials, private infrastructure details, or deployment-specific paths.
- [x] AI assistance is disclosed below and in the commit message.

## Review notes

- [x] Final candidate is commit `2d908fb`; the automated-review accuracy finding is resolved and exact-head CI remains the merge gate.

AI-assisted: Jasper implemented and verified this late-review follow-up on behalf of Magnus Hedemark.
