### PR TITLE
fix(validation): align local core tests with CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -84,9 +84,13 @@ jobs:
       - name: Check skill test coverage
         run: python3 scripts/check-skill-tests.py --check
       - name: Run core test suite with coverage
-        run: python3 -m pytest scripts/test-eval-validation.py scripts/test-eval-coverage.py scripts/test_check_skill_tests.py eval_runner/tests/ -v --durations=10 --cov=scripts --cov=eval_runner --cov-fail-under=60 --cov-report=term-missing
+        run: |
+          mapfile -t core_tests < <(sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' scripts/core-test-files.txt)
+          python3 -m pytest "${core_tests[@]}" -v --durations=10 --cov=scripts --cov=eval_runner --cov-fail-under=60 --cov-report=term-missing
       - name: Run tests in parallel (isolation check)
-        run: python3 -m pytest scripts/test-eval-validation.py scripts/test-eval-coverage.py scripts/test_check_skill_tests.py eval_runner/tests/ -n auto -v --durations=10
+        run: |
+          mapfile -t core_tests < <(sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' scripts/core-test-files.txt)
+          python3 -m pytest "${core_tests[@]}" -n auto -v --durations=10
       - name: Validate AGENTS.md consistency
         run: python3 scripts/validate-agents-md.py
       - name: Run integration tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: dev lint typecheck test complexity deps coverage security dep-age runbooks docs validate
 
+# Keep local core tests aligned with the required CI coverage selection.
+CORE_TESTS := $(shell cat scripts/core-test-files.txt)
+
 # ─── Development Setup ──────────────────────────────────────────
 dev: .venv
 	@echo "Development environment ready. Run 'make validate' to run all checks."
@@ -30,16 +33,16 @@ complexity:
 
 # ─── Testing ────────────────────────────────────────────────────
 test:
-	.venv/bin/python3 -m pytest scripts/test-eval-validation.py scripts/test-eval-coverage.py eval_runner/tests/ -v --durations=10
+	.venv/bin/python3 -m pytest $(CORE_TESTS) -v --durations=10
 
 test-integration:
 	.venv/bin/python3 -m pytest tests/integration/ -v --durations=10
 
 test-cov:
-	.venv/bin/python3 -m pytest scripts/test-eval-validation.py scripts/test-eval-coverage.py eval_runner/tests/ tests/integration/ -v --durations=10 --cov=scripts --cov=eval_runner --cov-fail-under=60 --cov-report=term-missing
+	.venv/bin/python3 -m pytest $(CORE_TESTS) tests/integration/ -v --durations=10 --cov=scripts --cov=eval_runner --cov-fail-under=60 --cov-report=term-missing
 
 test-parallel:
-	.venv/bin/python3 -m pytest scripts/test-eval-validation.py scripts/test-eval-coverage.py eval_runner/tests/ tests/integration/ -n auto -v --durations=10
+	.venv/bin/python3 -m pytest $(CORE_TESTS) -n auto -v --durations=10
 
 # ─── Dependencies ───────────────────────────────────────────────
 deps:

--- a/scripts/core-test-files.txt
+++ b/scripts/core-test-files.txt
@@ -1,0 +1,5 @@
+scripts/test-eval-validation.py
+scripts/test-eval-coverage.py
+scripts/test_check_skill_tests.py
+scripts/test_core_test_selection.py
+eval_runner/tests/

--- a/scripts/test_core_test_selection.py
+++ b/scripts/test_core_test_selection.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Ensure local and CI core test selections use the shared manifest."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "scripts" / "core-test-files.txt"
+MAKEFILE = ROOT / "Makefile"
+WORKFLOW = ROOT / ".github" / "workflows" / "validate.yml"
+
+
+def manifest_entries() -> list[str]:
+    return [
+        line.strip()
+        for line in MANIFEST.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def test_core_manifest_is_nonempty_and_files_exist() -> None:
+    entries = manifest_entries()
+    assert entries
+    assert all((ROOT / entry).is_file() or (ROOT / entry).is_dir() for entry in entries)
+    assert len(entries) == len(set(entries))
+
+
+def test_makefile_consumes_shared_core_manifest() -> None:
+    makefile = MAKEFILE.read_text()
+    assert "core-test-files.txt" in makefile
+    assert "$(CORE_TESTS)" in makefile
+
+
+def test_required_ci_consumes_shared_core_manifest() -> None:
+    workflow = WORKFLOW.read_text()
+    assert "core-test-files.txt" in workflow
+    assert "mapfile -t core_tests" in workflow
+    assert '"${core_tests[@]}"' in workflow
+
+
+def test_manifest_contains_required_validation_modules() -> None:
+    assert set(manifest_entries()) >= {
+        "scripts/test-eval-validation.py",
+        "scripts/test-eval-coverage.py",
+        "scripts/test_check_skill_tests.py",
+        "scripts/test_core_test_selection.py",
+        "eval_runner/tests/",
+    }


### PR DESCRIPTION
## Summary

Closes #412

Align Makefile core test and coverage targets with the required GitHub validate workflow through a shared `scripts/core-test-files.txt` manifest. Add a regression test that requires both consumers to use the manifest.

## Validation

- `make validate` passed at `f12e7fd57615536e687ab4c4aab6bfcf071b2907`
- CI-equivalent core coverage passed: 143 tests, 29 subtests, 62.62% coverage
- Named repository gates passed, including 167 valid eval manifests and 100% eval coverage
- Catalog generator checks passed for Claude, Codex, and llms.txt

## Documentation

- [x] Documentation not required for this Makefile/workflow alignment.

## Community and security

- [x] No credentials or private infrastructure details included.
- [x] Meaningful AI assistance disclosed: implementation and validation were performed with AI assistance and reviewed against repository gates.

## Review notes

- [x] Final-head evidence is tied to `f12e7fd57615536e687ab4c4aab6bfcf071b2907`.
- Advisory droid-review status is recorded separately from required validation checks.