### PR TITLE
feat(ffmpeg): add contract-driven media acceptance

### DIFF
--- a/ffmpeg/README.md
+++ b/ffmpeg/README.md
@@ -49,6 +49,7 @@ This skill provides a repeatable intake-to-acceptance workflow. It separates tec
 | `templates/visual-review-packet.md` | Timestamped review samples with attribution and coverage limits |
 | `templates/podcast-edit-plan.md` | Mechanical, signal-processing, and editorial audio plan |
 | `templates/media-acceptance-report.md` | Criterion-by-criterion evidence and release verdict |
+| `templates/media-acceptance-contract.json` | Parseable stream, format, evidence, loudness, and downstream criteria |
 | `templates/research-experiment-record.md` | Versioned, reproducible command experiment record |
 
 ### Existing automation and evals
@@ -62,7 +63,7 @@ This skill provides a repeatable intake-to-acceptance workflow. It separates tec
 | `scripts/extract-review-frames` | Bounded timestamp frame extraction for human or vision review |
 | `scripts/render-edl` | Validate single- or multi-source EDLs and emit non-executing concat-filter or concat-demuxer plans |
 | `scripts/audio-inspect` | Bounded silence, loudness, peak/clipping, transcript-candidate, and podcast-plan evidence |
-| `scripts/media-verify` | Compare input/output probe documents against basic criteria |
+| `scripts/media-verify` | Evaluate output probe and review evidence against a declared acceptance contract |
 | `scripts/editorial-workflow-example` | Generate synthetic audio/video and exercise the complete workflow with durable evidence |
 | `scripts/generate-media-fixtures` | Generate a bounded sanitized fixture battery and versioned evidence manifest |
 | `evals/evals.json` | Output-quality cases for core FFmpeg, media evidence, video, podcast, EDL, safety, and acceptance behavior |
