### PR TITLE
docs(jira): authorize mutating examples

### DIFF
--- a/jira/SKILL.md
+++ b/jira/SKILL.md
@@ -73,9 +73,9 @@ Uses `POST /search/approximate-count` — no fetching rows. JQL itself has no CO
 ### create — new issues
 
 ```bash
-jira create --project PROJ --summary "Fix login bug"            # Task (default)
-jira create --project PROJ --summary "Crash on startup" --type Bug
-jira create --project PROJ --summary "Add dark mode" --type Story --priority High
+jira --yes create --project PROJ --summary "Fix login bug"            # Task (default)
+jira --yes create --project PROJ --summary "Crash on startup" --type Bug
+jira --yes create --project PROJ --summary "Add dark mode" --type Story --priority High
 jira create --project PROJ --summary "Test" --dry-run           # preview payload
 ```
 
@@ -84,7 +84,7 @@ Descriptions are sent as ADF documents. Rich formatting beyond plain paragraphs 
 ### comment — add to threads
 
 ```bash
-jira comment PROJ-123 -m "Fixed in latest build"
+jira --yes comment PROJ-123 -m "Fixed in latest build"
 jira comment PROJ-123 -m "Looking into it" --dry-run
 ```
 
@@ -92,8 +92,8 @@ jira comment PROJ-123 -m "Looking into it" --dry-run
 
 ```bash
 jira transitions PROJ-123                     # LIST valid transition IDs first
-jira transition PROJ-123 --to "In Progress"   # then apply by name or ID
-jira transition PROJ-123 --to Done --resolution Done
+jira --yes transition PROJ-123 --to "In Progress"   # then apply by name or ID
+jira --yes transition PROJ-123 --to Done --resolution Done
 jira transition PROJ-123 --to "In Review" --dry-run
 ```
 
@@ -123,7 +123,7 @@ jira list --jql 'sprint IN openSprints() AND updated < -14d AND resolution = Unr
   | jq -r '.issues[].key' \
   | while read -r key; do jira view "$key"; jira transitions "$key"; done
 # after human review, per key:
-jira transition "$key" --to Done --resolution Done
+jira --yes transition "$key" --to Done --resolution Done
 ```
 
 The `list --json` shape is `{"total": N, "issues": [{"key", "summary", "status", "assignee", "issuetype", "priority"}]}`.
@@ -135,7 +135,7 @@ Transition IDs are workflow-specific — resolve before writing:
 ```bash
 for key in $(jira list --jql 'status = "In Progress" AND updated < -30d' --json | jq -r '.issues[].key'); do
   tid=$(jira transitions "$key" --json | jq -r '.transitions[] | select(.status_category=="completed") | .id' | head -1)
-  [ -n "$tid" ] && jira transition "$key" --to "$tid" --resolution Done
+  [ -n "$tid" ] && jira --yes transition "$key" --to "$tid" --resolution Done
 done
 ```
 


### PR DESCRIPTION
Closes #404

Add explicit `--yes` authorization to every non-dry-run Jira create, comment, and transition example while preserving dry-run previews. This corrects documentation drift after the Jira CLI mutation safety gate landed.

Validation at head `da43c6d7f1a8ad5bc77db5ed8a44f7523d6ee5ee`:
- Focused Jira offline tests: 22 passed (coverage plugin disabled for this docs-only test run)
- `ruby scripts/validate-skills.rb`
- `ruby scripts/validate-skill-quality.rb --base origin/main`
- `ruby scripts/validate-references.rb`
- `python3 scripts/test-eval-validation.py`
- `python3 scripts/validate-evals.py`
- `python3 scripts/check-skill-tests.py --check`
- `python3 scripts/validate-agents-md.py`
- `python3 scripts/check-artifacts.py`
- `ruby scripts/validate-bundles.rb`
- `ruby scripts/validate-lifecycle-matrix.rb`
- `make validate`

AI-assisted change.