### PR TITLE
fix(validation): add explicit catalog JSON selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,27 @@ For Hermes Agent, keep `--global`: the CLI then installs directly into `$HERMES_
 
 The [skills.sh catalog page](https://skills.sh/magnus919/agent-skills) is populated from installation telemetry rather than a separately submitted registry manifest.
 
+### Repository validation
+
+Contributors need Python 3.14+ and Ruby 2.6+ (the checked-in `.venv` uses the pinned development dependencies in `requirements-dev.txt`). Run the focused checks first, then the complete repository gate:
+
+```bash
+python3 scripts/check-catalog-set.py
+python3 scripts/check-artifacts.py
+python3 scripts/validate-evals.py
+make validate
+```
+
+`check-catalog-set.py` emits JSON by default and also accepts the explicit `--json` selector. It compares canonical top-level `SKILL.md` names with the Claude, Codex, Agents, and `llms.txt` projections, rejecting missing, extra, duplicate, retired, nested, or infrastructure entries. Regenerate projections from source metadata when needed:
+
+```bash
+ruby scripts/gen-claude-marketplace.rb --write
+ruby scripts/gen-codex-plugin.rb --write
+ruby scripts/gen-llms-txt.rb --write
+```
+
+The eval manifest contract is checked with `python3 scripts/validate-evals.py`; use `python3 scripts/eval-coverage.py` for the current coverage report and `python3 scripts/test-eval-validation.py` for focused validator tests. Lifecycle matrix and fake-adapter coverage are verified with `ruby scripts/validate-lifecycle-matrix.rb` and `CORPUS_OUT_DIR=/tmp/lifecycle-evals-runs-local bash lifecycle-evals/scripts/run-corpus.sh`.
+
 ### Harness-native installation
 
 Skills don't require installation in the traditional sense. They are loaded by your AI agent when triggered. Each agent framework documents its own skill directory path and loading mechanism — follow the links below for the authoritative setup guide for your harness.

--- a/scripts/check-catalog-set.py
+++ b/scripts/check-catalog-set.py
@@ -118,6 +118,11 @@ def compare(root: Path) -> dict[str, object]:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Compare canonical skills and generated catalogs")
     parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parent.parent)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="select JSON output (the default; retained for explicit CLI callers)",
+    )
     args = parser.parse_args()
     try:
         result = compare(args.root.resolve())

--- a/scripts/core-test-files.txt
+++ b/scripts/core-test-files.txt
@@ -2,4 +2,5 @@ scripts/test-eval-validation.py
 scripts/test-eval-coverage.py
 scripts/test_check_skill_tests.py
 scripts/test_core_test_selection.py
+scripts/test_check_catalog_set.py
 eval_runner/tests/

--- a/scripts/test_check_catalog_set.py
+++ b/scripts/test_check_catalog_set.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import importlib.util
 import json
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -17,6 +19,15 @@ class CatalogSetTest(unittest.TestCase):
     def test_current_catalogs_match(self) -> None:
         result = check_catalog_set.compare(Path(__file__).parent.parent)
         self.assertTrue(result["ok"], result)
+
+    def test_explicit_json_selector_preserves_default_output(self) -> None:
+        script = Path(__file__).parent / "check-catalog-set.py"
+        command = [sys.executable, str(script)]
+        default = subprocess.run(command, capture_output=True, text=True, check=False)
+        explicit = subprocess.run([*command, "--json"], capture_output=True, text=True, check=False)
+        self.assertEqual(default.returncode, 0)
+        self.assertEqual(explicit.returncode, 0)
+        self.assertEqual(json.loads(default.stdout), json.loads(explicit.stdout))
 
     def test_missing_duplicate_extra_and_retired_are_reported(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## What changed
- accept explicit `--json` while preserving JSON as the default catalog comparator output
- add regression coverage for both invocation forms
- document final catalog, eval, lifecycle, and repository validation commands in the root README
- include the catalog regression in the shared core test selection

## Validation
- `make validate`
- catalog, artifact, structure, reference, eval, bundle, lifecycle, and fake-adapter gates

AI-assisted change: implemented and validated with Codex.

Closes #412