### PR TITLE
feat(ffmpeg): add structured vision-review handoff

### DIFF
--- a/ffmpeg/README.md
+++ b/ffmpeg/README.md
@@ -47,6 +47,7 @@ This skill provides a repeatable intake-to-acceptance workflow. It separates tec
 | `templates/edit-decision-list.json` | Parseable source ranges, evidence, confidence, treatments, mapping, and verification |
 | `templates/video-inspection-report.md` | Fixed-section technical and sampled-evidence report |
 | `templates/visual-review-packet.md` | Timestamped review samples with attribution and coverage limits |
+| `templates/vision-review-observations.json` | Machine-readable reviewer attribution, evidence classes, blind spots, and EDL links |
 | `templates/podcast-edit-plan.md` | Mechanical, signal-processing, and editorial audio plan |
 | `templates/media-acceptance-report.md` | Criterion-by-criterion evidence and release verdict |
 | `templates/media-acceptance-contract.json` | Parseable stream, format, evidence, loudness, and downstream criteria |
@@ -61,6 +62,8 @@ This skill provides a repeatable intake-to-acceptance workflow. It separates tec
 | `scripts/fixtures/ffmpeg-8.1.2-inventories.json` | Small version-labeled parser fixture |
 | `scripts/media-intake` | Read-only input inventory with bounded `ffprobe` metadata |
 | `scripts/extract-review-frames` | Bounded timestamp frame extraction for human or vision review |
+| `scripts/vision-review-handoff` | Privacy-safe bounded frame packet with provenance, limits, hashes, and pending-review manifest |
+| `scripts/import-vision-review` | Validate attributed observations and link them to EDL events without rendering |
 | `scripts/render-edl` | Validate single- or multi-source EDLs and emit non-executing concat-filter or concat-demuxer plans |
 | `scripts/audio-inspect` | Bounded silence, loudness, peak/clipping, transcript-candidate, and podcast-plan evidence |
 | `scripts/media-verify` | Evaluate output probe and review evidence against a declared acceptance contract |
