### PR TITLE
fix: finalize FFmpeg preflight correctness

### DIFF
--- a/ffmpeg/README.md
+++ b/ffmpeg/README.md
@@ -23,6 +23,7 @@ After installation, an agent can reason about remuxing versus transcoding, const
 | `references/learning-summary.md` | Learning progression and consolidated mental model |
 | `scripts/ffmpeg-preflight` | Capability preflight: tool availability, inventory counts, and named filter/encoder/hwaccel checks |
 | `scripts/test_ffmpeg_preflight.py` | Deterministic pytest suite for the preflight (fake tools, no media or network) |
+| `scripts/fixtures/ffmpeg-8.1.2-inventories.json` | Small version-labeled real-output parser fixture |
 | `evals/evals.json` | Portable output-quality cases for the skill |
 
 ## Quick Start
@@ -43,7 +44,7 @@ Before automating a version-sensitive recipe, check that the installed build act
 scripts/ffmpeg-preflight --filter scale --filter subtitles --encoder libx264 --hwaccel videotoolbox
 ```
 
-Each name check is repeatable and reported `present` or `absent`. Exit codes: `0` all requested capabilities present, `1` a tool or probe failed, `2` a requested capability is absent. Add `--json` for machine-readable output.
+Each name check is repeatable and reported `present` or `absent`. Exit codes: `0` all requested capabilities present, `1` a required tool or probe failed (including timeout or unparseable inventory), `2` a requested capability is absent after a usable inventory was parsed. Add `--json` for machine-readable output. The default probe timeout is 10 seconds; override it with `--timeout SECONDS`. Named FFmpeg-only checks do not require `ffprobe`, but media inspection and the no-query environment check do.
 
 ## Triggers
 

--- a/ffmpeg/SKILL.md
+++ b/ffmpeg/SKILL.md
@@ -42,7 +42,7 @@ Treat FFmpeg commands as typed media pipelines, not incantations. Start from wha
 - Read `references/learning-summary.md` for the newcomer-first progression and consolidated mental model.
 - Read `references/source-inventory.md` when assessing evidence, choosing authoritative documentation, or refreshing version-sensitive guidance.
 - Read `references/local-verification.md` when interpreting the recorded local FFmpeg 8.1.2 evidence. It is a host-specific observation, not a universal capability claim.
-- Run `scripts/ffmpeg-preflight` before automating a version-sensitive workflow. It reports whether `ffmpeg` and `ffprobe` are available, summarizes parsed filter/encoder/hwaccel inventory counts, and answers named checks: `--filter NAME`, `--encoder NAME`, `--hwaccel NAME` (each repeatable). Use `--json` for machine-readable output. Exit codes: 0 every requested capability present, 1 tool or probe failure, 2 a requested capability is absent.
+- Run `scripts/ffmpeg-preflight` before automating a version-sensitive workflow. It reports tool status, parsed filter/encoder/hwaccel counts, and repeatable named checks: `--filter NAME`, `--encoder NAME`, `--hwaccel NAME`. Use `--json` for machine-readable output and `--timeout SECONDS` to bound each probe (10 seconds by default). Named FFmpeg-only checks do not require `ffprobe`; media inspection and the no-query environment check do. Exit codes: 0 every requested capability is present, 1 a required tool/probe failed or the requested inventory was empty/unparseable, 2 a usable inventory was parsed and a requested capability is absent. Empty inventories without named queries are reported as warnings.
 
 ## Debugging Rules
 

--- a/ffmpeg/scripts/ffmpeg-preflight
+++ b/ffmpeg/scripts/ffmpeg-preflight
@@ -5,19 +5,20 @@ Non-mutating, dependency-free, and offline: it runs read-only inventory
 probes, never touches media files, and makes no network requests.
 
 Checks reported:
-  ffmpeg / ffprobe  availability, resolved path, return code, and the first
-                    diagnostic line of the version probe.
+  ffmpeg / ffprobe  availability, resolved path, probe status, return code,
+                    and the first diagnostic line of the version probe.
   filters / encoders / hwaccels
-                    whether each inventory probe ran, plus a conservative
-                    count of parseable entries. A count of zero means the
-                    inventory was empty or used an unexpected format; it is
-                    a warning, not a proof of absence.
+                    whether each inventory probe produced usable output, plus
+                    a conservative count of parseable entries. With no named
+                    query, a count of zero is a warning rather than proof of
+                    absence.
 
 Named capability queries:
   --filter NAME, --encoder NAME, --hwaccel NAME (each repeatable)
   Report whether each exact name appears in the corresponding inventory.
-  Matching is case-sensitive and exact; a query against an unavailable or
-  empty inventory is reported absent.
+  Matching is case-sensitive and exact. A query against an unavailable, empty,
+  or unparseable inventory is unknown (JSON null) and is a probe failure.
+  These FFmpeg-only queries do not require ffprobe.
 
 Output:
   Default: concise human-readable lines. --json: one JSON document with the
@@ -25,9 +26,9 @@ Output:
   Raw inventory text is never printed; only counts and named results are.
 
 Exit codes:
-  0  tools available, probes ran, and every requested capability is present
-  1  probe or environment failure (missing binary, failed inventory probe)
-  2  probes ran but at least one requested capability is absent
+  0  required tools and probes succeeded, and every requested capability is present
+  1  required tool or probe failure (including timeout or unparseable inventory)
+  2  usable inventories were parsed but at least one requested capability is absent
 
 Human output is evidence for people; the parsed counts and query results in
 --json output are the stable interface. Inventory text itself varies across
@@ -44,6 +45,8 @@ import subprocess
 from typing import Any
 
 FIRST_LINE_LIMIT = 200
+DEFAULT_TIMEOUT_SECONDS = 10.0
+EMPTY_INVENTORY_MESSAGE = "no parseable entries; inventory empty or unexpected format"
 NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*")
 ENCODER_FLAG_RE = re.compile(r"[VAS][A-Za-z.]{5}")
 
@@ -55,14 +58,49 @@ def first_line(text: str) -> str:
     return ""
 
 
-def probe(binary: str, *args: str) -> tuple[dict[str, Any], str]:
-    """Run one read-only probe. Returns (public report, stdout for parsing)."""
+def positive_seconds(value: str) -> float:
+    try:
+        seconds = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("timeout must be a number") from exc
+    if seconds <= 0:
+        raise argparse.ArgumentTypeError("timeout must be greater than zero")
+    return seconds
+
+
+def probe(
+    binary: str,
+    *args: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> tuple[dict[str, Any], str]:
+    """Run one bounded read-only probe. Return its report and parseable stdout."""
     path = shutil.which(binary)
     if not path:
-        return {"available": False, "error": f"{binary} was not found on PATH"}, ""
-    result = subprocess.run([path, *args], capture_output=True, text=True, check=False)
+        return {
+            "available": False,
+            "status": "missing",
+            "error": f"{binary} was not found on PATH",
+        }, ""
+    try:
+        result = subprocess.run(
+            [path, *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "available": False,
+            "status": "timeout",
+            "path": path,
+            "returncode": None,
+            "timeout_seconds": timeout,
+            "error": f"{binary} probe timed out after {timeout:g} seconds",
+        }, ""
     report = {
         "available": result.returncode == 0,
+        "status": "ok" if result.returncode == 0 else "failed",
         "path": path,
         "returncode": result.returncode,
         "first_line": first_line(result.stdout + result.stderr),
@@ -125,26 +163,46 @@ PARSERS = {
 }
 
 
-def summarize_inventory(report: dict[str, Any], stdout: str, kind: str) -> tuple[dict[str, Any], set[str]]:
+def summarize_inventory(
+    report: dict[str, Any],
+    stdout: str,
+    kind: str,
+    *,
+    require_entries: bool = False,
+) -> tuple[dict[str, Any], set[str]]:
     summary: dict[str, Any] = {
         "available": report.get("available", False),
+        "status": report.get("status", "failed"),
         "returncode": report.get("returncode"),
     }
     entries = PARSERS[kind](stdout) if summary["available"] and stdout else set()
     summary["entry_count"] = len(entries)
     if summary["available"] and not entries:
-        summary["warning"] = "no parseable entries; inventory empty or unexpected format"
-    for key in ("error", "first_line"):
+        if require_entries:
+            summary["available"] = False
+            summary["status"] = "unparseable"
+            summary["error"] = EMPTY_INVENTORY_MESSAGE
+        else:
+            summary["status"] = "empty"
+            summary["warning"] = EMPTY_INVENTORY_MESSAGE
+    for key in ("error", "first_line", "timeout_seconds"):
         if key in report:
             summary[key] = report[key]
     return summary, entries
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Check local FFmpeg tools and named build capabilities before automating.",
     )
     parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument(
+        "--timeout",
+        type=positive_seconds,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        metavar="SECONDS",
+        help=f"bound each external probe (default: {DEFAULT_TIMEOUT_SECONDS:g} seconds)",
+    )
     parser.add_argument(
         "--filter", action="append", default=[], metavar="NAME",
         help="check whether filter NAME is available (repeatable)",
@@ -157,26 +215,53 @@ def main() -> int:
         "--hwaccel", action="append", default=[], metavar="NAME",
         help="check whether hardware acceleration method NAME is available (repeatable)",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    ffmpeg_report, _ = probe("ffmpeg", "-version")
-    ffprobe_report, _ = probe("ffprobe", "-version")
+    requested = {
+        "filters": list(dict.fromkeys(args.filter)),
+        "encoders": list(dict.fromkeys(args.encoder)),
+        "hwaccels": list(dict.fromkeys(args.hwaccel)),
+    }
+    has_named_queries = any(requested.values())
+
+    ffmpeg_report, _ = probe("ffmpeg", "-version", timeout=args.timeout)
+    ffprobe_report, _ = probe("ffprobe", "-version", timeout=args.timeout)
+    ffmpeg_report["required"] = True
+    ffprobe_report["required"] = not has_named_queries
 
     inventories: dict[str, dict[str, Any]] = {}
     entries: dict[str, set[str]] = {}
     for kind in ("filters", "encoders", "hwaccels"):
         if ffmpeg_report.get("available"):
-            report, stdout = probe("ffmpeg", "-hide_banner", f"-{kind}")
+            inventory_report, stdout = probe(
+                "ffmpeg",
+                "-hide_banner",
+                f"-{kind}",
+                timeout=args.timeout,
+            )
         else:
-            report, stdout = {"available": False, "error": ffmpeg_report.get("error", "")}, ""
-        inventories[kind], entries[kind] = summarize_inventory(report, stdout, kind)
+            inventory_report, stdout = dict(ffmpeg_report), ""
+        inventories[kind], entries[kind] = summarize_inventory(
+            inventory_report,
+            stdout,
+            kind,
+            require_entries=bool(requested[kind]),
+        )
 
-    queries = {
-        "filter": {name: name in entries["filters"] for name in dict.fromkeys(args.filter)},
-        "encoder": {name: name in entries["encoders"] for name in dict.fromkeys(args.encoder)},
-        "hwaccel": {name: name in entries["hwaccels"] for name in dict.fromkeys(args.hwaccel)},
+    query_labels = {
+        "filters": "filter",
+        "encoders": "encoder",
+        "hwaccels": "hwaccel",
     }
-    queries = {kind: names for kind, names in queries.items() if names}
+    queries: dict[str, dict[str, bool | None]] = {}
+    for kind, names in requested.items():
+        if not names:
+            continue
+        inventory_is_usable = inventories[kind]["available"]
+        queries[query_labels[kind]] = {
+            name: name in entries[kind] if inventory_is_usable else None
+            for name in names
+        }
 
     report = {
         "ffmpeg": ffmpeg_report,
@@ -210,7 +295,7 @@ def main() -> int:
 
     probe_failures = (
         not ffmpeg_report["available"]
-        or not ffprobe_report["available"]
+        or (ffprobe_report["required"] and not ffprobe_report["available"])
         or any(not inventories[kind]["available"] for kind in inventories)
     )
     if probe_failures:

--- a/ffmpeg/scripts/fixtures/ffmpeg-8.1.2-inventories.json
+++ b/ffmpeg/scripts/fixtures/ffmpeg-8.1.2-inventories.json
@@ -1,0 +1,37 @@
+{
+  "version": "FFmpeg 8.1.2",
+  "description": "Representative excerpts from FFmpeg 8.1.2 inventory output.",
+  "filters": [
+    "Filters:",
+    "  T.. = Timeline support",
+    "  .S. = Slice threading",
+    "  ..C = Command support",
+    "  A = Audio input/output",
+    "  V = Video input/output",
+    "  | = Source or sink filter",
+    "  ------",
+    " .. scale             V->V       Scale the input video size.",
+    " TS aap               AA->A      Apply Affine Projection algorithm.",
+    " .. anullsrc          |->A       Null audio source, return empty audio frames.",
+    " .. abuffersink       A->|       Buffer audio frames."
+  ],
+  "encoders": [
+    "Encoders:",
+    " V..... = Video",
+    " A..... = Audio",
+    " S..... = Subtitle",
+    " .F.... = Frame-level multithreading",
+    " ..S... = Slice-level multithreading",
+    " ...X.. = Codec is experimental",
+    " ....B. = Supports draw_horiz_band",
+    " .....D = Supports direct rendering method 1",
+    " ------",
+    " V....D libx264              libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)",
+    " A....D aac                  AAC (Advanced Audio Coding)",
+    " V....D libvpx-vp9           libvpx VP9 (codec vp9)"
+  ],
+  "hwaccels": [
+    "Hardware acceleration methods:",
+    "videotoolbox"
+  ]
+}

--- a/ffmpeg/scripts/test_ffmpeg_preflight.py
+++ b/ffmpeg/scripts/test_ffmpeg_preflight.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 SCRIPT = Path(__file__).resolve().parent / "ffmpeg-preflight"
+INVENTORY_FIXTURE = SCRIPT.parent / "fixtures" / "ffmpeg-8.1.2-inventories.json"
 
 FAKE_FFMPEG_VERSION = "ffmpeg version 8.1.2 fake"
 FAKE_FFPROBE_VERSION = "ffprobe version 8.1.2 fake"
@@ -158,6 +159,26 @@ def test_success_json_reports_availability_counts(environment):
     assert report["queries"] == {}
 
 
+def test_ffmpeg_8_1_2_fixture_parses_expected_entries(environment):
+    setup, run = environment
+    fixture = json.loads(INVENTORY_FIXTURE.read_text())
+    setup(**{
+        kind: "\n".join(fixture[kind]) + "\n"
+        for kind in ("filters", "encoders", "hwaccels")
+    })
+    result = run("--json", "--filter", "scale", "--encoder", "libx264",
+                 "--hwaccel", "videotoolbox")
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    counts = [report[kind]["entry_count"] for kind in ("filters", "encoders", "hwaccels")]
+    assert counts == [4, 3, 1]
+    assert report["queries"] == {
+        "filter": {"scale": True},
+        "encoder": {"libx264": True},
+        "hwaccel": {"videotoolbox": True},
+    }
+
+
 def test_named_queries_present_exit_zero(environment):
     setup, run = environment
     result = run("--json", "--filter", "scale", "--filter", "anullsrc",
@@ -199,7 +220,7 @@ def test_missing_tools_exit_one(environment, tmp_path):
     assert report["ffmpeg"]["available"] is False
     assert report["ffprobe"]["available"] is False
     assert report["filters"]["available"] is False
-    assert report["queries"] == {"filter": {"scale": False}}
+    assert report["queries"] == {"filter": {"scale": None}}
 
 
 def test_ffprobe_missing_exit_one(environment):
@@ -210,6 +231,27 @@ def test_ffprobe_missing_exit_one(environment):
     report = json.loads(result.stdout)
     assert report["ffmpeg"]["available"] is True
     assert report["ffprobe"]["available"] is False
+
+
+def test_ffprobe_missing_allows_ffmpeg_only_named_query(environment):
+    setup, run = environment
+    setup(with_ffprobe=False)
+    result = run("--json", "--filter", "scale")
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["ffprobe"]["required"] is False
+    assert report["queries"]["filter"]["scale"] is True
+
+
+def test_timeout_is_probe_failure(environment, tmp_path):
+    _, run = environment
+    ffmpeg = tmp_path / "bin" / "ffmpeg"
+    ffmpeg.write_text("#!/bin/sh\n/bin/sleep 1\n")
+    result = run("--json", "--timeout", "0.01")
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert report["ffmpeg"]["status"] == "timeout"
+    assert report["ffmpeg"]["timeout_seconds"] == 0.01
 
 
 def test_inventory_command_failure_exit_one(environment):
@@ -242,22 +284,26 @@ def test_empty_inventory_warns_and_exits_zero_without_queries(environment):
     assert report["hwaccels"]["entry_count"] == 0
 
 
-def test_query_against_empty_inventory_is_absent_exit_two(environment):
+def test_query_against_empty_inventory_is_probe_failure(environment):
     setup, run = environment
     setup(filters=HEADER_ONLY_FILTERS)
-    result = run("--filter", "scale")
-    assert result.returncode == 2
+    result = run("--json", "--filter", "scale")
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert report["filters"]["status"] == "unparseable"
+    assert report["queries"]["filter"]["scale"] is None
 
 
 def test_malformed_output_yields_no_entries(environment):
     setup, run = environment
     setup(filters=MALFORMED_FILTERS, encoders="garbage line\nsecond line\n")
     result = run("--json", "--filter", "scale", "--encoder", "libx264")
-    assert result.returncode == 2
+    assert result.returncode == 1
     report = json.loads(result.stdout)
     assert report["filters"]["entry_count"] == 0
     assert report["encoders"]["entry_count"] == 0
-    assert report["queries"]["filter"]["scale"] is False
+    assert report["queries"]["filter"]["scale"] is None
+    assert report["queries"]["encoder"]["libx264"] is None
 
 
 def test_repeated_flags_are_deduplicated(environment):


### PR DESCRIPTION
## What changed

- Harden FFmpeg preflight probes with a default timeout and explicit timeout status.
- Keep `ffprobe` optional for FFmpeg-only named capability queries.
- Distinguish usable inventories from empty or unparseable inventories and return structured unknown results for the latter.
- Add deterministic tests and a small version-labeled FFmpeg 8.1.2 parser fixture.
- Document the final preflight contract and its exit codes.

## Verification

- `python3 -m pytest ffmpeg/scripts -q -o addopts=''` (19 passed)
- `python3 scripts/validate-evals.py`
- `uvx --from skills-ref agentskills validate ffmpeg`
- `ruby scripts/validate-skills.rb`
- `python3 scripts/check-skill-tests.py --check`
- `git diff --check`

No real-media transcode, network protocol, or GPU hardware path was exercised.

Closes #430
