### PR TITLE
fix(validation): align README and core test filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: dev lint typecheck test complexity deps coverage security dep-age runbooks docs validate
 
 # Keep local core tests aligned with the required CI coverage selection.
-CORE_TESTS := $(shell cat scripts/core-test-files.txt)
+CORE_TESTS := $(shell grep -Ev '^[[:space:]]*\#|^[[:space:]]*$$' scripts/core-test-files.txt)
 
 # ─── Development Setup ──────────────────────────────────────────
 dev: .venv

--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ The [skills.sh catalog page](https://skills.sh/magnus919/agent-skills) is popula
 
 ### Repository validation
 
-Contributors need Python 3.14+ and Ruby 2.6+ (the checked-in `.venv` uses the pinned development dependencies in `requirements-dev.txt`). Run the focused checks first, then the complete repository gate:
+Contributors need Python 3.10+ and Ruby 2.6+ for local development. CI currently runs the validation workflow with Python 3.12 and Ruby 3.3; the checked-in `.venv` uses the pinned development dependencies in `requirements-dev.txt`. Run the focused checks first, then the complete repository gate:
 
 ```bash
 python3 scripts/check-catalog-set.py

--- a/scripts/test_core_test_selection.py
+++ b/scripts/test_core_test_selection.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """Ensure local and CI core test selections use the shared manifest."""
 
+import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = ROOT / "scripts" / "core-test-files.txt"
 MAKEFILE = ROOT / "Makefile"
 WORKFLOW = ROOT / ".github" / "workflows" / "validate.yml"
+FILTER = "sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d'"
 
 
 def manifest_entries() -> list[str]:
@@ -28,6 +30,26 @@ def test_makefile_consumes_shared_core_manifest() -> None:
     makefile = MAKEFILE.read_text()
     assert "core-test-files.txt" in makefile
     assert "$(CORE_TESTS)" in makefile
+
+
+def test_makefile_filters_comments_and_blank_lines_like_ci() -> None:
+    makefile = MAKEFILE.read_text()
+    # Make doubles the dollar sign so the shell receives the same expression as CI.
+    assert "grep -Ev '^[[:space:]]*\\#|^[[:space:]]*$$'" in makefile
+
+
+def test_make_and_ci_filtering_semantics_match() -> None:
+    sample = "# comment\n  # indented comment\n\n  scripts/example.py  \n\t\n"
+    expected = ["scripts/example.py"]
+    filtered = subprocess.run(
+        ["sed", "-e", "/^[[:space:]]*#/d", "-e", "/^[[:space:]]*$/d"],
+        input=sample,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.splitlines()
+    assert [line.strip() for line in filtered] == expected
+    assert FILTER in WORKFLOW.read_text()
 
 
 def test_required_ci_consumes_shared_core_manifest() -> None:


### PR DESCRIPTION
## What changed
- Correct the README supported local baseline to Python 3.10+ and document current CI Python/Ruby versions.
- Make Makefile core-test loading ignore comments and blank lines exactly like the required CI selection.
- Add regression coverage for filtering semantics and shared-manifest usage.

## Validation
- `make validate`
- `./.venv/bin/python -m pytest $(sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' scripts/core-test-files.txt) -v --durations=10 --cov=scripts --cov=eval_runner --cov-fail-under=60 --cov-report=term-missing` (61.82%, 149 passed)
- All named repository gates, catalog checks, and lifecycle coverage checks passed.

This is a focused repository-quality consistency fix. No snapshot issue is being closed by this PR.