@@ -118,6 +119,15 @@ scripts/audio-inspect input.wav \
 ```
 
 Optional timed transcript JSON must disclose alignment quality. Detector intervals and transcript ranges remain candidates until listening review approves an edit.
+
+Evaluate a rendered output against declared criteria:
+
+```sh
+scripts/media-verify acceptance-contract.json output-probe.json \
+  --evidence review-evidence.json --json
+```
+
+Missing fields or review evidence remain `UNVERIFIED`; blocked reviews remain `BLOCKED`; local probe/decode success never supplies downstream compatibility evidence.
 
 ## Triggers
 

--- a/ffmpeg/SKILL.md
+++ b/ffmpeg/SKILL.md
@@ -91,6 +91,7 @@ For shipped helper workflows, run the helper from the skill root with explicit o
 - `templates/visual-review-packet.md` — attributed frame/clip observations and coverage limits
 - `templates/podcast-edit-plan.md` — mechanical, signal, and editorial audio decisions
 - `templates/media-acceptance-report.md` — layered verification and criterion verdicts
+- `templates/media-acceptance-contract.json` — machine-readable stream, format, evidence, loudness, and downstream requirements
 - `templates/research-experiment-record.md` — reproducible version/command/result record
 
 Run `scripts/editorial-workflow-example` in a new or empty task-local directory when a reproducible synthetic integration proof is required. Its `PASS_WITH_UNVERIFIED_BOUNDARIES` result is deliberately narrower than editorial or destination acceptance.
@@ -100,6 +101,8 @@ Run `scripts/generate-media-fixtures` when tests need deterministic non-personal
 Use `scripts/render-edl` for a non-executing single- or multi-source plan. Default to decoded concat-filter assembly; select concat-demuxer stream copy only with matching probe-derived signatures and verified packet/keyframe boundaries. Unsupported transitions must remain explicit errors.
 
 Use `scripts/audio-inspect` for bounded silence, EBU R128, peak/clipping, and transcript-alignment evidence. Request each measurement explicitly, preserve unavailable filters as `UNAVAILABLE`, and treat every interval or transcript range as a listening-review candidate. Its optional report output refuses overwrite.
+
+Use `scripts/media-verify` with a declared acceptance contract, output FFprobe JSON, and optional evidence JSON. It reports every criterion independently as `PASS`, `FAIL`, `BLOCKED`, `UNVERIFIED`, or `NOT_APPLICABLE`; only a report with no failed or missing required evidence is an overall pass.
 
 Copy a template into the task workspace and replace its placeholder/example values. Do not put private paths, media, transcripts, or review evidence in the public skill repository.
 

--- a/ffmpeg/evals/evals.json
+++ b/ffmpeg/evals/evals.json
@@ -144,6 +144,19 @@
         "records source ranges, actions, reasons, evidence, confidence, handles, fades, and output contract"
       ],
       "case_set": "release"
+    },
+    {
+      "id": "criterion-level-media-acceptance",
+      "prompt": "Verify this rendered MP4 against the attached delivery contract. The probe is present, but the listening review and destination-player result are missing. Tell me whether it passes.",
+      "expected_output": "Evaluate each declared stream, format, timing, subtitle, metadata, decode, signal, review, and downstream criterion independently. Report missing listening and destination evidence as UNVERIFIED, keep local probe/decode evidence at its own boundary, and return an overall UNVERIFIED result rather than a pass.",
+      "assertions": [
+        "reports criterion, expected and observed values, evidence, boundary, and verdict separately",
+        "uses explicit tolerances for duration, timestamps, rates, and measured values",
+        "marks absent required evidence unverified or blocked rather than passing it",
+        "tests streams, subtitles, timing, audio, video, and downstream evidence independently",
+        "does not generalize local probe or decode success into destination compatibility"
+      ],
+      "case_set": "release"
     }
   ]
 }

--- a/ffmpeg/references/media-verification-and-acceptance.md
+++ b/ffmpeg/references/media-verification-and-acceptance.md
@@ -53,6 +53,16 @@ For every criterion, capture:
 
 The final verdict is `accepted`, `rejected`, or `blocked`. Do not convert an untested criterion into a pass. Any post-review change invalidates affected evidence and requires re-verification.
 
+For machine-readable verification, copy `templates/media-acceptance-contract.json` and evaluate it with:
+
+```sh
+scripts/media-verify CONTRACT.json OUTPUT-PROBE.json --evidence EVIDENCE.json --json
+```
+
+The contract can require exact stream order/counts, codecs, dimensions, pixel format, rational frame rate with tolerance, sample rate/channels/layout, forbidden stream types, format duration/start tolerances, chapters, and metadata. Its separate evidence requirements cover decode, visual review, audio review, measured loudness/true peak, and a named downstream target.
+
+The verifier emits one record per criterion with expected and observed values, evidence locator, boundary, reason, and one of `PASS`, `FAIL`, `BLOCKED`, `UNVERIFIED`, or `NOT_APPLICABLE`. A required stream that is absent fails; a required field or review artifact that cannot be observed remains unverified. The overall verdict follows the strongest unresolved state: `FAIL`, then `BLOCKED`, then `UNVERIFIED`, otherwise `PASS`.
+
 Minimize reports before sharing: remove private paths, personal names, account identifiers, unnecessary transcript excerpts, and embedded metadata.
 
 ## Evidence and heuristic boundary

--- a/ffmpeg/scripts/media-verify
+++ b/ffmpeg/scripts/media-verify
@@ -1,53 +1,472 @@
 #!/usr/bin/env python3
-"""Compare two ffprobe JSON documents against basic media criteria."""
+"""Evaluate FFprobe and review evidence against a declared media contract."""
+
+from __future__ import annotations
+
 import argparse
 import json
+import math
 import sys
+from fractions import Fraction
 from pathlib import Path
+from typing import Any
+
+VERDICTS = {"PASS", "FAIL", "BLOCKED", "UNVERIFIED", "NOT_APPLICABLE"}
 
 
-def load(path):
+class VerifyError(Exception):
+    pass
+
+
+def load_object(path: str, kind: str) -> dict[str, Any]:
     try:
-        return json.loads(Path(path).read_text(encoding="utf-8"))
+        document = json.loads(Path(path).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError(str(exc)) from exc
+        raise VerifyError(f"could not load {kind}: {exc}") from exc
+    if not isinstance(document, dict):
+        raise VerifyError(f"{kind} root must be an object")
+    return document
 
 
-def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("input_probe")
-    parser.add_argument("output_probe")
-    parser.add_argument("--duration-tolerance", type=float, default=0.1)
-    parser.add_argument("--require-subtitles", action="store_true")
-    args = parser.parse_args()
+def finite(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def numeric(value: Any) -> float | None:
     try:
-        before = load(args.input_probe)
-        after = load(args.output_probe)
-    except ValueError as exc:
-        print(json.dumps({"ok": False, "status": "invalid_probe", "error": str(exc)}))
-        return 2
-    before_streams = before.get("streams", [])
-    after_streams = after.get("streams", [])
-    checks = [{"criterion": "output_has_streams", "passed": bool(after_streams)}]
-    for stream_type in ("video", "audio"):
-        before_stream = next((s for s in before_streams if s.get("codec_type") == stream_type), None)
-        after_stream = next((s for s in after_streams if s.get("codec_type") == stream_type), None)
-        if before_stream:
-            checks.append({"criterion": f"{stream_type}_stream", "passed": after_stream is not None})
-            if after_stream and before_stream.get("codec_name") and after_stream.get("codec_name"):
-                checks.append({"criterion": f"{stream_type}_codec", "passed": before_stream["codec_name"] == after_stream["codec_name"], "input": before_stream["codec_name"], "output": after_stream["codec_name"]})
-    if args.require_subtitles:
-        checks.append({"criterion": "subtitle_stream", "passed": any(s.get("codec_type") == "subtitle" for s in after_streams)})
-    try:
-        input_duration = float(before.get("format", {}).get("duration"))
-        output_duration = float(after.get("format", {}).get("duration"))
+        result = float(value)
     except (TypeError, ValueError):
-        input_duration = output_duration = None
-    if input_duration is not None and output_duration is not None:
-        checks.append({"criterion": "duration", "passed": abs(input_duration - output_duration) <= args.duration_tolerance, "input": input_duration, "output": output_duration, "tolerance": args.duration_tolerance})
-    ok = all(check["passed"] for check in checks)
-    print(json.dumps({"ok": ok, "status": "pass" if ok else "fail", "checks": checks}, indent=2, sort_keys=True))
-    return 0 if ok else 1
+        return None
+    return result if math.isfinite(result) else None
+
+
+def rate(value: Any) -> float | None:
+    if not isinstance(value, (str, int, float)):
+        return None
+    try:
+        result = float(Fraction(str(value)))
+    except (ValueError, ZeroDivisionError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def evidence_verdict(value: Any) -> tuple[str, str | None, Any]:
+    if not isinstance(value, dict):
+        return "UNVERIFIED", "evidence record is missing", None
+    status = value.get("status")
+    if status not in VERDICTS:
+        return "UNVERIFIED", "evidence status is missing or invalid", value
+    return status, value.get("reason"), value.get("artifact") or value.get("command")
+
+
+class Report:
+    def __init__(self) -> None:
+        self.criteria: list[dict[str, Any]] = []
+
+    def add(
+        self,
+        criterion: str,
+        boundary: str,
+        verdict: str,
+        *,
+        expected: Any = None,
+        observed: Any = None,
+        evidence: Any = None,
+        reason: str | None = None,
+    ) -> None:
+        if verdict not in VERDICTS:
+            raise VerifyError(f"invalid verdict for {criterion}: {verdict}")
+        self.criteria.append(
+            {
+                "criterion": criterion,
+                "boundary": boundary,
+                "verdict": verdict,
+                "expected": expected,
+                "observed": observed,
+                "evidence": evidence,
+                "reason": reason,
+            }
+        )
+
+    def overall(self) -> str:
+        verdicts = {item["verdict"] for item in self.criteria}
+        if "FAIL" in verdicts:
+            return "FAIL"
+        if "BLOCKED" in verdicts:
+            return "BLOCKED"
+        if "UNVERIFIED" in verdicts:
+            return "UNVERIFIED"
+        return "PASS"
+
+
+def validate_contract(contract: dict[str, Any]) -> None:
+    if contract.get("schema_version") != 1:
+        raise VerifyError("acceptance contract schema_version must be 1")
+    required = contract.get("required_streams")
+    if not isinstance(required, list) or not required:
+        raise VerifyError("acceptance contract requires a non-empty required_streams array")
+    for index, item in enumerate(required):
+        if not isinstance(item, dict) or item.get("type") not in {
+            "video",
+            "audio",
+            "subtitle",
+            "data",
+            "attachment",
+        }:
+            raise VerifyError(f"required_streams[{index}] needs a supported type")
+    order = contract.get("stream_order")
+    if order is not None and (
+        not isinstance(order, list) or not all(isinstance(item, str) for item in order)
+    ):
+        raise VerifyError("stream_order must be an array of stream type strings")
+    evidence = contract.get("evidence", {})
+    if not isinstance(evidence, dict):
+        raise VerifyError("evidence contract must be an object")
+
+
+def streams(document: dict[str, Any]) -> list[dict[str, Any]]:
+    value = document.get("streams")
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def compare_field(
+    report: Report,
+    criterion: str,
+    boundary: str,
+    expected: Any,
+    observed: Any,
+    *,
+    tolerance: float | None = None,
+    rational: bool = False,
+) -> None:
+    if observed is None:
+        report.add(
+            criterion,
+            boundary,
+            "UNVERIFIED",
+            expected=expected,
+            reason="required output field is absent",
+        )
+        return
+    if tolerance is not None:
+        expected_number = rate(expected) if rational else numeric(expected)
+        observed_number = rate(observed) if rational else numeric(observed)
+        if expected_number is None or observed_number is None:
+            report.add(
+                criterion,
+                boundary,
+                "UNVERIFIED",
+                expected=expected,
+                observed=observed,
+                reason="numeric comparison could not be evaluated",
+            )
+            return
+        passed = abs(observed_number - expected_number) <= tolerance
+    else:
+        passed = str(observed) == str(expected)
+    report.add(
+        criterion,
+        boundary,
+        "PASS" if passed else "FAIL",
+        expected=expected,
+        observed=observed,
+        evidence="output probe",
+        reason=None if passed else "observed value does not satisfy the contract",
+    )
+
+
+def verify_streams(report: Report, contract: dict[str, Any], probe: dict[str, Any]) -> None:
+    output_streams = streams(probe)
+    report.add(
+        "output_has_streams",
+        "component",
+        "PASS" if output_streams else "FAIL",
+        expected="one or more streams",
+        observed=len(output_streams),
+        evidence="output probe",
+    )
+    observed_order = [item.get("codec_type") for item in output_streams]
+    expected_order = contract.get("stream_order")
+    if expected_order is not None:
+        report.add(
+            "stream_order",
+            "component",
+            "PASS" if observed_order == expected_order else "FAIL",
+            expected=expected_order,
+            observed=observed_order,
+            evidence="output probe",
+        )
+
+    by_type: dict[str, list[dict[str, Any]]] = {}
+    for item in output_streams:
+        by_type.setdefault(str(item.get("codec_type")), []).append(item)
+    required_counts: dict[str, int] = {}
+    for requirement in contract["required_streams"]:
+        kind = requirement["type"]
+        ordinal = required_counts.get(kind, 0)
+        required_counts[kind] = ordinal + 1
+        candidates = by_type.get(kind, [])
+        criterion_prefix = f"{kind}_{ordinal}"
+        if ordinal >= len(candidates):
+            report.add(
+                f"{criterion_prefix}_present",
+                "component",
+                "FAIL",
+                expected=requirement,
+                observed=None,
+                evidence="output probe",
+                reason="required stream is absent",
+            )
+            continue
+        actual = candidates[ordinal]
+        report.add(
+            f"{criterion_prefix}_present",
+            "component",
+            "PASS",
+            expected=kind,
+            observed=actual.get("index"),
+            evidence="output probe",
+        )
+        field_tolerances = requirement.get("tolerances", {})
+        if not isinstance(field_tolerances, dict):
+            raise VerifyError(f"{criterion_prefix}.tolerances must be an object")
+        for field, expected in requirement.items():
+            if field in {"type", "tolerances"}:
+                continue
+            compare_field(
+                report,
+                f"{criterion_prefix}_{field}",
+                "component",
+                expected,
+                actual.get(field),
+                tolerance=field_tolerances.get(field),
+                rational=field in {"avg_frame_rate", "r_frame_rate"},
+            )
+
+    for kind, count in required_counts.items():
+        actual_count = len(by_type.get(kind, []))
+        report.add(
+            f"{kind}_stream_count",
+            "component",
+            "PASS" if actual_count == count else "FAIL",
+            expected=count,
+            observed=actual_count,
+            evidence="output probe",
+        )
+    forbidden = contract.get("forbidden_stream_types", [])
+    if not isinstance(forbidden, list):
+        raise VerifyError("forbidden_stream_types must be an array")
+    for kind in forbidden:
+        count = len(by_type.get(str(kind), []))
+        report.add(
+            f"forbidden_{kind}_streams",
+            "component",
+            "PASS" if count == 0 else "FAIL",
+            expected=0,
+            observed=count,
+            evidence="output probe",
+        )
+
+
+def verify_format(report: Report, contract: dict[str, Any], probe: dict[str, Any]) -> None:
+    requirements = contract.get("format", {})
+    if not isinstance(requirements, dict):
+        raise VerifyError("format contract must be an object")
+    actual = probe.get("format", {})
+    if not isinstance(actual, dict):
+        actual = {}
+    for field in ("format_name", "duration", "start_time", "size", "bit_rate"):
+        if field not in requirements:
+            continue
+        tolerance = requirements.get(f"{field}_tolerance")
+        compare_field(
+            report,
+            f"format_{field}",
+            "integration" if field in {"duration", "start_time"} else "component",
+            requirements[field],
+            actual.get(field),
+            tolerance=tolerance,
+        )
+
+
+def verify_chapters_and_metadata(
+    report: Report, contract: dict[str, Any], probe: dict[str, Any]
+) -> None:
+    chapter_contract = contract.get("chapters")
+    if chapter_contract is not None:
+        if not isinstance(chapter_contract, dict):
+            raise VerifyError("chapters contract must be an object")
+        chapters = probe.get("chapters")
+        observed = len(chapters) if isinstance(chapters, list) else None
+        expected = chapter_contract.get("count")
+        compare_field(report, "chapter_count", "component", expected, observed)
+
+    metadata = contract.get("metadata")
+    if metadata is None:
+        return
+    if not isinstance(metadata, dict):
+        raise VerifyError("metadata contract must be an object")
+    tags = probe.get("format", {}).get("tags", {})
+    if not isinstance(tags, dict):
+        tags = {}
+    required = metadata.get("required", {})
+    forbidden = metadata.get("forbidden", [])
+    if not isinstance(required, dict) or not isinstance(forbidden, list):
+        raise VerifyError("metadata required/forbidden fields are invalid")
+    for key, expected in required.items():
+        compare_field(report, f"metadata_{key}", "component", expected, tags.get(key))
+    for key in forbidden:
+        report.add(
+            f"metadata_forbidden_{key}",
+            "component",
+            "PASS" if key not in tags else "FAIL",
+            expected="absent",
+            observed=tags.get(key),
+            evidence="output probe",
+        )
+
+
+def verify_recorded_evidence(
+    report: Report, contract: dict[str, Any], evidence: dict[str, Any]
+) -> None:
+    for key, boundary in (
+        ("decode", "component"),
+        ("visual_review", "editorial"),
+        ("audio_review", "editorial"),
+    ):
+        requirement = contract.get("evidence", {}).get(key, "optional")
+        if requirement == "optional":
+            report.add(
+                key, boundary, "NOT_APPLICABLE", reason="contract does not require this evidence"
+            )
+            continue
+        verdict, reason, locator = evidence_verdict(evidence.get(key))
+        report.add(key, boundary, verdict, expected=requirement, evidence=locator, reason=reason)
+
+    loudness = contract.get("loudness")
+    if loudness is not None:
+        if not isinstance(loudness, dict):
+            raise VerifyError("loudness contract must be an object")
+        measured = evidence.get("loudness")
+        if not isinstance(measured, dict):
+            for criterion in loudness:
+                report.add(
+                    f"loudness_{criterion}",
+                    "signal",
+                    "UNVERIFIED",
+                    expected=loudness[criterion],
+                    reason="loudness evidence is missing",
+                )
+        else:
+            integrated = loudness.get("integrated_lufs")
+            if isinstance(integrated, dict):
+                compare_field(
+                    report,
+                    "loudness_integrated_lufs",
+                    "signal",
+                    integrated.get("target"),
+                    measured.get("integrated_lufs"),
+                    tolerance=integrated.get("tolerance"),
+                )
+            if "true_peak_max_dbfs" in loudness:
+                observed = numeric(measured.get("true_peak_dbfs"))
+                maximum = numeric(loudness["true_peak_max_dbfs"])
+                if observed is None or maximum is None:
+                    report.add(
+                        "loudness_true_peak",
+                        "signal",
+                        "UNVERIFIED",
+                        expected=loudness["true_peak_max_dbfs"],
+                        observed=measured.get("true_peak_dbfs"),
+                        reason="true-peak comparison could not be evaluated",
+                    )
+                else:
+                    report.add(
+                        "loudness_true_peak",
+                        "signal",
+                        "PASS" if observed <= maximum else "FAIL",
+                        expected={"maximum": maximum},
+                        observed=observed,
+                        evidence=measured.get("artifact") or measured.get("command"),
+                    )
+
+    downstream = contract.get("downstream", {})
+    if not isinstance(downstream, dict):
+        raise VerifyError("downstream contract must be an object")
+    target = downstream.get("target")
+    if not target:
+        report.add(
+            "downstream_consumer",
+            "downstream",
+            "NOT_APPLICABLE",
+            reason="no downstream target is declared",
+        )
+    else:
+        verdict, reason, locator = evidence_verdict(evidence.get("downstream"))
+        downstream_evidence = evidence.get("downstream")
+        observed_target = (
+            downstream_evidence.get("target") if isinstance(downstream_evidence, dict) else None
+        )
+        if verdict == "PASS" and observed_target != target:
+            verdict = "FAIL"
+            reason = "downstream evidence target does not match the declared target"
+        report.add(
+            "downstream_consumer",
+            "downstream",
+            verdict,
+            expected=target,
+            observed=observed_target,
+            evidence=locator,
+            reason=reason,
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("contract", help="acceptance contract JSON")
+    parser.add_argument("output_probe", help="FFprobe JSON for the rendered output")
+    parser.add_argument("--evidence", help="decode, review, loudness, and downstream evidence JSON")
+    parser.add_argument("--json", action="store_true", help="emit compact JSON")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        contract = load_object(args.contract, "acceptance contract")
+        probe = load_object(args.output_probe, "output probe")
+        evidence = load_object(args.evidence, "evidence") if args.evidence else {}
+        validate_contract(contract)
+        report = Report()
+        verify_streams(report, contract, probe)
+        verify_format(report, contract, probe)
+        verify_chapters_and_metadata(report, contract, probe)
+        verify_recorded_evidence(report, contract, evidence)
+        overall = report.overall()
+        payload = {
+            "ok": overall == "PASS",
+            "schema_version": 1,
+            "overall_verdict": overall,
+            "criteria": report.criteria,
+            "summary": {
+                verdict: sum(item["verdict"] == verdict for item in report.criteria)
+                for verdict in sorted(VERDICTS)
+            },
+            "boundary_statement": "local probe or decode success is not downstream compatibility evidence",
+        }
+        print(
+            json.dumps(payload, sort_keys=True, separators=(",", ":"))
+            if args.json
+            else json.dumps(payload, indent=2, sort_keys=True)
+        )
+        return 0 if overall == "PASS" else 1
+    except VerifyError as exc:
+        print(
+            json.dumps({"ok": False, "status": "INVALID_INPUT", "error": str(exc)}, sort_keys=True)
+        )
+        return 2
 
 
 if __name__ == "__main__":

--- a/ffmpeg/scripts/test_media_workflows.py
+++ b/ffmpeg/scripts/test_media_workflows.py
@@ -470,33 +470,39 @@ def test_audio_inspect_measures_synthetic_candidates_and_builds_plan(tmp_path: P
     )
     assert render.returncode == 0, render.stderr
 
-    probe_paths: list[Path] = []
-    for name, media_path in (
-        ("source", fixture_workspace / "speech-like-audio.wav"),
-        ("treated", treated),
-    ):
-        probe_result = subprocess.run(
-            [
-                "ffprobe",
-                "-v",
-                "error",
-                "-show_format",
-                "-show_streams",
-                "-of",
-                "json",
-                str(media_path),
+    probe_result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_format",
+            "-show_streams",
+            "-of",
+            "json",
+            str(treated),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert probe_result.returncode == 0, probe_result.stderr
+    treated_probe = write_json(tmp_path / "treated-probe.json", json.loads(probe_result.stdout))
+    contract = write_json(
+        tmp_path / "treated-contract.json",
+        {
+            "schema_version": 1,
+            "required_streams": [
+                {"type": "audio", "codec_name": "pcm_s16le", "sample_rate": "48000", "channels": 1}
             ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert probe_result.returncode == 0, probe_result.stderr
-        probe_paths.append(
-            write_json(tmp_path / f"{name}-probe.json", json.loads(probe_result.stdout))
-        )
-    verify = run_script("media-verify", *(str(path) for path in probe_paths))
+            "stream_order": ["audio"],
+            "format": {"duration": 3.0, "duration_tolerance": 0.05},
+            "evidence": {},
+            "downstream": {},
+        },
+    )
+    verify = run_script("media-verify", str(contract), str(treated_probe))
     assert verify.returncode == 0, verify.stdout + verify.stderr
-    assert json.loads(verify.stdout)["status"] == "pass"
+    assert json.loads(verify.stdout)["overall_verdict"] == "PASS"
 
 
 def test_audio_inspect_rejects_invalid_thresholds(tmp_path: Path) -> None:
@@ -512,41 +518,196 @@ def test_audio_inspect_rejects_invalid_thresholds(tmp_path: Path) -> None:
     assert json.loads(result.stdout)["status"] == "invalid_threshold"
 
 
-def test_media_verify_passes_matching_probe_files(tmp_path: Path) -> None:
-    input_probe = write_json(tmp_path / "input-probe.json", probe("video", "audio"))
-    output_probe = write_json(tmp_path / "output-probe.json", probe("video", "audio"))
-
-    result = run_script("media-verify", str(input_probe), str(output_probe))
-
-    assert result.returncode == 0, result.stderr
-    report = json.loads(result.stdout)
-    assert report["ok"] is True
-    assert {check["criterion"]: check["passed"] for check in report["checks"]} == {
-        "output_has_streams": True,
-        "video_stream": True,
-        "audio_stream": True,
-        "duration": True,
+def acceptance_contract() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "required_streams": [
+            {
+                "type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": 1080,
+                "pix_fmt": "yuv420p",
+                "avg_frame_rate": "30000/1001",
+                "tolerances": {"avg_frame_rate": 0.001},
+            },
+            {
+                "type": "audio",
+                "codec_name": "aac",
+                "sample_rate": "48000",
+                "channels": 2,
+                "channel_layout": "stereo",
+            },
+            {"type": "subtitle", "codec_name": "subrip"},
+        ],
+        "stream_order": ["video", "audio", "subtitle"],
+        "forbidden_stream_types": ["data", "attachment"],
+        "format": {
+            "format_name": "matroska,webm",
+            "duration": 5.0,
+            "duration_tolerance": 0.1,
+            "start_time": 0.0,
+            "start_time_tolerance": 0.01,
+        },
+        "chapters": {"count": 1},
+        "metadata": {"required": {"title": "Accepted output"}, "forbidden": ["comment"]},
+        "evidence": {"decode": "required", "visual_review": "required", "audio_review": "required"},
+        "loudness": {
+            "integrated_lufs": {"target": -16.0, "tolerance": 0.5},
+            "true_peak_max_dbfs": -1.0,
+        },
+        "downstream": {"target": "Test Player 1.0"},
     }
 
 
-def test_media_verify_fails_probe_contract_mismatches(tmp_path: Path) -> None:
-    input_probe = write_json(tmp_path / "input-probe.json", probe("video", "audio"))
-    output_probe = write_json(
-        tmp_path / "output-probe.json",
-        probe("video", duration="5.5"),
+def accepted_probe() -> dict[str, object]:
+    return {
+        "streams": [
+            {
+                "index": 0,
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": 1080,
+                "pix_fmt": "yuv420p",
+                "avg_frame_rate": "60000/2002",
+            },
+            {
+                "index": 1,
+                "codec_type": "audio",
+                "codec_name": "aac",
+                "sample_rate": "48000",
+                "channels": 2,
+                "channel_layout": "stereo",
+            },
+            {"index": 2, "codec_type": "subtitle", "codec_name": "subrip"},
+        ],
+        "format": {
+            "format_name": "matroska,webm",
+            "duration": "5.04",
+            "start_time": "0.000000",
+            "tags": {"title": "Accepted output"},
+        },
+        "chapters": [{"id": 0}],
+    }
+
+
+def accepted_evidence() -> dict[str, object]:
+    return {
+        "decode": {"status": "PASS", "command": ["ffmpeg", "-f", "null", "-"]},
+        "visual_review": {"status": "PASS", "artifact": "visual-review.json"},
+        "audio_review": {"status": "PASS", "artifact": "listening-review.json"},
+        "loudness": {
+            "integrated_lufs": -16.2,
+            "true_peak_dbfs": -1.2,
+            "artifact": "loudness.json",
+        },
+        "downstream": {
+            "status": "PASS",
+            "target": "Test Player 1.0",
+            "artifact": "player-result.json",
+        },
+    }
+
+
+def test_media_verify_passes_complete_contract(tmp_path: Path) -> None:
+    contract = write_json(tmp_path / "contract.json", acceptance_contract())
+    output_probe = write_json(tmp_path / "probe.json", accepted_probe())
+    evidence = write_json(tmp_path / "evidence.json", accepted_evidence())
+
+    result = run_script(
+        "media-verify", str(contract), str(output_probe), "--evidence", str(evidence)
     )
 
-    result = run_script("media-verify", str(input_probe), str(output_probe))
+    assert result.returncode == 0, result.stdout + result.stderr
+    report = json.loads(result.stdout)
+    assert report["ok"] is True
+    assert report["overall_verdict"] == "PASS"
+    assert report["summary"]["FAIL"] == 0
+    assert report["summary"]["UNVERIFIED"] == 0
+    assert all(
+        {"criterion", "boundary", "verdict", "expected", "observed", "evidence", "reason"}
+        == set(item)
+        for item in report["criteria"]
+    )
+
+
+def test_media_verify_fails_independent_stream_subtitle_and_tolerance_checks(
+    tmp_path: Path,
+) -> None:
+    probe_document = accepted_probe()
+    probe_document["streams"] = [probe_document["streams"][0]]
+    probe_document["format"]["duration"] = "5.5"
+    contract = write_json(tmp_path / "contract.json", acceptance_contract())
+    output_probe = write_json(tmp_path / "probe.json", probe_document)
+    evidence = write_json(tmp_path / "evidence.json", accepted_evidence())
+
+    result = run_script(
+        "media-verify", str(contract), str(output_probe), "--evidence", str(evidence)
+    )
 
     assert result.returncode == 1
     report = json.loads(result.stdout)
-    assert report["ok"] is False
-    assert {check["criterion"]: check["passed"] for check in report["checks"]} == {
-        "output_has_streams": True,
-        "video_stream": True,
-        "audio_stream": False,
-        "duration": False,
+    verdicts = {item["criterion"]: item["verdict"] for item in report["criteria"]}
+    assert report["overall_verdict"] == "FAIL"
+    assert verdicts["audio_0_present"] == "FAIL"
+    assert verdicts["subtitle_0_present"] == "FAIL"
+    assert verdicts["stream_order"] == "FAIL"
+    assert verdicts["format_duration"] == "FAIL"
+
+
+def test_media_verify_marks_missing_fields_and_evidence_unverified(tmp_path: Path) -> None:
+    probe_document = accepted_probe()
+    del probe_document["streams"][0]["pix_fmt"]
+    contract = write_json(tmp_path / "contract.json", acceptance_contract())
+    output_probe = write_json(tmp_path / "probe.json", probe_document)
+
+    result = run_script("media-verify", str(contract), str(output_probe))
+
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    verdicts = {item["criterion"]: item["verdict"] for item in report["criteria"]}
+    assert report["overall_verdict"] == "UNVERIFIED"
+    assert verdicts["video_0_pix_fmt"] == "UNVERIFIED"
+    assert verdicts["decode"] == "UNVERIFIED"
+    assert verdicts["loudness_integrated_lufs"] == "UNVERIFIED"
+    assert verdicts["downstream_consumer"] == "UNVERIFIED"
+
+
+def test_media_verify_preserves_blocked_review_status(tmp_path: Path) -> None:
+    evidence_document = accepted_evidence()
+    evidence_document["visual_review"] = {
+        "status": "BLOCKED",
+        "reason": "authorized reviewer unavailable",
     }
+    contract = write_json(tmp_path / "contract.json", acceptance_contract())
+    output_probe = write_json(tmp_path / "probe.json", accepted_probe())
+    evidence = write_json(tmp_path / "evidence.json", evidence_document)
+
+    result = run_script(
+        "media-verify", str(contract), str(output_probe), "--evidence", str(evidence)
+    )
+
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert report["overall_verdict"] == "BLOCKED"
+    visual = next(item for item in report["criteria"] if item["criterion"] == "visual_review")
+    assert visual["reason"] == "authorized reviewer unavailable"
+
+
+def test_media_verify_rejects_malformed_contract_and_probe(tmp_path: Path) -> None:
+    bad_contract = write_json(tmp_path / "contract.json", {"schema_version": 1})
+    probe_path = write_json(tmp_path / "probe.json", accepted_probe())
+    result = run_script("media-verify", str(bad_contract), str(probe_path))
+    assert result.returncode == 2
+    assert json.loads(result.stdout)["status"] == "INVALID_INPUT"
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("not-json")
+    contract = write_json(tmp_path / "valid-contract.json", acceptance_contract())
+    result = run_script("media-verify", str(contract), str(malformed))
+    assert result.returncode == 2
+    assert "could not load output probe" in json.loads(result.stdout)["error"]
 
 
 def test_editorial_workflow_example_runs_with_real_tools(tmp_path: Path) -> None:

--- a/ffmpeg/templates/media-acceptance-contract.json
+++ b/ffmpeg/templates/media-acceptance-contract.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "required_streams": [
+    {
+      "type": "video",
+      "codec_name": "h264",
+      "width": 1920,
+      "height": 1080,
+      "pix_fmt": "yuv420p",
+      "avg_frame_rate": "30000/1001",
+      "tolerances": {"avg_frame_rate": 0.001}
+    },
+    {
+      "type": "audio",
+      "codec_name": "aac",
+      "sample_rate": "48000",
+      "channels": 2,
+      "channel_layout": "stereo"
+    }
+  ],
+  "stream_order": ["video", "audio"],
+  "forbidden_stream_types": ["data", "attachment"],
+  "format": {
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
+    "duration": 120.0,
+    "duration_tolerance": 0.1,
+    "start_time": 0.0,
+    "start_time_tolerance": 0.05
+  },
+  "chapters": {"count": 0},
+  "metadata": {"required": {}, "forbidden": ["comment"]},
+  "evidence": {
+    "decode": "required",
+    "visual_review": "required",
+    "audio_review": "required"
+  },
+  "loudness": {
+    "integrated_lufs": {"target": -16.0, "tolerance": 1.0},
+    "true_peak_max_dbfs": -1.0
+  },
+  "downstream": {"target": "<named player, editor, host, archive, or service>"}
+}

--- a/ffmpeg/templates/media-acceptance-report.md
+++ b/ffmpeg/templates/media-acceptance-report.md
@@ -7,14 +7,14 @@
 
 ## Criteria
 
-| Criterion | Evidence command/artifact | Boundary | Verdict |
-|---|---|---|---|
-| Output decodes | | component | PASS/FAIL/BLOCKED |
-| Streams/codecs/mapping | | component | PASS/FAIL/BLOCKED |
-| Timing/duration/sync | | integration | PASS/FAIL/BLOCKED |
-| Visual boundaries/captions | | editorial | PASS/FAIL/BLOCKED |
-| Audio levels/listening | | editorial | PASS/FAIL/BLOCKED |
-| Downstream consumer | | end-to-end | PASS/FAIL/BLOCKED |
+| Criterion | Expected/observed value | Evidence command/artifact | Boundary | Verdict |
+|---|---|---|---|---|
+| Output decodes | | | component | PASS/FAIL/BLOCKED/UNVERIFIED |
+| Streams/codecs/mapping | | | component | PASS/FAIL/BLOCKED/UNVERIFIED |
+| Timing/duration/sync | | | integration | PASS/FAIL/BLOCKED/UNVERIFIED |
+| Visual boundaries/captions | | | editorial | PASS/FAIL/BLOCKED/UNVERIFIED |
+| Audio levels/listening | | | editorial | PASS/FAIL/BLOCKED/UNVERIFIED |
+| Downstream consumer | | | downstream | PASS/FAIL/BLOCKED/UNVERIFIED/NOT_APPLICABLE |
 
 ## Unverified Boundaries
 


### PR DESCRIPTION
## Summary

- replace basic before/after probe comparison with a declared acceptance contract for streams, order, codecs, dimensions, rates, layout, timing, subtitles, chapters, and metadata
- evaluate decode, bounded visual/audio review, loudness/true peak, and named downstream evidence as independent criteria
- preserve PASS, FAIL, BLOCKED, UNVERIFIED, and NOT_APPLICABLE outcomes so local probe success cannot become a false destination pass

## Verification

- `.venv/bin/pytest --no-cov -q ffmpeg/scripts/test_media_workflows.py`
- `.venv/bin/ruff check ffmpeg/scripts/media-verify ffmpeg/scripts/test_media_workflows.py`
- `python3 scripts/check-skill-tests.py --check`
- `ruby scripts/validate-skills.rb`
- `ruby scripts/validate-skill-quality.rb`
- `python3 scripts/validate-evals.py ffmpeg`
- `python3 scripts/test-eval-validation.py`
- `python3 scripts/eval-coverage.py --modified-from origin/main`
- generated catalog checks

Closes #456

@droid please review this PR.