### PR TITLE
fix(raleigh): classify upstream WAF challenges

### DIFF
--- a/raleigh/EVIDENCE-LEDGER.md
+++ b/raleigh/EVIDENCE-LEDGER.md
@@ -191,6 +191,39 @@ The following public service boundaries were exercised successfully on 2026-07-2
 - No model-backed eval run, CI run, commit, push, pull request, deployment, release, or merge is claimed.
 - Roll back the aggregate adapter and CLI wiring if the official site removes JSON:API access or publication links cannot be validated without broadening the trust boundary.
 
+## Current Issue: Upstream Browser Challenge
+
+### Intent and authority
+
+- Keep the scheduled canary truthful when Raleigh's Cloudflare edge blocks
+  non-browser clients, without bypassing the provider's challenge or hiding
+  genuine contract failures.
+- Modify the local Raleigh skill only. No publish, deploy, merge, or provider
+  configuration authority was used.
+
+### Evidence and decision
+
+- Runs `33259202346`, `33211420732`, and `33113598834` each reported HTTP 403
+  for both civic probes, while all other probes passed.
+- Direct probes returned the Cloudflare `cf-mitigated: challenge` marker and
+  challenge HTML. The same endpoints returned valid content from a browser-like
+  local request, establishing an access-policy boundary rather than a Raleigh
+  schema failure.
+- Classify this exact marker as `waf_challenge`, preserve source and target in
+  the report, and keep the observation non-failing. Other 403 responses remain
+  `auth_regression` and continue to fail the canary.
+
+### Verification target and follow-up
+
+- Deterministic tests cover the marker-specific classification and the
+  non-failing summary accounting.
+- The scheduled workflow remains the delivery-boundary check. A later green
+  run proves the canary no longer treats this known upstream challenge as a
+  durable failure; it does not prove Raleigh machine access has been restored.
+- Do not add retries, browser automation, or challenge bypasses. Reclassify only
+  when the provider removes the marker or a new upstream access contract is
+  verified.
+
 ## Issue 157 Addendum: Restore Live RPD Queries
 
 ### Intent and authority

--- a/raleigh/references/civic-content-reference.md
+++ b/raleigh/references/civic-content-reference.md
@@ -40,6 +40,9 @@ on later `--new-only` runs.
 
 ## Notes
 
+- Raleigh's site may present a Cloudflare browser challenge to non-browser
+  clients. The CLI does not attempt to bypass that challenge; the scheduled
+  canary records it as a visible, non-failing upstream access observation.
 - The CLI preserves canonical page URLs so users can inspect the source presentation.
 - Rendered HTML is treated as content, not executable markup.
 - Publication status is requested server-side with `filter[status]=1`; the CLI

--- a/raleigh/scripts/canary.py
+++ b/raleigh/scripts/canary.py
@@ -54,11 +54,18 @@ FAILURE_CLASSES = (
     "parser_failure",
     "empty_but_valid",
     "restricted_folder",
+    "waf_challenge",
 )
 
 
 def _classify_exception(exc: Exception) -> str:
     if isinstance(exc, urllib.error.HTTPError):
+        if (
+            exc.code == 403
+            and exc.headers
+            and exc.headers.get("cf-mitigated", "").lower() == "challenge"
+        ):
+            return "waf_challenge"
         if exc.code in (401, 403):
             return "auth_regression"
         if exc.code >= 500:
@@ -78,6 +85,13 @@ def _classify_exception(exc: Exception) -> str:
     return "parser_failure"
 
 
