### PR TITLE
ci(skillevaluator): add advisory SkillEvaluator quality gate

### DIFF
--- a/.github/workflows/skillevaluator.yml
+++ b/.github/workflows/skillevaluator.yml
@@ -1,0 +1,132 @@
+name: SkillEvaluator advisory gate
+
+# Advisory (non-blocking) Tier 1 quality gate from NVIDIA SkillEvaluator,
+# complementing scripts/validate-skills.rb. See issue #383.
+#
+# Version pinning and the known skew:
+#
+# - skillevaluator is pinned to the v0.1.0 git tag
+#   (commit 4975c97d49e3623eeab739248e52d83c4aa8f582). It is not published to
+#   PyPI; git+tag is the only released distribution channel. The default
+#   `main` branch already carries unreleased 0.2.0 content, so a bare
+#   `git+https://...` install would drift under every push — hence the tag.
+#
+# - SkillSpector is deliberately NOT installed. At implementation time the
+#   latest releases were skillevaluator v0.1.0 (2026-08-05) and SkillSpector
+#   v2.9.6 (2026-08-18); upstream still documents SkillSpector as "separately
+#   installed and unpinned by this distribution" with no blessed version pair
+#   (v0.1.0 CHANGELOG, Fixed section). The historical skew described in #383
+#   (LOW severity mapping to CAUTION instead of SAFE, scoring-math
+#   disagreements) made 4/153 skills produce incomplete scans in earlier local
+#   runs even when pinned to SkillSpector @v2.5.3. Rather than gamble on an
+#   unpinned scanner in CI, this workflow runs NVIDIA's documented keyless
+#   check set -- schema,pii,license,quality,unicode,lint -- which excludes the
+#   security scan by design. Security findings are therefore out of scope for
+#   this gate; scripts/validate-skills.rb plus repo-local tests remain the
+#   deterministic floor, and any future promotion of the security scan here
+#   must first pin both tools to a documented compatible pair.
+
+on:
+  pull_request:
+    paths:
+      - '*/SKILL.md'
+      - '*/references/**'
+      - '*/scripts/**'
+      - '*/evals/evals.json'
+      - '.github/workflows/skillevaluator.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '*/SKILL.md'
+      - '*/references/**'
+      - '*/scripts/**'
+      - '*/evals/evals.json'
+      - '.github/workflows/skillevaluator.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  advisory:
+    name: Tier 1 keyless validation (advisory)
+    runs-on: ubuntu-latest
+    # Genuinely advisory: failures surface as neutral checks and never block
+    # merge. This job is intentionally NOT a required branch-protection check;
+    # promote it to blocking only after the baseline noise floor (issue #383)
+    # is reviewed and each check's signal is understood.
+    continue-on-error: true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Install pinned skillevaluator
+        # Pinned exactly: skillevaluator v0.1.0 via git tag (not on PyPI).
+        # Keyless: no SKILL_EVAL_LLM_* credentials are configured, and the
+        # selected checks below are all LLM-free.
+        run: |
+          python3 -m pip install --user \
+            "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git@v0.1.0"
+          echo "$(python3 -m site --user-base)/bin" >> "$GITHUB_PATH"
+
+      - name: Detect changed skills
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          skills=$(
+            git diff --name-only "$BASE_SHA" HEAD -- \
+              '*/SKILL.md' '*/evals/evals.json' '*/scripts/**' '*/references/**' \
+              | awk -F/ 'NF > 1 { print $1 }' \
+              | sort -u \
+              | while read -r skill; do
+                  if [ -f "$skill/SKILL.md" ]; then
+                    printf '%s\n' "$skill"
+                  fi
+                done \
+              | head -10 \
+              | paste -sd' ' -
+          )
+          echo "skills=$skills" >> "$GITHUB_OUTPUT"
+          echo "Changed skills: ${skills:-<none>}"
+
+      - name: Run SkillEvaluator Tier 1 per changed skill
+        if: steps.changed.outputs.skills != ''
+        env:
+          CHANGED_SKILLS: ${{ steps.changed.outputs.skills }}
+        run: |
+          mkdir -p reports
+          for skill in $CHANGED_SKILLS; do
+            start=$(date +%s)
+            if skillevaluator validate "./$skill" \
+                --checks schema,pii,license,quality,unicode,lint \
+                --no-dedup \
+                -r json \
+                -o "reports/$skill"; then
+              verdict=PASS
+            else
+              verdict=FAIL
+            fi
+            end=$(date +%s)
+            report=$(ls -t "reports/$skill"/skillevaluator-output-*.json 2>/dev/null | head -1 || true)
+            summary_line="unknown"
+            score="n/a"
+            if [ -n "$report" ]; then
+              summary_line=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print("errors=%s warnings=%s status=%s incomplete=%d" % (d.get("total_errors","?"), d.get("total_warnings","?"), d.get("overall_status","?"), len(d.get("incomplete_scans") or [])))' "$report")
+              score=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); qs=d.get("quality_summary") or []; print("%s/100 (%s)" % (qs[0].get("overall_score","?"), qs[0].get("grade","?")) if qs else "n/a")' "$report")
+            fi
+            echo "::warning title=SkillEvaluator:$skill::advisory result for $skill: $verdict quality=$score $summary_line"
+            echo "$verdict  $skill  quality=$score  ($summary_line)  $((end - start))s"
+          done
+          # Advisory only: never propagate validation failures to the PR.
+          exit 0
+
+      - name: Upload SkillEvaluator JSON reports
+        if: always() && steps.changed.outputs.skills != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: skillevaluator-reports
+          path: reports/
+          retention-days: 7


