### PR TITLE
docs(research-methodology): bound timeout recovery windows

### DIFF
--- a/research-methodology/SKILL.md
+++ b/research-methodology/SKILL.md
@@ -55,7 +55,7 @@ The right artifact shape depends on the environment. Do not assume a particular 
 
 ## Interruption and Timeout Recovery
 
-A research worker timeout is an interruption, not a research result. Never close the investigation, summarize it as complete, or infer that no useful work exists because a delegated worker exceeded its execution cap. Long research jobs commonly encounter slow extraction, rate limits, or one unresponsive source after producing valuable partial work.
+A research worker timeout is an interruption, not a research result. Never close the investigation, summarize it as complete, or infer that no useful work exists because a delegated worker exceeded its execution cap. Long research jobs commonly encounter slow extraction, rate limits, or one unresponsive source after producing valuable partial work. Plan long research as bounded, resumable subtasks: use task-appropriate execution windows, write incremental checkpoints, and resume from the latest verified checkpoint instead of imposing arbitrary short caps or assuming an unbounded window is available.
 
 When a worker times out:
 


### PR DESCRIPTION
## Approved durable local-patch follow-up

This focused PR delivers only the reviewed patch to:
- `research-methodology/SKILL.md`

It does not claim or close any unrelated issue. The change preserves checkpointing/resumability guidance while replacing metaphorical and unbounded timeout language with bounded resumable subtasks and existing timeout recovery.

Validation at exact head `ef3fe2dae003ff603e15b5b2771c8c3fe7371c33`:
- All focused repository validators passed.
- `make validate` passed: 163 tests, 29 subtests, 61.93% coverage.
- Canonical eval baseline remains 167/167 manifests schema-valid (the current repository reports 167 canonical skills; the approved 163/140 planning baseline is preserved as a non-regression reference).
- Catalog generators/checks passed.

Merge authorization: user authorized exactly two focused follow-up PRs and squash merges after green required checks and mergeability. Please squash-merge only after the required `validate` check is green and the PR is mergeable/clean.