+def _waf_observation(source: str, target: str, err: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Keep a provider browser challenge visible without treating it as drift."""
+    if err and err.get("failure_class") == "waf_challenge":
+        return {"source": source, "target": target, "status": "pass", **err}
+    return None
+
+
 def _is_transient(failure_class: str) -> bool:
     return failure_class == "transport_outage"
 
@@ -90,9 +104,12 @@ def _probe_with_retry(fn, *args, **kwargs) -> tuple[Any, None] | tuple[None, dic
             return result, None
         except Exception as exc:
             fc = _classify_exception(exc)
+            error_text = str(exc)
+            if fc == "waf_challenge":
+                error_text = "Cloudflare managed browser challenge (cf-mitigated: challenge)"
             evidence = {
                 "failure_class": fc,
-                "error": str(exc),
+                "error": error_text,
                 "attempt": attempt,
             }
             if first_evidence is None:
@@ -278,6 +295,9 @@ def probe_civic_jsonapi() -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     index, err = _probe_with_retry(core.json_request, civic.JSONAPI_ROOT)
     if err:
+        observation = _waf_observation("civic", "jsonapi-index", err)
+        if observation:
+            return [observation]
         results.append({"source": "civic", "target": "jsonapi-index", "status": "fail", **err})
         return results
 
@@ -297,6 +317,9 @@ def probe_civic_rss() -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     data, err = _probe_with_retry(core.raw_request, civic.RSS_FEED)
     if err:
+        observation = _waf_observation("civic", "rss-feed", err)
+        if observation:
+            return [observation]
         results.append({"source": "civic", "target": "rss-feed", "status": "fail", **err})
         return results
 
@@ -481,6 +504,7 @@ def run_canary() -> dict[str, Any]:
     transient_failures = 0
     empty_valid = 0
     restricted = 0
+    waf_challenges = 0
 
     for name, probe_fn in ALL_PROBES:
         try:
@@ -505,6 +529,8 @@ def run_canary() -> dict[str, Any]:
                 empty_valid += 1
             elif r.get("failure_class") == "restricted_folder":
                 restricted += 1
+            elif r.get("failure_class") == "waf_challenge":
+                waf_challenges += 1
             continue
         fc = r.get("failure_class", "unknown")
         if _is_transient(fc):
@@ -524,6 +550,7 @@ def run_canary() -> dict[str, Any]:
             "transient_failures": transient_failures,
             "empty_but_valid": empty_valid,
             "restricted_folders": restricted,
+            "waf_challenges": waf_challenges,
         },
         "results": all_results,
     }
@@ -546,6 +573,7 @@ def write_github_summary(report: dict[str, Any]) -> None:
     lines.append(f"| Transient failures | {s['transient_failures']} |")
     lines.append(f"| Empty-but-valid | {s['empty_but_valid']} |")
     lines.append(f"| Restricted folders | {s.get('restricted_folders', 0)} |")
+    lines.append(f"| WAF challenges | {s.get('waf_challenges', 0)} |")
     lines.append("")
 
     restricted = [r for r in report["results"] if r.get("failure_class") == "restricted_folder"]
@@ -556,6 +584,19 @@ def write_github_summary(report: dict[str, Any]) -> None:
         lines.append("|--------|--------|----------|")
         for r in restricted:
             lines.append(f"| {r.get('source', '?')} | {r.get('target', '?')} | {r.get('error', '')[:120]} |")
+        lines.append("")
+
+    challenges = [r for r in report["results"] if r.get("failure_class") == "waf_challenge"]
+    if challenges:
+        lines.append("### Upstream WAF challenges (blocked machine access; non-failing)")
+        lines.append("")
+        lines.append("| Source | Target | Evidence |")
+        lines.append("|--------|--------|----------|")
+        for r in challenges:
+            lines.append(
+                f"| {r.get('source', '?')} | {r.get('target', '?')} "
+                f"| {r.get('error', '')[:120]} |"
+            )
         lines.append("")
 
     failures = [r for r in report["results"] if r.get("status") == "fail"]
@@ -592,7 +633,8 @@ def main() -> int:
         f"{s['durable_failures']} durable failures, "
         f"{s['transient_failures']} transient failures, "
         f"{s['empty_but_valid']} empty-but-valid, "
-        f"{s.get('restricted_folders', 0)} restricted folders"
+        f"{s.get('restricted_folders', 0)} restricted folders, "
+        f"{s.get('waf_challenges', 0)} WAF challenges"
     )
     print(f"Report written to {report_path}")
 

--- a/raleigh/tests/test_raleigh.py
+++ b/raleigh/tests/test_raleigh.py
@@ -2726,6 +2726,45 @@ class PoliceTests(unittest.TestCase):
         self.assertFalse(report["passed"])
         self.assertEqual(report["summary"]["transient_failures"], 1)
 
+    def test_canary_classifies_cloudflare_challenge_as_visible_non_failing_observation(self):
+        headers = Message()
+        headers["Server"] = "cloudflare"
+        headers["cf-mitigated"] = "challenge"
+        error = urllib.error.HTTPError(
+            "https://raleighnc.gov/jsonapi", 403, "Forbidden", headers, None
+        )
+        with patch("canary.core.json_request", side_effect=error):
+            results = canary_lib.probe_civic_jsonapi()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["status"], "pass")
+        self.assertEqual(results[0]["failure_class"], "waf_challenge")
+        self.assertIn("Cloudflare", results[0]["error"])
+
+    def test_canary_keeps_plain_forbidden_as_auth_failure(self):
+        headers = Message()
+        error = urllib.error.HTTPError(
+            "https://raleighnc.gov/jsonapi", 403, "Forbidden", headers, None
+        )
+        with patch("canary.core.json_request", side_effect=error):
+            results = canary_lib.probe_civic_jsonapi()
+        self.assertEqual(results[0]["status"], "fail")
+        self.assertEqual(results[0]["failure_class"], "auth_regression")
+
+    def test_canary_summary_counts_waf_challenges_without_failing(self):
+        observations = [{
+            "source": "civic",
+            "target": "jsonapi-index",
+            "status": "pass",
+            "failure_class": "waf_challenge",
+            "error": "Cloudflare managed challenge",
+            "attempt": 1,
+        }]
+        with patch.object(canary_lib, "ALL_PROBES", [("civic", lambda: observations)]):
+            report = canary_lib.run_canary()
+        self.assertTrue(report["passed"])
+        self.assertEqual(report["summary"]["waf_challenges"], 1)
+        self.assertEqual(report["summary"]["durable_failures"], 0)
+
     def test_canary_imagery_probe_reports_restricted_folders_as_non_failing(self):
         with patch("canary.imagery.list_services", return_value=(
             [{"name": "Orthos2025", "type": "ImageServer"}],


### PR DESCRIPTION
## Summary

RaleighNC.gov began returning a Cloudflare managed browser challenge to the civic-content probes on August 27, after 21 consecutive green canary runs. The endpoint remains public from suitable clients, but the GitHub Actions request path receives HTTP 403 with `cf-mitigated: challenge`.

This change classifies that exact provider marker as `waf_challenge`, keeps it visible in the machine-readable report and GitHub step summary, and treats it as a non-failing upstream access observation. Ordinary 401/403 responses remain blocking `auth_regression` failures.

## Evidence

- Runs `33113598834`, `33211420732`, and `33259202346` failed only on the two civic probes.
- The uploaded report for run `33259202346` records the two 403 responses.
- Independent requests identified the Cloudflare challenge marker and challenge HTML.
- No browser automation, challenge bypass, or unbounded retry was added.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest raleigh/tests/test_raleigh.py` (382 passed)
- `python3 scripts/validate-evals.py raleigh`
- `ruby scripts/validate-skills.rb`
- `python3 -m py_compile raleigh/scripts/canary.py raleigh/tests/test_raleigh.py`
- `git diff --check`
- Live modified-worktree probes report both civic endpoints as `waf_challenge` observations.

Closes #120

AI assistance: implementation and verification were performed with assistance from Jasper, an AI agent for @magnus919.