### PR DESCRIPTION
## Summary

Implements #383: adopts NVIDIA [SkillEvaluator](https://github.com/NVIDIA/SkillEvaluator) as an **advisory (non-blocking)** Tier 1 quality gate complementing `scripts/validate-skills.rb`. Adds exactly one file: `.github/workflows/skillevaluator.yml`.

- Triggers on `pull_request` and `push` to `main`, path-gated to `*/SKILL.md`, `*/references/**`, `*/scripts/**`, `*/evals/evals.json`, plus the workflow itself.
- Single job, `continue-on-error: true`, `permissions: contents: read`. Failures surface as neutral checks and annotations; the PR is never blocked. This job must **not** be added to branch-protection required checks until the noise floor below is reviewed.
- Detects changed skills with the house diff pattern from `.github/workflows/skill-eval.yml` (extended to include `*/references/**`), caps at 10 skills per run, and validates each skill individually.
- Per skill: one summary line to the job log (`PASS/FAIL quality=<score>/<100> (<grade>) errors=N warnings=N status=... incomplete=N`), a `::warning` annotation (visible on the PR), and a JSON report written under `reports/<skill>/`.
- Uploads all JSON reports as the `skillevaluator-reports` artifact, retention 7 days, `if: always()`.

### Version pinning and how the SkillSpector skew was handled

Research findings at implementation time:

| Tool | Latest released | Channel | Notes |
|---|---|---|---|
| `skillevaluator` | **v0.1.0** (2026-08-05) | git tag only — not on PyPI (404) | `main` already carries unreleased v0.2.0 content (PR #52 merged 2026-08-20); only tag is `v0.1.0` |
| SkillSpector | **v2.9.6** (2026-08-18) | GitHub releases / local uv tool | No PyPI package under any tested name |

**Pins used:** `skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git@v0.1.0` (commit `4975c97d49e3623eeab739248e52d83c4aa8f582`). A bare `git+https://...` install would drift because upstream `main` is unreleased v0.2.0 content.

**Skew resolution: designed around.** Upstream has *not* resolved the skew: the v0.1.0 CHANGELOG still states SkillSpector is "separately installed and unpinned by this distribution", no issue or release documents a blessed version pair (searched upstream issues for "2.5.3"/SkillSpector; nothing). Local testing confirmed the mechanics now tolerate structurally complete reports even on SkillSpector policy exit 1, but with zero pinning guidance in CI the scanner would be a floating dependency. Therefore the workflow runs NVIDIA's own documented keyless check set from the README/release notes:

```
skillevaluator validate ./<skill> --checks schema,pii,license,quality,unicode,lint --no-dedup -r json -o reports/<skill>
```

which excludes the `security` check by design. Security scanning remains out of scope for this gate; promoting it later requires first pinning both tools to a documented compatible pair. (The NVIDIA external-publication profile was intentionally not used — it fails every skill here by design due to its `metadata.author`/`skills/<name>/` layout assumptions.)

### Baseline noise floor

Local runs with the exact pinned tooling (`skillevaluator` v0.1.0 isolated venv; no API keys; keyless check set only):

| Skill | Runtime | Quality score | Errors | Warnings | Real signal? |
|---|---|---|---|---|---|
| `lastfm` | ~0.4s | 88.0/100 (B) | 1 | 10 | No |
| `binary-analysis` | ~0.8s | 88.8/100 (B) | 1 | 12 | No |
| `secure-software-engineering` | ~0.3s | 85.2/100 (B) | 1 | 14 | No |
| `tailscale` | ~0.4s | 88.0/100 (B) | 1 | 18 | No |

The single error on **every** skill is `SCHEMA.author_missing` ("Author not specified in metadata") — this repo deliberately does not use `metadata.author` (our own validator governs frontmatter), so it is structural noise, not signal. Remaining warnings are stylistic quality advisories (`## Purpose`/`Troubleshooting` section suggestions, long descriptions) plus benign PII heuristics (e.g., documentation IPs flagged as "Non-RFC1918"). Zero incomplete scans. Conclusion: the current advisory floor is dominated by one known false positive per skill plus style suggestions; no real defects were surfaced on these four skills. With security-scan findings excluded by design, didactic security prose (e.g., `binary-analysis`'s YARA teaching content, which produced 61 mostly-false HIGH/MEDIUM findings when the scan was enabled experimentally) stays out of the gate entirely.

### Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` → `yaml ok`; embedded loop passes `bash -n`.
- Job loop simulated end-to-end locally against two skills with the pinned binary: PASS/FAIL verdicts, log lines, annotations, and per-skill JSON reports all behave as designed; loop exits 0 despite validation FAILs (advisory confirmed).
- `ruby scripts/validate-skills.rb` → `Validated 163 canonical skills.` (unchanged, green).
- `git status` shows exactly one new file: `.github/workflows/skillevaluator.yml`.

Closes #383

AI assistance disclosure: this PR was authored by an AI agent (Factory Droid) working from the issue text, with human review of the pinned versions and baseline numbers before merge.