@@ -128,6 +131,16 @@ scripts/media-verify acceptance-contract.json output-probe.json \
 ```
 
 Missing fields or review evidence remain `UNVERIFIED`; blocked reviews remain `BLOCKED`; local probe/decode success never supplies downstream compatibility evidence.
+
+Prepare visual evidence around proposed edit boundaries without exposing the source path:
+
+```sh
+ffmpeg/scripts/vision-review-handoff private.mov --asset-id asset-017 \
+  --question "Does the sampled boundary preserve title continuity?" \
+  --timestamp 12.4 --neighbor-seconds 0.25 --output-dir review-packet --json
+```
+
+The manifest covers only its listed samples. An authorized reviewer must add attributed observations before `import-vision-review` can link them to an EDL; sparse frames never prove absence throughout a video.
 
 ## Triggers
 

--- a/ffmpeg/SKILL.md
+++ b/ffmpeg/SKILL.md
@@ -89,6 +89,7 @@ For shipped helper workflows, run the helper from the skill root with explicit o
 - `templates/edit-decision-list.json` — reviewable source ranges and treatments
 - `templates/video-inspection-report.md` — technical inspection and bounded evidence ledger
 - `templates/visual-review-packet.md` — attributed frame/clip observations and coverage limits
+- `templates/vision-review-observations.json` — parseable attributed observation block for a prepared packet
 - `templates/podcast-edit-plan.md` — mechanical, signal, and editorial audio decisions
 - `templates/media-acceptance-report.md` — layered verification and criterion verdicts
 - `templates/media-acceptance-contract.json` — machine-readable stream, format, evidence, loudness, and downstream requirements
@@ -103,6 +104,8 @@ Use `scripts/render-edl` for a non-executing single- or multi-source plan. Defau
 Use `scripts/audio-inspect` for bounded silence, EBU R128, peak/clipping, and transcript-alignment evidence. Request each measurement explicitly, preserve unavailable filters as `UNAVAILABLE`, and treat every interval or transcript range as a listening-review candidate. Its optional report output refuses overwrite.
 
 Use `scripts/media-verify` with a declared acceptance contract, output FFprobe JSON, and optional evidence JSON. It reports every criterion independently as `PASS`, `FAIL`, `BLOCKED`, `UNVERIFIED`, or `NOT_APPLICABLE`; only a report with no failed or missing required evidence is an overall pass.
+
+Use `scripts/vision-review-handoff` to prepare bounded, privacy-safe frame packets for an authorized human or vision reviewer. Import only attributed reviewed observations with `scripts/import-vision-review`; treat proposed editorial consequences as evidence for review, never automatic decisions.
 
 Copy a template into the task workspace and replace its placeholder/example values. Do not put private paths, media, transcripts, or review evidence in the public skill repository.
 

--- a/ffmpeg/evals/evals.json
+++ b/ffmpeg/evals/evals.json
@@ -157,6 +157,19 @@
         "does not generalize local probe or decode success into destination compatibility"
       ],
       "case_set": "release"
+    },
+    {
+      "id": "bounded-vision-review-handoff",
+      "prompt": "Prepare frames around two proposed cut boundaries for a vision reviewer, then link any reviewed findings to my EDL without exposing the private source path or treating the reviewer as an automatic editor.",
+      "expected_output": "Create a bounded packet with opaque asset and stream IDs, explicit and neighboring timestamps, extraction/build/transform provenance, hashes, byte and range limits, and a sparse-coverage warning. Require attributed observations with evidence class, confidence, blind spots, artifact references, and editorial consequences before writing a new EDL whose visual evidence remains subject to editorial approval.",
+      "assertions": [
+        "records opaque identity, stream, timestamps, build, extraction parameters, transforms, hashes, and coverage",
+        "enforces frame-count, timestamp-range, and output-size limits",
+        "does not expose the private source path in the shareable manifest",
+        "rejects missing attribution and whole-video conclusions from sparse samples",
+        "links reviewed observations to named EDL events as evidence rather than automatic truth"
+      ],
+      "case_set": "release"
     }
   ]
 }

--- a/ffmpeg/references/video-inspection-and-visual-evidence.md
+++ b/ffmpeg/references/video-inspection-and-visual-evidence.md
@@ -44,6 +44,25 @@ For each sample include:
 
 Avoid embedding private source paths, personal names, faces, transcript text, or location metadata unless required and authorized. Share the smallest packet that answers the review question.
 
+### Structured handoff workflow
+
+Use `scripts/vision-review-handoff` to turn explicit timestamps, a bounded cadence, or neighboring frames around proposed boundaries into a new review packet. The helper enforces frame-count, timestamp-span, and aggregate-byte limits; records the selected stream, local FFmpeg build, extraction parameters, transformations, hashes, and sampling blind spots; and substitutes an opaque asset ID for the private source path in the manifest. It does not perform semantic review.
+
+```sh
+scripts/vision-review-handoff private-source.mov \
+  --asset-id asset-017 --stream 0:v:0 \
+  --question "Does the sampled boundary preserve title continuity?" \
+  --timestamp 12.4 --timestamp 18.2 --neighbor-seconds 0.25 \
+  --max-frames 12 --max-range-seconds 30 --max-output-bytes 12000000 \
+  --output-dir review-packet --json
+```
+
+Give `manifest.json` and its relative frame artifacts to an authorized human or vision-capable reviewer. The reviewer must replace the pending review block with attributed observations using one of four classes: `technical_observation`, `human_or_vision_observation`, `heuristic`, or `unresolved_claim`. Each observation records confidence, blind spots, sampled-artifact scope, and a proposed editorial consequence. If the samples cannot answer the question, request more bounded samples or human review rather than inferring across the gap.
+
+After review, `scripts/import-vision-review MANIFEST EDL --output REVIEWED-EDL` validates the evidence and links it to named EDL events. The importer rejects missing attribution, missing observations, unknown events, and claims covering the whole asset or unsampled intervals. It writes a new EDL and never renders media or accepts the proposed consequence automatically.
+
+This workflow is distinct from transcript acquisition, which belongs to the source/transcription system and supplies text/timing evidence, and from HyperFrames composition, which creates visual experiences. FFmpeg only extracts declared pixels and records technical provenance here; semantic interpretation belongs to the reviewer.
+
 ## Evidence and heuristic boundary
 
 | Classification | Defensible statement |

--- a/ffmpeg/scripts/extract-review-frames
+++ b/ffmpeg/scripts/extract-review-frames
@@ -4,15 +4,15 @@
 from __future__ import annotations
 
 import argparse
-from decimal import Decimal, InvalidOperation
 import json
 import math
 import os
-from pathlib import Path
 import shutil
 import subprocess
 import sys
 import tempfile
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
 from typing import Any
 
 MAX_FRAMES_HARD = 100
@@ -33,7 +33,12 @@ class CLIError(Exception):
 class JSONArgumentParser(argparse.ArgumentParser):
     def error(self, message: str) -> None:
         if "--json" in sys.argv[1:]:
-            print(json.dumps({"ok": False, "error": {"code": "invalid_arguments", "message": message}}, sort_keys=True))
+            print(
+                json.dumps(
+                    {"ok": False, "error": {"code": "invalid_arguments", "message": message}},
+                    sort_keys=True,
+                )
+            )
             raise SystemExit(2)
         super().error(message)
 
@@ -132,7 +137,9 @@ def run_bounded(argv: list[str], timeout: float) -> tuple[int, str]:
 def build_parser() -> argparse.ArgumentParser:
     parser = JSONArgumentParser(description=__doc__)
     parser.add_argument("input", help="source media file")
-    parser.add_argument("-o", "--output-dir", required=True, help="directory for extracted JPEG frames")
+    parser.add_argument(
+        "-o", "--output-dir", required=True, help="directory for extracted JPEG frames"
+    )
     parser.add_argument(
         "-t",
         "--timestamp",
@@ -147,15 +154,27 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="TIME",
         help="additional explicit timestamps",
     )
-    parser.add_argument("--ffmpeg", default="ffmpeg", help="ffmpeg executable (default: ffmpeg from PATH)")
-    parser.add_argument("--max-frames", type=int, default=24, help="maximum requested frames (1-100)")
+    parser.add_argument(
+        "--ffmpeg", default="ffmpeg", help="ffmpeg executable (default: ffmpeg from PATH)"
+    )
+    parser.add_argument(
+        "--stream", default="0:v:0", help="explicit video stream specifier (default: 0:v:0)"
+    )
+    parser.add_argument("--video-filter", help="optional explicitly recorded video filter chain")
+    parser.add_argument(
+        "--max-frames", type=int, default=24, help="maximum requested frames (1-100)"
+    )
     parser.add_argument(
         "--max-timestamp",
         default="86400",
         help="maximum allowed timestamp in seconds (default: 86400; hard maximum: 604800)",
     )
-    parser.add_argument("--timeout", type=float, default=30.0, help="per-frame ffmpeg timeout in seconds")
-    parser.add_argument("--overwrite", action="store_true", help="allow replacing existing frame files")
+    parser.add_argument(
+        "--timeout", type=float, default=30.0, help="per-frame ffmpeg timeout in seconds"
+    )
+    parser.add_argument(
+        "--overwrite", action="store_true", help="allow replacing existing frame files"
+    )
     parser.add_argument("--json", action="store_true", help="emit compact JSON")
     return parser
 
@@ -166,7 +185,10 @@ def main(argv: list[str] | None = None) -> int:
         if not 1 <= args.max_frames <= MAX_FRAMES_HARD:
             raise CLIError("invalid_limit", f"--max-frames must be between 1 and {MAX_FRAMES_HARD}")
         if not math.isfinite(args.timeout) or not 0 < args.timeout <= MAX_TIMEOUT_HARD:
-            raise CLIError("invalid_limit", f"--timeout must be greater than 0 and at most {MAX_TIMEOUT_HARD:g}")
+            raise CLIError(
+                "invalid_limit",
+                f"--timeout must be greater than 0 and at most {MAX_TIMEOUT_HARD:g}",
+            )
         max_timestamp = parse_timestamp(args.max_timestamp)
         if max_timestamp <= 0 or max_timestamp > MAX_TIMESTAMP_HARD:
             raise CLIError(
@@ -185,7 +207,7 @@ def main(argv: list[str] | None = None) -> int:
                 limit=args.max_frames,
             )
         timestamps = [parse_timestamp(raw) for raw in raw_timestamps]
-        for raw, timestamp in zip(raw_timestamps, timestamps):
+        for raw, timestamp in zip(raw_timestamps, timestamps, strict=True):
             if timestamp > max_timestamp:
                 raise CLIError(
                     "timestamp_limit_exceeded",
@@ -203,7 +225,9 @@ def main(argv: list[str] | None = None) -> int:
 
         output_dir = Path(args.output_dir).expanduser().resolve()
         if output_dir.exists() and not output_dir.is_dir():
-            raise CLIError("invalid_output_directory", f"output path is not a directory: {output_dir}")
+            raise CLIError(
+                "invalid_output_directory", f"output path is not a directory: {output_dir}"
+            )
         outputs = [output_dir / f"frame-{index:04d}.jpg" for index in range(1, len(timestamps) + 1)]
         existing = [str(path) for path in outputs if path.exists()]
         if existing and not args.overwrite:
@@ -216,11 +240,13 @@ def main(argv: list[str] | None = None) -> int:
 
         tool = resolve_tool(args.ffmpeg)
         if tool is None:
-            raise CLIError("tool_not_found", f"ffmpeg executable not found: {args.ffmpeg}", 3, tool=args.ffmpeg)
+            raise CLIError(
+                "tool_not_found", f"ffmpeg executable not found: {args.ffmpeg}", 3, tool=args.ffmpeg
+            )
 
         output_dir.mkdir(parents=True, exist_ok=True)
         results: list[dict[str, Any]] = []
-        for timestamp, output in zip(timestamps, outputs):
+        for timestamp, output in zip(timestamps, outputs, strict=True):
             timestamp_text = canonical_decimal(timestamp)
             command = [
                 tool,
@@ -232,13 +258,14 @@ def main(argv: list[str] | None = None) -> int:
                 timestamp_text,
                 "-i",
                 str(source),
+                "-map",
+                args.stream,
                 "-frames:v",
                 "1",
-                "-q:v",
-                "2",
-                "-y" if args.overwrite else "-n",
-                str(output),
             ]
+            if args.video_filter:
+                command.extend(["-vf", args.video_filter])
+            command.extend(["-q:v", "2", "-y" if args.overwrite else "-n", str(output)])
             returncode, diagnostic = run_bounded(command, args.timeout)
             if returncode != 0:
                 raise CLIError(
@@ -271,6 +298,8 @@ def main(argv: list[str] | None = None) -> int:
                 "input": str(source),
                 "output_directory": str(output_dir),
                 "frame_count": len(results),
+                "stream": args.stream,
+                "video_filter": args.video_filter,
                 "overwrite": args.overwrite,
                 "frames": results,
             },

--- a/ffmpeg/scripts/import-vision-review
+++ b/ffmpeg/scripts/import-vision-review
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Link attributed, reviewed visual observations to existing EDL events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+ALLOWED_CLASSES = {
+    "technical_observation",
+    "human_or_vision_observation",
+    "heuristic",
+    "unresolved_claim",
+}
+
+
+def fail(code: str, message: str) -> int:
+    print(json.dumps({"ok": False, "error": {"code": code, "message": message}}))
+    return 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest")
+    parser.add_argument("edl")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    try:
+        manifest = json.loads(Path(args.manifest).read_text())
+        edl = json.loads(Path(args.edl).read_text())
+        output = Path(args.output)
+    except (OSError, json.JSONDecodeError) as exc:
+        return fail("invalid_input", str(exc))
+    if output.exists():
+        return fail("output_exists", "output already exists")
+    review = manifest.get("review", {})
+    if review.get("status") != "reviewed" or not review.get("reviewer"):
+        return fail(
+            "review_evidence_missing",
+            "manifest needs an attributed reviewed status before EDL import",
+        )
+    observations = review.get("observations")
+    if not isinstance(observations, list) or not observations:
+        return fail("review_evidence_missing", "manifest has no reviewed observations")
+    events = {event.get("id"): event for event in edl.get("events", [])}
+    imported = 0
+    for observation in observations:
+        event_id = observation.get("edl_event_id")
+        evidence_class = observation.get("evidence_class")
+        if event_id not in events:
+            return fail("event_not_found", f"observation targets unknown EDL event: {event_id}")
+        if evidence_class not in ALLOWED_CLASSES:
+            return fail("invalid_evidence_class", f"unsupported evidence class: {evidence_class}")
+        if observation.get("coverage_scope") in {"whole_asset", "all_unsampled_intervals"}:
+            return fail(
+                "unsupported_coverage_claim",
+                "sparse samples cannot establish whole-asset or unsampled absence",
+            )
+        if (
+            not observation.get("id")
+            or not observation.get("observation")
+            or not observation.get("artifact_refs")
+        ):
+            return fail(
+                "invalid_observation", "each observation needs id, text, and artifact references"
+            )
+        events[event_id].setdefault("evidence", []).append(
+            {
+                "type": "visual_review",
+                "packet_id": manifest.get("packet_id"),
+                "observation_id": observation["id"],
+                "asset_id": manifest.get("asset_id"),
+                "reviewer": review["reviewer"],
+                "evidence_class": evidence_class,
+                "confidence": observation.get("confidence"),
+                "editorial_consequence": observation.get("editorial_consequence"),
+                "artifact_refs": observation["artifact_refs"],
+                "coverage_scope": observation.get("coverage_scope", "sampled_artifacts_only"),
+            }
+        )
+        imported += 1
+    output.write_text(json.dumps(edl, indent=2) + "\n")
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "output": str(output),
+                "imported_observations": imported,
+                "executed_media_change": False,
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ffmpeg/scripts/test_media_workflows.py
+++ b/ffmpeg/scripts/test_media_workflows.py
@@ -73,6 +73,180 @@ def error_code(result: subprocess.CompletedProcess[str]) -> str:
     return json.loads(result.stdout)["error"]["code"]
 
 
+def make_visual_fixture(path: Path) -> None:
+    result = subprocess.run(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=160x90:rate=10:duration=3",
+            "-c:v",
+            "mpeg4",
+            "-y",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_vision_handoff_orders_neighbors_and_keeps_manifest_private(tmp_path: Path) -> None:
+    if shutil.which("ffmpeg") is None:
+        import pytest
+
+        pytest.skip("ffmpeg is required for visual handoff testing")
+    source = tmp_path / "private-person-name.mov"
+    make_visual_fixture(source)
+    packet = tmp_path / "packet"
+
+    result = run_script(
+        "vision-review-handoff",
+        str(source),
+        "--asset-id",
+        "asset-opaque-7",
+        "--question",
+        "Is the sampled boundary visually continuous?",
+        "--timestamp",
+        "2",
+        "--timestamp",
+        "1",
+        "--neighbor-seconds",
+        "0.25",
+        "--max-frames",
+        "8",
+        "--max-range-seconds",
+        "2",
+        "--output-dir",
+        str(packet),
+        "--json",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    manifest_text = (packet / "manifest.json").read_text()
+    manifest = json.loads(manifest_text)
+    assert manifest["sampling"]["timestamps_seconds"] == ["0.75", "1", "1.25", "1.75", "2", "2.25"]
+    assert manifest["asset_id"] == "asset-opaque-7"
+    assert str(source) not in manifest_text
+    assert "private-person-name" not in manifest_text
+    assert all(item["source_asset_id"] == "asset-opaque-7" for item in manifest["artifacts"])
+    assert all((packet / item["artifact"]).is_file() for item in manifest["artifacts"])
+    assert (
+        sum(item["size_bytes"] for item in manifest["artifacts"]) == manifest["total_output_bytes"]
+    )
+    assert "not established" in manifest["sampling"]["coverage_statement"]
+
+
+def test_vision_handoff_enforces_neighbor_frame_and_range_limits(tmp_path: Path) -> None:
+    source = tmp_path / "source.mov"
+    source.write_bytes(b"not decoded because validation fails first")
+    frame_limit = run_script(
+        "vision-review-handoff",
+        str(source),
+        "--asset-id",
+        "asset-a",
+        "--question",
+        "boundary",
+        "--timestamp",
+        "1",
+        "--neighbor-seconds",
+        "0.25",
+        "--max-frames",
+        "2",
+        "--output-dir",
+        str(tmp_path / "packet-a"),
+        "--json",
+    )
+    range_limit = run_script(
+        "vision-review-handoff",
+        str(source),
+        "--asset-id",
+        "asset-a",
+        "--question",
+        "range",
+        "--timestamp",
+        "1",
+        "--timestamp",
+        "5",
+        "--max-range-seconds",
+        "2",
+        "--output-dir",
+        str(tmp_path / "packet-b"),
+        "--json",
+    )
+
+    assert frame_limit.returncode == 2
+    assert error_code(frame_limit) == "frame_limit_exceeded"
+    assert range_limit.returncode == 2
+    assert error_code(range_limit) == "range_limit_exceeded"
+
+
+def test_import_vision_review_requires_reviewed_evidence(tmp_path: Path) -> None:
+    manifest = write_json(
+        tmp_path / "manifest.json", {"packet_id": "packet-1", "review": {"status": "pending"}}
+    )
+    edl = write_json(tmp_path / "edl.json", edl_document())
+
+    result = run_script(
+        "import-vision-review",
+        str(manifest),
+        str(edl),
+        "--output",
+        str(tmp_path / "out.json"),
+        "--json",
+    )
+
+    assert result.returncode == 2
+    assert error_code(result) == "review_evidence_missing"
+
+
+def test_import_vision_review_links_attributed_sample_evidence_without_paths(
+    tmp_path: Path,
+) -> None:
+    manifest = write_json(
+        tmp_path / "manifest.json",
+        {
+            "packet_id": "packet-1",
+            "asset_id": "camera-a",
+            "review": {
+                "status": "reviewed",
+                "reviewer": "reviewer-7",
+                "blind_spots": ["unsampled intervals"],
+                "observations": [
+                    {
+                        "id": "observation-1",
+                        "edl_event_id": "event-a",
+                        "artifact_refs": ["frames/frame-0001.jpg"],
+                        "observation": "The sampled title remains visible.",
+                        "evidence_class": "human_or_vision_observation",
+                        "confidence": 0.7,
+                        "coverage_scope": "sampled_artifacts_only",
+                        "editorial_consequence": "Review the proposed cut after the title.",
+                    }
+                ],
+            },
+        },
+    )
+    edl = write_json(tmp_path / "edl.json", edl_document())
+    output = tmp_path / "reviewed-edl.json"
+
+    result = run_script(
+        "import-vision-review", str(manifest), str(edl), "--output", str(output), "--json"
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    evidence = json.loads(output.read_text())["events"][0]["evidence"][0]
+    assert evidence["packet_id"] == "packet-1"
+    assert evidence["reviewer"] == "reviewer-7"
+    assert evidence["coverage_scope"] == "sampled_artifacts_only"
+    assert "source" not in evidence
+
+
 def test_render_edl_multi_source_concat_filter_plan_does_not_execute(tmp_path: Path) -> None:
     output = tmp_path / "rendered.mkv"
     edl = write_json(tmp_path / "multi-source.json", edl_document())

--- a/ffmpeg/scripts/vision-review-handoff
+++ b/ffmpeg/scripts/vision-review-handoff
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Prepare a bounded, privacy-safe frame packet for attributed visual review."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+MAX_FRAMES_HARD = 100
+MAX_RANGE_HARD = Decimal("604800")
+MAX_OUTPUT_BYTES_HARD = 1024 * 1024 * 1024
+
+
+class CLIError(Exception):
+    def __init__(self, code: str, message: str, exit_code: int = 2, **details: Any) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.exit_code = exit_code
+        self.details = details
+
+
+def decimal_value(raw: str, label: str) -> Decimal:
+    try:
+        value = Decimal(raw)
+    except InvalidOperation:
+        raise CLIError("invalid_number", f"{label} must be a decimal number: {raw}") from None
+    if not value.is_finite() or value < 0:
+        raise CLIError("invalid_number", f"{label} must be finite and nonnegative: {raw}")
+    return value
+
+
+def rendered(value: Decimal) -> str:
+    result = format(value, "f").rstrip("0").rstrip(".")
+    return result or "0"
+
+
+def cadence_points(raw: str) -> list[Decimal]:
+    parts = raw.split(":")
+    if len(parts) != 3:
+        raise CLIError("invalid_cadence", "cadence must be START:END:STEP in decimal seconds")
+    start, end, step = (decimal_value(value, "cadence value") for value in parts)
+    if step <= 0 or end < start:
+        raise CLIError("invalid_cadence", "cadence requires STEP > 0 and END >= START")
+    points: list[Decimal] = []
+    cursor = start
+    while cursor <= end and len(points) <= MAX_FRAMES_HARD:
+        points.append(cursor)
+        cursor += step
+    return points
+
+
+def safe_version(tool: str) -> str:
+    result = subprocess.run(
+        [tool, "-version"], capture_output=True, text=True, check=False, timeout=10
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise CLIError("version_probe_failed", "could not record the FFmpeg build", 3)
+    return result.stdout.splitlines()[0]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source")
+    parser.add_argument("--asset-id", required=True)
+    parser.add_argument("--question", required=True)
+    parser.add_argument("--stream", default="0:v:0")
+    parser.add_argument("--timestamp", action="append", default=[])
+    parser.add_argument("--cadence", action="append", default=[])
+    parser.add_argument("--neighbor-seconds", action="append", default=[])
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--max-frames", type=int, default=24)
+    parser.add_argument("--max-range-seconds", default="3600")
+    parser.add_argument("--max-output-bytes", type=int, default=50 * 1024 * 1024)
+    parser.add_argument("--scale", default="none")
+    parser.add_argument("--crop", default="none")
+    parser.add_argument("--color-transform", default="none")
+    parser.add_argument("--ffmpeg", default="ffmpeg")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    try:
+        source = Path(args.source).expanduser().resolve()
+        output = Path(args.output_dir).expanduser().resolve()
+        if not source.is_file():
+            raise CLIError("input_not_found", "source is not a regular file")
+        if output.exists():
+            raise CLIError(
+                "output_exists", "output directory already exists; choose a new task-local path", 4
+            )
+        if not 1 <= args.max_frames <= MAX_FRAMES_HARD:
+            raise CLIError("invalid_limit", f"max frames must be between 1 and {MAX_FRAMES_HARD}")
+        max_range = decimal_value(args.max_range_seconds, "max range")
+        if max_range <= 0 or max_range > MAX_RANGE_HARD:
+            raise CLIError("invalid_limit", f"max range must be in (0, {rendered(MAX_RANGE_HARD)}]")
+        if not 0 < args.max_output_bytes <= MAX_OUTPUT_BYTES_HARD:
+            raise CLIError(
+                "invalid_limit", f"max output bytes must be in (0, {MAX_OUTPUT_BYTES_HARD}]"
+            )
+
+        explicit = [decimal_value(value, "timestamp") for value in args.timestamp]
+        if not explicit and not args.cadence:
+            raise CLIError("sampling_required", "provide an explicit timestamp or bounded cadence")
+        requested: list[tuple[Decimal, str, Decimal | None]] = [
+            (point, "explicit", None) for point in explicit
+        ]
+        for specification in args.cadence:
+            requested.extend((point, "cadence", None) for point in cadence_points(specification))
+        offsets = [decimal_value(value, "neighbor seconds") for value in args.neighbor_seconds]
+        for boundary in explicit:
+            for offset in offsets:
+                if offset == 0:
+                    continue
+                requested.append((max(Decimal(0), boundary - offset), "neighbor_before", boundary))
+                requested.append((boundary + offset, "neighbor_after", boundary))
+
+        by_timestamp: dict[Decimal, dict[str, Any]] = {}
+        for point, reason, boundary in requested:
+            entry = by_timestamp.setdefault(point, {"reasons": [], "boundary_seconds": []})
+            entry["reasons"].append(reason)
+            if boundary is not None:
+                entry["boundary_seconds"].append(rendered(boundary))
+        timestamps = sorted(by_timestamp)
+        if len(timestamps) > args.max_frames:
+            raise CLIError(
+                "frame_limit_exceeded",
+                "sampling plan exceeds the declared frame limit",
+                requested=len(timestamps),
+                limit=args.max_frames,
+            )
+        span = timestamps[-1] - timestamps[0]
+        if span > max_range:
+            raise CLIError(
+                "range_limit_exceeded",
+                "sampling plan exceeds the declared timestamp range",
+                observed=rendered(span),
+                limit=rendered(max_range),
+            )
+
+        ffmpeg = shutil.which(args.ffmpeg)
+        if ffmpeg is None:
+            raise CLIError("tool_not_found", f"FFmpeg executable not found: {args.ffmpeg}", 3)
+        build = safe_version(ffmpeg)
+        extractor = Path(__file__).with_name("extract-review-frames")
+        command = [
+            sys.executable,
+            str(extractor),
+            str(source),
+            "--output-dir",
+            str(output / "frames"),
+            "--ffmpeg",
+            ffmpeg,
+            "--stream",
+            args.stream,
+            "--max-frames",
+            str(args.max_frames),
+            "--max-timestamp",
+            rendered(timestamps[-1] or Decimal("0.001")),
+            "--json",
+        ]
+        video_filters = []
+        if args.scale != "none":
+            video_filters.append(f"scale={args.scale}")
+        if args.crop != "none":
+            video_filters.append(f"crop={args.crop}")
+        if args.color_transform != "none":
+            video_filters.append(args.color_transform)
+        if video_filters:
+            command.extend(["--video-filter", ",".join(video_filters)])
+        for timestamp in timestamps:
+            command.extend(["--timestamp", rendered(timestamp)])
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            try:
+                detail = json.loads(result.stdout)
+            except json.JSONDecodeError:
+                detail = {"stderr": result.stderr[-2000:]}
+            raise CLIError("extraction_failed", "bounded frame extraction failed", 1, detail=detail)
+        extraction = json.loads(result.stdout)
+        total_bytes = sum(frame["size_bytes"] for frame in extraction["frames"])
+        if total_bytes > args.max_output_bytes:
+            shutil.rmtree(output)
+            raise CLIError(
+                "output_limit_exceeded",
+                "extracted packet exceeds the declared byte limit",
+                4,
+                observed=total_bytes,
+                limit=args.max_output_bytes,
+            )
+
+        artifacts = []
+        for timestamp, frame in zip(timestamps, extraction["frames"], strict=True):
+            artifact = Path(frame["output"])
+            artifacts.append(
+                {
+                    "artifact": str(Path("frames") / artifact.name),
+                    "source_asset_id": args.asset_id,
+                    "stream": args.stream,
+                    "source_timestamp_seconds": rendered(timestamp),
+                    "sampling_reasons": sorted(set(by_timestamp[timestamp]["reasons"])),
+                    "boundary_seconds": sorted(set(by_timestamp[timestamp]["boundary_seconds"])),
+                    "size_bytes": frame["size_bytes"],
+                    "sha256": hashlib.sha256(artifact.read_bytes()).hexdigest(),
+                    "extraction_command": [
+                        ffmpeg,
+                        "-ss",
+                        rendered(timestamp),
+                        "-i",
+                        f"<SOURCE:{args.asset_id}>",
+                        "-map",
+                        args.stream,
+                        "-frames:v",
+                        "1",
+                        *(["-vf", ",".join(video_filters)] if video_filters else []),
+                        f"<PACKET>/frames/{artifact.name}",
+                    ],
+                    "transforms": {
+                        "scale": args.scale,
+                        "crop": args.crop,
+                        "color": args.color_transform,
+                    },
+                }
+            )
+        manifest = {
+            "schema_version": 1,
+            "packet_id": hashlib.sha256(
+                f"{args.asset_id}:{','.join(rendered(x) for x in timestamps)}".encode()
+            ).hexdigest()[:16],
+            "asset_id": args.asset_id,
+            "stream": args.stream,
+            "question": args.question,
+            "ffmpeg_build": build,
+            "sampling": {
+                "timestamps_seconds": [rendered(value) for value in timestamps],
+                "explicit_timestamps_seconds": [rendered(value) for value in explicit],
+                "cadence_specs": args.cadence,
+                "neighbor_offsets_seconds": [rendered(value) for value in offsets],
+                "coverage_statement": "Only the listed timestamps were sampled; unsampled intervals and whole-asset absence claims are not established.",
+                "blind_spots": [
+                    "motion between samples",
+                    "unsampled intervals",
+                    "target display and color pipeline",
+                    "audio and transcript content",
+                ],
+            },
+            "limits": {
+                "max_frames": args.max_frames,
+                "max_range_seconds": rendered(max_range),
+                "max_output_bytes": args.max_output_bytes,
+            },
+            "total_output_bytes": total_bytes,
+            "artifacts": artifacts,
+            "review": {
+                "status": "pending",
+                "required_fields": [
+                    "reviewer",
+                    "observations",
+                    "blind_spots",
+                    "editorial_consequence",
+                ],
+            },
+        }
+        manifest_path = output / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+        payload = {"ok": True, "manifest": str(manifest_path), **manifest}
+        print(
+            json.dumps(
+                payload,
+                separators=(",", ":") if args.json else None,
+                indent=None if args.json else 2,
+            )
+        )
+        return 0
+    except (CLIError, OSError, subprocess.TimeoutExpired) as exc:
+        if isinstance(exc, CLIError):
+            payload = {
+                "ok": False,
+                "error": {"code": exc.code, "message": exc.message, **exc.details},
+            }
+            code = exc.exit_code
+        else:
+            payload = {"ok": False, "error": {"code": "io_error", "message": str(exc)}}
+            code = 2
+        print(
+            json.dumps(payload, separators=(",", ":") if args.json else None),
+            file=sys.stdout if args.json else sys.stderr,
+        )
+        return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ffmpeg/templates/vision-review-observations.json
+++ b/ffmpeg/templates/vision-review-observations.json
@@ -1,0 +1,19 @@
+{
+  "review": {
+    "status": "reviewed",
+    "reviewer": "human-or-vision-reviewer-id",
+    "blind_spots": ["unsampled intervals", "motion between frames"],
+    "observations": [
+      {
+        "id": "observation-001",
+        "edl_event_id": "event-001",
+        "artifact_refs": ["frames/frame-0001.jpg"],
+        "observation": "Describe only what is visible in the referenced sample.",
+        "evidence_class": "human_or_vision_observation",
+        "confidence": 0.8,
+        "coverage_scope": "sampled_artifacts_only",
+        "editorial_consequence": "Candidate consequence requiring editorial approval"
+      }
+    ]
+  }
+}

--- a/ffmpeg/templates/visual-review-packet.md
+++ b/ffmpeg/templates/visual-review-packet.md
@@ -2,21 +2,31 @@
 
 ## Coverage
 
+- Packet ID:
 - Source asset ID:
+- Selected stream:
+- FFmpeg build:
 - Sampling timestamps:
-- Sampling method and bounds:
+- Sampling method, neighboring offsets, and bounds:
+- Extraction command template:
+- Scaling, cropping, and color transforms:
+- Maximum frame count, timestamp range, and output bytes:
 - Review target:
 - Coverage statement: this packet represents only the listed timestamps and neighboring windows.
+- Blind spots: unsampled intervals, motion between samples, audio/transcript content, and target display behavior.
 
 ## Observations
 
-| Timestamp | Artifact | Observation | Reviewer | Evidence class | Confidence |
-|---|---|---|---|---|---|
-| | | | | | |
+| Observation ID | Timestamp | Artifact ref | Observation | Reviewer | Evidence class | Confidence | Coverage scope |
+|---|---|---|---|---|---|---|---|
+| | | | | | technical / human-or-vision / heuristic / unresolved | | sampled artifacts only |
 
 ## Editorial Consequence
 
 - Candidate cut/join:
 - Continuity concerns:
 - Missing evidence:
+- More samples requested:
 - Human decision required:
+
+Do not state that a feature is absent throughout the asset unless the whole asset was reviewed using evidence capable of supporting that claim. Link reviewed observations to EDL events as attributed evidence; they do not become automatic editorial truth.


### PR DESCRIPTION
## Summary

- prepare bounded privacy-safe frame packets from explicit timestamps, cadence, and neighboring boundary samples
- retain stream/build/extraction/transform provenance, hashes, coverage limits, and sparse-sampling blind spots
- import only attributed reviewed observations into named EDL events without rendering or automatic editorial decisions
- cover ordering, bounds, manifest integrity, source-path redaction, and missing/reviewed evidence in real subprocess tests

## Verification

- `.venv/bin/pytest --no-cov -q ffmpeg/scripts/test_media_workflows.py` (27 passed)
- `python3 scripts/check-skill-tests.py --check`
- `ruby scripts/validate-skills.rb`
- `ruby scripts/validate-skill-quality.rb`
- `python3 scripts/validate-evals.py ffmpeg`
- `python3 scripts/eval-coverage.py --modified-from origin/main`
- generated catalog checks

Closes #455

@droid please review this PR.