### PR TITLE
docs(skills): add product-shaping routing seams

### DIFF
--- a/neckbeard/README.md
+++ b/neckbeard/README.md
@@ -57,8 +57,8 @@ Load the umbrella when a non-trivial change lands — read `SKILL.md` and follow
 its core loop. For a bug, the agent frames a change contract, loads
 `systematic-debugging` for root cause, makes the smallest safe fix, verifies at
 the real boundary, and writes an evidence ledger. For a feature, it routes
-discovery to `product-discovery` and specification to `spec-driven-development`
-before writing code.
+discovery to `product-discovery`, shaping of the bounded idea to `product-shaping`,
+and specification to `spec-driven-development` before writing code.
 
 To run the evaluation suite against your harness:
 

--- a/product-roadmapping-and-portfolio/SKILL.md
+++ b/product-roadmapping-and-portfolio/SKILL.md
@@ -89,6 +89,11 @@ Executive narrative, team view, external/customer view — each tailored.
 - **For project scheduling, Gantt charts, or milestone tracking:** this skill produces outcome roadmaps, not project plans.
 - **For delivery-flow management:** route to `kanban-guru`.
 - **For corporate capital allocation and M&A portfolio decisions:** route to `strategy-frameworks`.
+- **For shaping a single bet** (setting its appetite, narrowing it into a bounded
+  problem, writing its pitch): route to `product-shaping`. This skill sequences bets
+  across cycles at the portfolio level; shaping packages one bet before it enters a
+  roadmap — "strategic bet" here means a roadmap entry with sequencing criteria, not
+  the shaped single-project commitment that `product-shaping` produces.
 
 ## Evidence, Assumptions, Commitments, and Options
 

--- a/product-shaping/SKILL.md
+++ b/product-shaping/SKILL.md
@@ -84,7 +84,8 @@ Load only what the current step needs:
   validated problems; it does not investigate whether the problem is real.
 - **The question is strategic** (positioning, market entry, portfolio weight across
   quarters) → `product-strategy` or `product-roadmapping-and-portfolio`. This skill
-  packages single bets; roadmapping sequences them.
+  packages a single bet — one bounded commitment with an appetite and circuit breaker;
+  roadmapping sequences many such bets across cycles with continue/pause/kill criteria.
 - **The bet is already placed and the work needs a formal spec** → `spec-driven-
   development` consumes shaped output when formal specification is warranted.
 - **Comparing unrelated feature proposals by score** → `product-methodology` (RICE/


### PR DESCRIPTION
## Summary

Implements the docs-only routing seams from #394 so the catalog's routing is honest about where `product-shaping` sits between discovery and specification, and about the boundary between a shaped single bet and portfolio-level bet sequencing:

- **`product-shaping/SKILL.md`** — sharpened the existing strategic-boundary bullet in "When not to use" to name both skills explicitly: this skill packages *a single bet* (one bounded commitment with an appetite and circuit breaker); roadmapping sequences *many bets across cycles* with continue/pause/kill criteria.
- **`product-roadmapping-and-portfolio/SKILL.md`** — added an explicit boundary bullet in "When Not to Use": shaping a single bet (appetite, bounded problem, pitch) routes to `product-shaping`; clarifies that "strategic bet" here means a roadmap entry with sequencing criteria, not the shaped single-project commitment.
- **`neckbeard/README.md`** — feature-routing sentence in Quick Start now routes feature-sized work through `product-shaping` between discovery (`product-discovery`) and specification (`spec-driven-development`). Checked for parallel text: the same sentence does not appear in `neckbeard/SKILL.md` or `references/routing-table.md` (both use stage-based tables without that sentence), so no other edits were needed.

No behavioral content changed — documentation seams only.

Closes #394

## Files changed

| File | Change |
|---|---|
| `product-shaping/SKILL.md` | Boundary sentence expanded in "When not to use" |
| `product-roadmapping-and-portfolio/SKILL.md` | New boundary bullet in "When Not to Use" |
| `neckbeard/README.md` | Feature path now includes `product-shaping` |

No new eval manifest was needed: all three modified skills already had schema-valid manifests (`product-shaping` from #393, `product-roadmapping-and-portfolio`, and `neckbeard` with 14 cases).

## Validation

All commands run on branch `docs/product-shaping-routing-seams` against base `main`:

- `ruby scripts/validate-skills.rb` → exit 0 ("Validated 164 canonical skills.")
- `python3 scripts/validate-evals.py` → exit 0 ("Validated 131 eval manifests")
- `python3 scripts/eval-coverage.py --modified-from main` → exit 0 (ratchet green; coverage 79.9%, above the 50% fail-on-modify threshold)
- `ruby scripts/validate-skill-quality.rb --base main` → exit 0 ("Quality-checked 2 changed skill(s): 0 error(s), 0 warning(s).")
- `python3 scripts/check-artifacts.py` → exit 0 (all generated-artifact freshness tests pass)
- `git status` clean after commit; only the three intended files changed

## Disclosure

Authored with AI assistance (Factory Droid); all changes reviewed against the issue's acceptance criteria.
