### PR TITLE
fix(jira): gate mutating CLI operations

### DIFF
--- a/jira/README.md
+++ b/jira/README.md
@@ -39,6 +39,8 @@ export JIRA_SERVER="https://your-domain.atlassian.net"
 jira me                        # verify auth works
 jira list --project PROJ       # newest tickets
 jira count --jql 'issuetype = Bug AND resolution = Unresolved'
+jira create --project PROJ --summary "Test" --dry-run  # preview writes
+jira --yes create --project PROJ --summary "Test"      # authorize a write
 ```
 
 ## Triggers

--- a/jira/SKILL.md
+++ b/jira/SKILL.md
@@ -101,11 +101,12 @@ Always run `transitions` first when unsure: IDs differ per workflow and current 
 
 ## Global Flags
 
-All flags work in any position:
+All flags work in any position. Read commands need credentials; `--help` and `--dry-run` do not. Mutating commands require an explicit `--yes`/`--force` gate:
 
 ```bash
 jira --json list --project PROJ                        # machine output anywhere
 jira --dry-run create --project PROJ --summary "Test"  # offline preview
+jira --yes create --project PROJ --summary "Test"      # explicit write authorization
 jira --quiet list                                      # suppress non-essential output
 ```
 

--- a/jira/scripts/jira
+++ b/jira/scripts/jira
@@ -49,7 +49,7 @@ def emit(human: str, data: Any) -> None:
         print(human)
 
 
-def require_mutation_authorization(client: JiraClient, command: str) -> None:
+def require_mutation_authorization(client: "JiraClient", command: str) -> None:
     """Require an explicit bypass for non-dry-run state changes."""
     if client.dry_run or GLOBAL_FLAGS.get("force", False):
         return

--- a/jira/scripts/jira
+++ b/jira/scripts/jira
@@ -49,6 +49,14 @@ def emit(human: str, data: Any) -> None:
         print(human)
 
 
+def require_mutation_authorization(client: JiraClient, command: str) -> None:
+    """Require an explicit bypass for non-dry-run state changes."""
+    if client.dry_run or GLOBAL_FLAGS.get("force", False):
+        return
+    die(f"{command} changes Jira state. Re-run with --yes (or --force), "
+        "or use --dry-run to preview the request.")
+
+
 # === Global flags ===
 GLOBAL_FLAGS: Dict[str, Any] = {
     "json": False, "dry_run": False, "force": False,
@@ -57,14 +65,15 @@ GLOBAL_FLAGS: Dict[str, Any] = {
 
 
 def _preparse_global_flags(argv: List[str]) -> Tuple[Dict[str, Any], List[str]]:
-    GLOBAL_BOOLS = {"--json", "--dry-run", "--force", "--quiet", "--verbose"}
+    GLOBAL_BOOLS = {"--json", "--dry-run", "--force", "--yes", "--quiet", "--verbose"}
     flags: Dict[str, Any] = {}
     filtered: List[str] = [argv[0]]
     i = 1
     while i < len(argv):
         arg = argv[i]
         if arg in GLOBAL_BOOLS:
-            flags[arg.lstrip("-").replace("-", "_")] = True
+            key = arg.lstrip("-").replace("-", "_")
+            flags["force" if key == "yes" else key] = True
             i += 1
         elif arg in ("--help", "-h"):
             return flags, argv
@@ -456,6 +465,7 @@ def cmd_create(client: JiraClient, args: List[str]) -> None:
               "project": parsed.project, "summary": parsed.summary,
               "type": parsed.type})
         return
+    require_mutation_authorization(client, "create")
 
     result = client.create_issue(
         project_key=parsed.project,
@@ -482,6 +492,7 @@ def cmd_comment(client: JiraClient, args: List[str]) -> None:
              {"dry_run": True, "command": "comment",
               "issue_key": parsed.issue_key, "body": parsed.body})
         return
+    require_mutation_authorization(client, "comment")
 
     result = client.add_comment(parsed.issue_key, parsed.body)
     cid = result.get("id", "?") if result else "?"
@@ -504,6 +515,7 @@ def cmd_transition(client: JiraClient, args: List[str]) -> None:
               "issue_key": parsed.issue_key, "to": parsed.to,
               "resolution": parsed.resolution})
         return
+    require_mutation_authorization(client, "transition")
 
     # First, get available transitions — IDs are workflow- and status-specific,
     # so names alone are ambiguous across projects.

--- a/jira/scripts/test_jira.py
+++ b/jira/scripts/test_jira.py
@@ -158,6 +158,29 @@ class DryRunTests(unittest.TestCase):
             req.assert_not_called()
 
 
+class MutationGateTests(unittest.TestCase):
+    def setUp(self):
+        self._env = (jira_cli.ENV_EMAIL, jira_cli.ENV_TOKEN)
+        jira_cli.ENV_EMAIL = "ops@example.com"
+        jira_cli.ENV_TOKEN = "test-token-123"
+
+    def tearDown(self):
+        jira_cli.ENV_EMAIL, jira_cli.ENV_TOKEN = self._env
+
+    def test_create_requires_explicit_yes_or_force(self):
+        code, _, err = run_cli("create", "--project", "PROJ", "--summary", "Test")
+        self.assertEqual(code, 1)
+        self.assertIn("--yes", err)
+
+    def test_yes_alias_allows_mutation(self):
+        with mock.patch.object(requests, "request", return_value=FakeResponse(
+                201, {"key": "PROJ-1", "self": "https://jira.example/issue/PROJ-1"})):
+            code, out, _ = run_cli("--yes", "create", "--project", "PROJ",
+                                   "--summary", "Test", "--json")
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out)["status"], "created")
+
+
 # === Class 4: mocked client logic ===
 
 
@@ -227,7 +250,7 @@ class MockedClientTests(unittest.TestCase):
         resp = FakeResponse(400, {"errorMessages": [],
                                   "errors": {"resolution": "Resolution is required"}})
         with mock.patch.object(requests, "request", return_value=resp):
-            code, _, err = run_cli("comment", "PROJ-1", "-m", "hi")
+            code, _, err = run_cli("--force", "comment", "PROJ-1", "-m", "hi")
         self.assertEqual(code, 1)
         self.assertIn("resolution: Resolution is required", err)
 
@@ -261,7 +284,7 @@ class MockedClientTests(unittest.TestCase):
         ]}
         resp = FakeResponse(200, payload)
         with mock.patch.object(requests, "request", return_value=resp):
-            code, out, _ = run_cli("transitions", "PROJ-1", "--json")
+            code, out, _ = run_cli("--force", "transitions", "PROJ-1", "--json")
         self.assertEqual(code, 0)
         data = json.loads(out)
         self.assertEqual([t["id"] for t in data["transitions"]], ["31", "11"])
@@ -281,7 +304,7 @@ class MockedClientTests(unittest.TestCase):
             return FakeResponse(204, None, text="")
 
         with mock.patch.object(requests, "request", side_effect=fake_request):
-            code, out, _ = run_cli("transition", "PROJ-1", "--to", "Done",
+            code, out, _ = run_cli("--force", "transition", "PROJ-1", "--to", "Done",
                                    "--resolution", "Fixed", "--json")
         self.assertEqual(code, 0)
         self.assertEqual(len(posted), 1)
@@ -296,7 +319,7 @@ class MockedClientTests(unittest.TestCase):
              "to": {"name": "In Progress",
                     "statusCategory": {"key": "in-flight"}}}]})
         with mock.patch.object(requests, "request", return_value=listing):
-            code, _, err = run_cli("transition", "PROJ-1", "--to", "Done")
+            code, _, err = run_cli("--force", "transition", "PROJ-1", "--to", "Done")
         self.assertEqual(code, 1)
         self.assertIn("Available: 11=Start Progress", err)
 


### PR DESCRIPTION
Closes #404

## Summary

Complete the canonical Jira skill migration by retaining the monolithic Jira CLI/JQL surface and hardening mutating operations with explicit dry-run and confirmation gates. Offline tests cover read, JSON, JQL, missing-auth, dry-run, and mutation behavior.

## Validation

- `ruby scripts/validate-skills.rb`
- `ruby scripts/validate-skill-quality.rb --base origin/main`
- `ruby scripts/validate-references.rb`
- `python3 scripts/validate-evals.py`
- `python3 scripts/check-skill-tests.py --check`
- `make validate`
- Catalog freshness checks for Claude, Codex, and `llms.txt`

All checks passed at exact branch head `1817203`.

Generated with assistance from Factory Droid.
